### PR TITLE
Actually expose the default auth module

### DIFF
--- a/lib/googleapis.js
+++ b/lib/googleapis.js
@@ -27,6 +27,7 @@
  * @private
  */
 var apis = require('../apis');
+var googleAuth = require('google-auth-library');
 
 /**
  * GoogleApis constructor.
@@ -36,11 +37,7 @@ var apis = require('../apis');
 function GoogleApis(options) {
   this.options(options);
   this.addAPIs(apis);
-  this.auth = {
-    Compute: require('./auth/computeclient.js'),
-    JWT: require('./auth/jwtclient.js'),
-    OAuth2: require('./auth/oauth2client.js')
-  };
+  this.auth = new googleAuth();
   this.GoogleApis = GoogleApis;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Google Inc.",
   "description": "Google APIs Client Library for Node.js",
   "contributors": [

--- a/test/test.auth.js
+++ b/test/test.auth.js
@@ -26,6 +26,15 @@ nock.disableNetConnect();
 
 describe('JWT client', function() {
 
+  it('should expose the default auth module', function () {
+    var defaultAuthExists = false;
+    if (googleapis.auth.getApplicationDefault) {
+      defaultAuthExists = true;
+    }
+
+    assert.equal(true, defaultAuthExists);
+  });
+
   it('should create a jwt', function () {
     var jwt = new JWT('someone@somewhere.com', 'file1', 'key1', 'scope1', 'subject1');
     assert.equal(jwt.email, 'someone@somewhere.com');


### PR DESCRIPTION
When the refactoring happened to pull the auth module out of the V1 library and into it's own separate auth library, a critical piece was left out. This PR actually exposes the default auth module into the V1 client.