### PR TITLE
Avoid url-encoding path parameters.

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -52,30 +52,6 @@ function getMissingParams(params, required) {
 }
 
 /**
- * Take a url path template and replace placeholders with data from params,
- * i.e. parsePath('/my/{value}', { value: 'something' }); // /my/something
- * @param  {String} path   String with template placeholders in curly braces
- * @param  {object} params Properties to be placed into the placeholders
- * @return {String}        Templated string with actual values
- */
-function parsePath(path, params) {
-
-  if (! path) {
-    return path;
-  }
-
-  // escape path params
-  var escapedParams = {};
-
-  Object.keys(params).forEach(function(value) {
-    escapedParams[value] = encodeURIComponent(params[value]);
-  });
-
-  // process the url template and return parsed url
-  return parseString(path, escapedParams);
-}
-
-/**
  * Create and send request to Google API
  * @param  {object}   parameters Parameters used to form request
  * @param  {Function} callback   Callback when request finished or error found
@@ -127,8 +103,8 @@ function createAPIRequest(parameters, callback) {
   delete params.auth;
 
   // Parse urls and urlescape path params
-  options.url = parsePath(options.url, params);
-  parameters.mediaUrl = parsePath(parameters.mediaUrl, params);
+  options.url = parseString(options.url, params);
+  parameters.mediaUrl = parseString(parameters.mediaUrl, params);
 
   // delete path parameters from the params object so they do not end up in query
   parameters.pathParams.forEach(function(param) {

--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -102,9 +102,13 @@ function createAPIRequest(parameters, callback) {
   delete params.resource;
   delete params.auth;
 
-  // Parse urls and urlescape path params
-  options.url = parseString(options.url, params);
-  parameters.mediaUrl = parseString(parameters.mediaUrl, params);
+  // Parse urls
+  if (options.url) {
+    options.url = parseString(options.url, params);
+  }
+  if (parameters.mediaUrl) {
+    parameters.mediaUrl = parseString(parameters.mediaUrl, params);
+  }
 
   // delete path parameters from the params object so they do not end up in query
   parameters.pathParams.forEach(function(param) {

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -88,9 +88,9 @@ describe('Path params', function() {
     assert.equal(req.uri.pathname, '/drive/v2/files/123abc');
   });
 
-  it('should be urlencoded', function () {
+  it('should not be urlencoded', function () {
     var req = drive.files.get({ fileId: 'p@ram' }, noop);
-    assert.equal(req.uri.path.split('/').pop(), 'p%40ram');
+    assert.equal(req.uri.path.split('/').pop(), 'p@ram');
   });
 
   it('should keep query params null if only path params', function() {


### PR DESCRIPTION
GAPI node.js client currently url-encodes path parameters. This causes problem when path parameters contain '/'. This pull request stops url encoding path parameters. This makes node.js client consistent with GAPI Go client.