### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,21 +40,21 @@
     "async": "~0.9.0",
     "gapitoken": "~0.1.2",
     "google-auth-library": "~0.9.3",
-    "request": "~2.51.0",
+    "request": "~2.54.0",
     "string-template": "~0.2.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",
-    "istanbul": "~0.3.2",
+    "istanbul": "^0.3.2",
     "js-beautify": "^1.5.1",
     "jshint": "^2.5.5",
-    "jsdoc": "~3.3.0-alpha9",
-    "mkdirp": "~0.5.0",
-    "mocha": "^1.8.1",
-    "nock": "~0.46.0",
+    "jsdoc": "^3.3.0-beta3",
+    "mkdirp": "^0.5.0",
+    "mocha": "^2.2.1",
+    "nock": "^1.2.1",
     "rimraf": "^2.2.8",
     "swig": "^1.4.2",
-    "url": "~0.10.1",
+    "url": "^0.10.1",
     "minimist": "^1.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Updated dependencies to latest versions.

Also switched *devDependencies* to restrict only major version ranges (^) as they are not production-critical.

PS. As soon as [google-auth-library](https://github.com/google/google-auth-library-nodejs) bumps their release on npm, `node-gapitoken` should be removed from this repo (authentication is no longer part of this project) - see [this commit](https://github.com/google/google-auth-library-nodejs/commit/97cefdd08f8f50ebe654d3a21bac85e9cc2cf1be).