### PR TITLE
Example using JWT auth client with .json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,21 +231,11 @@ To learn more about API keys, please see the [documentation][usingkeys].
 
 #### Using JWT (Service Tokens)
 
-Configure a JWT auth client with your service account email and the pem file that contains your private key. Google Developers Console only provide `.p12` files, but you can convert a `.p12` to `.pem` with the following command:
-
-``` sh
-openssl pkcs12 -in key.p12 -nocerts -passin pass:notasecret -nodes -out key.pem
-```
-
-Construct a JWT client, and authenticate your requests.
+The Google Developers Console provides `.json` file that you can use to configure a JWT auth client and authenticate your requests.
 
 ``` js
-var jwtClient = new google.auth.JWT(
-  'serviceaccount@email.com',
-  '/path/to/key.pem',
-  null,
-  [scope1, scope2],
-  'bar@subjectaccount.com');
+var key = require('path/to/key.json');
+var jwtClient = new google.auth.JWT(key.client_email, null, key.private_key, [scope1, scope2], null);
 
 jwtClient.authorize(function(err, tokens) {
   if (err) {
@@ -259,6 +249,8 @@ jwtClient.authorize(function(err, tokens) {
   });
 });
 ```
+
+The parameters for the JWT auth client including how to use it with a `.pem` file are explained in [examples/jwt.js](examples/jwt.js)
 
 #### Choosing the correct credential type automatically
 


### PR DESCRIPTION
I'm guessing that when this documentation was first written, either the Google Developer Console didn't yet provide .json files or the JWT auth client didn't yet accept keys as strings. Now that they do, it's much easier to configure the client using the .json file than it is to convert a .p12 file to .pem file. Also, the instructions for using openssl to convert a .p12 file didn't work on my system and I had to search for the correct way to do that. So, I removed the convert .p12 to .pem instructions and example and replaced them with an example using a .json file. I also added a link to the example/jwt.js in case someone wants to still use .pem files, use the impersonate functionality or any of the other functionality.