### PR TITLE
Pass req_opts from constructor args to request in oauth2client

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -21,6 +21,7 @@ var AuthClient = require('./authclient.js');
 var util = require('util');
 var PemVerifier = require('./../pemverifier.js');
 var LoginTicket = require('./loginticket.js');
+var utils = require('../utils');
 
 var certificateCache = null;
 var certificateExpiry = null;
@@ -130,12 +131,12 @@ OAuth2Client.prototype.getToken = function(code, opt_callback) {
     grant_type: 'authorization_code'
   };
 
-  this.transporter.request({
+  this.transporter.request(utils.extend({}, this.opts.requestOpts || {}, {
     method: 'POST',
     uri: uri,
     form: values,
     json: true
-  }, function(err, tokens) {
+  }), function(err, tokens) {
     if (!err && tokens && tokens.expires_in) {
       tokens.expiry_date = ((new Date()).getTime() + (tokens.expires_in * 1000));
       delete tokens.expires_in;
@@ -162,12 +163,12 @@ OAuth2Client.prototype.refreshToken_ = function(refresh_token, opt_callback) {
   };
 
   // request for new token
-  this.transporter.request({
+  this.transporter.request(utils.extend({}, this.opts.requestOpts || {}, {
     method: 'POST',
     uri: uri,
     form: values,
     json: true
-  }, function(err, tokens) {
+  }), function(err, tokens) {
     if (!err && tokens && tokens.expires_in) {
       tokens.expiry_date = ((new Date()).getTime() + (tokens.expires_in * 1000));
       delete tokens.expires_in;
@@ -208,11 +209,11 @@ OAuth2Client.prototype.refreshAccessToken = function(callback) {
  * @param {function=} opt_callback Optional callback fn.
  */
 OAuth2Client.prototype.revokeToken = function(token, opt_callback) {
-  this.transporter.request({
+  this.transporter.request(utils.extend({}, this.opts.requestOpts || {}, {
     uri: OAuth2Client.GOOGLE_OAUTH2_REVOKE_URL_ +
       '?' + querystring.stringify({ token: token }),
     json: true
-  }, opt_callback);
+  }), opt_callback);
 };
 
 /**
@@ -281,7 +282,7 @@ OAuth2Client.prototype._makeRequest = function(opts, callback) {
   opts.headers = opts.headers || {};
   opts.headers.Authorization = credentials.token_type + ' ' + credentials.access_token;
 
-  return this.transporter.request(opts, callback);
+  return this.transporter.request(utils.extend({}, this.opts.requestOpts || {}, opts), callback);
 };
 
 /**
@@ -326,11 +327,11 @@ OAuth2Client.prototype.getFederatedSignonCerts = function(callback) {
     return;
   }
 
-  this.transporter.request({
+  this.transporter.request(utils.extend({}, this.opts.requestOpts || {}, {
     method: 'GET',
     uri: OAuth2Client.GOOGLE_OAUTH2_FEDERATED_SIGNON_CERTS_URL_,
     json: true
-  }, function(err, body, res) {
+  }), function(err, body, res) {
     if (err) {
       callback('Failed to retrieve verification certificates: ' + err, null);
       return;
@@ -449,7 +450,7 @@ OAuth2Client.prototype.verifySignedJwtWithCerts =
 };
 
 /**
- * This is a utils method to decode a base64 string
+ * This is a util method to decode a base64 string
  * @param {string} b64String The string to base64 decode
  * @return {string} The decoded string
  */


### PR DESCRIPTION
This permits client code to pass options (e.g. proxy) directly to request (the transport library).
