### PR TITLE
Handle error in URL shortener example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ var params = { shortUrl: 'http://goo.gl/xKbRu3' };
 
 // get the long url of a shortened url
 urlshortener.url.get(params, function (err, response) {
-  console.log('Long url is', response.longUrl);
+  if (err) {
+    console.log('Encountered error', err);
+  } else {
+    console.log('Long url is', response.longUrl);
+  }
 });
 ```
 


### PR DESCRIPTION
When I first came across the example in the Readme, I tried blindly copy/pasting it into a new sample js file and was surprised to see it failed with the following error:

`TypeError: Cannot read property 'longUrl' of null`

I was just about to submit a bug report, but I realized after adding an error check to the sample code that it was failing because no authorization credentials were provided.