### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,7 @@ var jwtClient = new google.auth.JWT(
   'serviceaccount@email.com',
   '/path/to/key.pem',
   null,
-  [scope1, scope2],
-  'bar@subjectaccount.com');
+  [scope1, scope2]);
 
 jwtClient.authorize(function(err, tokens) {
   if (err) {

--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -40,9 +40,7 @@ var authClient = new google.auth.JWT(
     // (do not use the path parameter above if using this param)
     'key',
     // Scopes can be specified either as an array or as a single, space-delimited string
-    ['https://www.googleapis.com/auth/drive.readonly'],
-    // User to impersonate (leave empty if no impersonation needed)
-    'subject-account-email@example.com');
+    ['https://www.googleapis.com/auth/drive.readonly']);
 
 authClient.authorize(function(err, tokens) {
   if (err) {


### PR DESCRIPTION
Remove last parm (email address) from google.auth.JWT() call. It causes "Error authorizing with JWT [Error: unauthorized_client]" and nothing here explains why so I believe it's an error.