### PR TITLE
Fix endpoints for APIs by using baseUrl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,6 @@ You can pass in a custom Discovery URL:
 node scripts/generate --discovery-url "http://discoveryurl.example.com"
 ```
 
-Or a custom Base URL:
-
-``` sh
-node scripts/generate --base-url "http://baseurl.example.com"
-```
-
 ## Generating Documentation
 
 You can generate the documentation for the APIs by running:

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -25,7 +25,6 @@ var mkdirp = require('mkdirp');
 var fs = require('fs');
 var argv = require('minimist')(process.argv.slice(2));
 
-var BASE_URL = argv['base-url'] || 'https://www.googleapis.com';
 var DISCOVERY_URL = argv['discovery-url'] || 'https://www.googleapis.com/discovery/v1/apis/';
 
 var API_INDEX = './apis/index.js';
@@ -59,8 +58,14 @@ var transporter = new DefaultTransporter();
  * @return {String}       Resulting built URL
  */
 function buildurl(input) {
-  return ('\'' + BASE_URL + input + '\'')
+  return ('\'' + input + '\'')
+    // No * symbols
     .replace(/\*/g, '')
+    // No + symbols
+    .replace(/\+/g, '')
+    // replace double slashes with single slash (except in https://)
+    .replace(/([^:]\/)\/+/g, '$1')
+    // No {/ symbols
     .replace(/\{\//g, '/{');
 }
 

--- a/templates/method-partial.js
+++ b/templates/method-partial.js
@@ -29,11 +29,11 @@
 {% if globalmethods %}this.{{ mname }} ={% else %}{{ mname }}:{% endif %} function(params, callback) {
   var parameters = {
     options: {
-      url: {{ (basePath + m.path)|buildurl }},
+      url: {{ (rootUrl + servicePath + m.path)|buildurl }},
       method: '{{ m.httpMethod }}'
     },
     params: params,
-    {%- if m.mediaUpload.protocols.simple.path -%}mediaUrl: {{ m.mediaUpload.protocols.simple.path|buildurl }},{%- endif -%}
+    {%- if m.mediaUpload.protocols.simple.path -%}mediaUrl: {{ [rootUrl, m.mediaUpload.protocols.simple.path]|join('')|buildurl }},{%- endif -%}
     requiredParams: [{%- if m.parameterOrder.length -%}'{{ m.parameterOrder|join("', '")|safe }}'{%- endif -%}],
     pathParams: [{%- if pathParams.length -%}'{{ pathParams|join("', '")|safe }}'{%- endif -%}],
     context: self


### PR DESCRIPTION
Fixes Pubsub and other endpoints that use a different baseUrl.