### PR TITLE
Add better handling for string errors

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -75,8 +75,16 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
 
     if (body && body.error) {
       // handle single request errors
-      err = new Error(body.error.message);
-      err.code = body.error.code;
+
+      if (typeof body.error === 'string') {
+        err = new Error(body.error_description);
+        err.code = res.statusCode;
+        err.type = body.error;
+      } else {
+        err = new Error(body.error.message);
+        err.code = body.error.code;
+      }
+
       body = null;
     }
 

--- a/test/test.transporters.js
+++ b/test/test.transporters.js
@@ -82,6 +82,27 @@ it('should return errors within response body as instances of Error', function(d
 
     drive.files.list({ q: 'hello' }, function(err) {
       assert(err instanceof Error);
+      assert.equal(err.message, 'Error!');
+      assert.equal(err.code, 400);
+      scope.done();
+      done();
+    });
+  });
+
+  it('should return error message correctly when error is not an object', function(done) {
+    var google = require('../lib/googleapis');
+    var oauth2 = google.oauth2('v2');
+
+    var scope = nock('https://www.googleapis.com')
+      .post('/oauth2/v2/tokeninfo?access_token=hello')
+      // Simulate an error returned via response body from Google's tokeninfo endpoint
+      .reply(400, { error: 'invalid_grant', error_description: 'Code was already redeemed.' });
+
+    oauth2.tokeninfo({ access_token: 'hello' }, function(err) {
+      assert(err instanceof Error);
+      assert.equal(err.message, 'Code was already redeemed.');
+      assert.equal(err.type, 'invalid_grant');
+      assert.equal(err.code, 400);
       scope.done();
       done();
     });


### PR DESCRIPTION
This adds better support for errors returned from google apis that follow this response body format:
```
{
  error: 'invalid_grant',
  error_description: 'Code was already redeemed.'
}
```
(in this example, for `oauth2.tokeninfo(...)`)

Previously, stack trace message for this error would look like:
```
  Error
      at Request._callback (/Users/stephen/git/formresponses/node_modules/googleapis/lib/transporters.js:78:13)
      at Request.self.callback (/Users/stephen/git/formresponses/node_modules/request/request.js:373:22)
      at Request.EventEmitter.emit (events.js:110:17)
      at Request.<anonymous> (/Users/stephen/git/formresponses/node_modules/request/request.js:1318:14)
      at Request.EventEmitter.emit (events.js:129:20)
  ...
```

With this change, they would look like:
```
  Error: Code was already redeemed.
      at Request._callback (/Users/stephen/git/formresponses/node_modules/googleapis/lib/transporters.js:82:15)
      at Request.self.callback (/Users/stephen/git/formresponses/node_modules/request/request.js:373:22)
      at Request.EventEmitter.emit (events.js:110:17)
      at Request.<anonymous> (/Users/stephen/git/formresponses/node_modules/request/request.js:1318:14)
      at Request.EventEmitter.emit (events.js:129:20)
  ...
```

Which is much more informative.

This PR also includes a new test case for this example, and adds constraints to the previous test case for `Error` handling.