### PR TITLE
Change extend util to check hasOwnProperty

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,7 +32,9 @@ module.exports = {
     for (var i = 1, length = arguments.length; i < length; i++) {
       source = arguments[i];
       for (prop in source) {
-        obj[prop] = source[prop];
+        if (source.hasOwnProperty(prop)) {
+          obj[prop] = source[prop];
+        }
       }
     }
     return obj;

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2014 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var assert = require('assert');
+var utils = require('../lib/utils.js');
+
+describe('Utils', function() {
+
+  it('should not extend funtions on the prototype', function() {
+
+    var object = {
+      property: 'test'
+    };
+
+    /* jshint ignore:start */
+    Object.prototype.entries = function() {};
+    /* jshint ignore:end */
+
+    var newObject = utils.extend({}, object);
+
+    assert.equal('entries' in newObject, true);
+    assert.equal(newObject.hasOwnProperty('entries'), false);
+
+    assert.equal('property' in newObject, true);
+    assert.equal(newObject.hasOwnProperty('property'), true);
+
+    delete Object.prototype.entries;
+  });
+
+});


### PR DESCRIPTION
The lack of a `hasOwnProperty` check can accidentally cause functions on the prototype to bubble up to being a parameter in an API request.

For example... defining a polyfill:
```
Object.prototype.entries = function* entries(obj) {
  for (let key of Object.keys(obj)) {
    yield [key, obj[key]];
  }
};
```

will cause an extra `entries` param to exist in a request in the query string, e.g. `https://www.googleapis.com:443'/calendar/v3/calendars/stephen%40stephenwan.net/events?entries=`.
