### PR TITLE
apirequest/isReadableStream rework

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -19,7 +19,6 @@
 var Multipart = require('multipart-stream');
 var utils = require('./utils.js');
 var DefaultTransporter = require('./transporters.js');
-var stream = require('stream');
 var parseString = require('string-template');
 
 function isReadableStream(obj) {

--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -23,9 +23,7 @@ var stream = require('stream');
 var parseString = require('string-template');
 
 function isReadableStream(obj) {
-  return obj instanceof stream.Stream &&
-    typeof obj._read === 'function' &&
-    typeof obj._readableState === 'object';
+  return typeof obj.pipe === 'function';
 }
 
 function logError(err) {


### PR DESCRIPTION
I tried using a http.get response object directly as GCS media.body, which should be a valid readable stream.

Fixes #334