### PR TITLE
All API call errors should be returned as instances of Error

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -75,14 +75,16 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
 
     if (body && body.error) {
       // handle single request errors
-      err = body.error;
+      err = new Error(body.error.message);
+      err.code = body.error.code;
       body = null;
     }
 
     // there is no err and is a body and no body.error
     // but server still returns error code
     if (res.statusCode >= 500) {
-      err = { code: res.statusCode, message: body };
+      err = new Error(body);
+      err.code = res.statusCode;
       body = null;
     }
 


### PR DESCRIPTION
Hopefully I have not missed any other place where we wrap callbacks or create errors ourselves...

Thanks to @sindresorhus for pointing the issue out!
Closes #345