### PR TITLE
Avoid parameter name conflicts with resource/media/auth

### DIFF
--- a/apis/compute/v1.js
+++ b/apis/compute/v1.js
@@ -46,9 +46,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -167,9 +167,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.region - The name of the region for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -320,9 +320,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -415,9 +415,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -476,9 +476,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - The name of the zone for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -512,9 +512,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -665,9 +665,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - The name of the zone for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -788,9 +788,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -883,9 +883,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1004,9 +1004,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {string} params.region - Name of the region scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -1158,9 +1158,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1280,9 +1280,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1345,9 +1345,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1370,13 +1370,13 @@ function Compute(options) {
     /**
      * compute.globalOperations.delete
      *
-     * @desc Deletes the specified operation resource.
+     * @desc Deletes the specified Operations resource.
      *
      * @alias compute.globalOperations.delete
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string} params.operation - Name of the operation resource to delete.
+     * @param  {string} params.operation - Name of the Operations resource to delete.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1399,13 +1399,13 @@ function Compute(options) {
     /**
      * compute.globalOperations.get
      *
-     * @desc Retrieves the specified operation resource.
+     * @desc Retrieves the specified Operations resource.
      *
      * @alias compute.globalOperations.get
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string} params.operation - Name of the operation resource to return.
+     * @param  {string} params.operation - Name of the Operations resource to return.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1428,15 +1428,15 @@ function Compute(options) {
     /**
      * compute.globalOperations.list
      *
-     * @desc Retrieves the list of operation resources contained within the specified project.
+     * @desc Retrieves the list of Operation resources contained within the specified project.
      *
      * @alias compute.globalOperations.list
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1556,9 +1556,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1768,9 +1768,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1784,6 +1784,663 @@ function Compute(options) {
         params: params,
         requiredParams: ['project'],
         pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.instanceGroupManagers = {
+
+    /**
+     * compute.instanceGroupManagers.abandonInstances
+     *
+     * @desc Removes the specified instances from the managed instance group, and from any target pools where they are a member. The instances are not deleted. The managed instance group automatically reduces its targetSize value by the number of instances that you abandon from the group.
+     *
+     * @alias compute.instanceGroupManagers.abandonInstances
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    abandonInstances: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/abandonInstances',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.aggregatedList
+     *
+     * @desc Retrieves the list of managed instance groups, and groups them by project and zone.
+     *
+     * @alias compute.instanceGroupManagers.aggregatedList
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
+     * @param  {integer=} params.maxResults - Maximum count of results to be returned.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    aggregatedList: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/aggregated/instanceGroupManagers',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project'],
+        pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.delete
+     *
+     * @desc Deletes the specified managed instance group resource.
+     *
+     * @alias compute.instanceGroupManagers.delete
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager to delete.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.deleteInstances
+     *
+     * @desc Deletes the specified instances. The instances are deleted and removed from the instance group and any target pools where they are a member. The managed instance group automatically reduces its targetSize value by the number of instances that you delete.
+     *
+     * @alias compute.instanceGroupManagers.deleteInstances
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    deleteInstances: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/deleteInstances',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.get
+     *
+     * @desc Returns the specified managed instance group resource.
+     *
+     * @alias compute.instanceGroupManagers.get
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager resource.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.insert
+     *
+     * @desc Creates a managed instance group resource in the specified project using the data that is included in the request.
+     *
+     * @alias compute.instanceGroupManagers.insert
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    insert: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone'],
+        pathParams: ['project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.list
+     *
+     * @desc Retrieves a list of managed instance groups that are contained within the specified project and zone.
+     *
+     * @alias compute.instanceGroupManagers.list
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
+     * @param  {integer=} params.maxResults - Maximum count of results to be returned.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'zone'],
+        pathParams: ['project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.listManagedInstances
+     *
+     * @desc Lists managed instances.
+     *
+     * @alias compute.instanceGroupManagers.listManagedInstances
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the managed instance group.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    listManagedInstances: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/listManagedInstances',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.recreateInstances
+     *
+     * @desc Recreates the specified instances. The instances are deleted, then recreated using the managed instance group's current instance template.
+     *
+     * @alias compute.instanceGroupManagers.recreateInstances
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    recreateInstances: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/recreateInstances',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.resize
+     *
+     * @desc Resizes the managed instance group. If you increase the size, the group creates new instances using the current instance template. If you decrease the size, the group removes instances in the order that is outlined in Resizing a managed instance group.
+     *
+     * @alias compute.instanceGroupManagers.resize
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {integer} params.size - The number of running instances that the managed instance group should maintain at any given time. The group automatically adds or removes instances to maintain the number of instances specified by this parameter.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    resize: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/resize',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager', 'size'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.setInstanceTemplate
+     *
+     * @desc Specifies the instance template to use when creating new instances in this group. The templates for existing instances in the group do not change unless you recreate them.
+     *
+     * @alias compute.instanceGroupManagers.setInstanceTemplate
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    setInstanceTemplate: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/setInstanceTemplate',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroupManagers.setTargetPools
+     *
+     * @desc Modifies the target pools to which all new instances in this group are assigned. The target pools for existing instances in the group do not change unless you recreate them.
+     *
+     * @alias compute.instanceGroupManagers.setTargetPools
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroupManager - The name of the instance group manager.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the managed instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    setTargetPools: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}/setTargetPools',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.instanceGroups = {
+
+    /**
+     * compute.instanceGroups.addInstances
+     *
+     * @desc Adds a list of instances to an instance group. All of the instances in the instance group must be in the same network.
+     *
+     * @alias compute.instanceGroups.addInstances
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroup - The name of the instance group where you are adding instances.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    addInstances: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}/addInstances',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroup'],
+        pathParams: ['instanceGroup', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.aggregatedList
+     *
+     * @desc Retrieves the list of instance groups, and sorts them by zone.
+     *
+     * @alias compute.instanceGroups.aggregatedList
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
+     * @param  {integer=} params.maxResults - Maximum count of results to be returned.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    aggregatedList: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/aggregated/instanceGroups',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project'],
+        pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.delete
+     *
+     * @desc Deletes the specified instance group.
+     *
+     * @alias compute.instanceGroups.delete
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroup - The name of the instance group to delete.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroup'],
+        pathParams: ['instanceGroup', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.get
+     *
+     * @desc Returns the specified instance group resource.
+     *
+     * @alias compute.instanceGroups.get
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroup - The name of the instance group.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroup'],
+        pathParams: ['instanceGroup', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.insert
+     *
+     * @desc Creates an instance group in the specified project using the parameters that are included in the request.
+     *
+     * @alias compute.instanceGroups.insert
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    insert: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone'],
+        pathParams: ['project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.list
+     *
+     * @desc Retrieves the list of instance groups that are located in the specified project and zone.
+     *
+     * @alias compute.instanceGroups.list
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
+     * @param  {integer=} params.maxResults - Maximum count of results to be returned.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'zone'],
+        pathParams: ['project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.listInstances
+     *
+     * @desc Lists instances in an instance group. The parameters for this method specify whether the list filters instances by state and named ports information.
+     *
+     * @alias compute.instanceGroups.listInstances
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
+     * @param  {string} params.instanceGroup - The name of the instance group from which you want to generate a list of included instances.
+     * @param  {integer=} params.maxResults - Maximum count of results to be returned.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    listInstances: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}/listInstances',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroup'],
+        pathParams: ['instanceGroup', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.removeInstances
+     *
+     * @desc Removes a list of instances from an instance group.
+     *
+     * @alias compute.instanceGroups.removeInstances
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroup - The name of the instance group where the specified instances will be removed.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    removeInstances: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}/removeInstances',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroup'],
+        pathParams: ['instanceGroup', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.instanceGroups.setNamedPorts
+     *
+     * @desc Sets the named ports in an instance group.
+     *
+     * @alias compute.instanceGroups.setNamedPorts
+     * @memberOf! compute(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.instanceGroup - The name of the instance group where the named ports are updated.
+     * @param  {string} params.project - The project ID for this request.
+     * @param  {string} params.zone - The URL of the zone where the instance group is located.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    setNamedPorts: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}/setNamedPorts',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instanceGroup'],
+        pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
 
@@ -1890,9 +2547,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - The project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -1957,9 +2614,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -2143,7 +2800,7 @@ function Compute(options) {
      *
      * @param  {object} params - Parameters for request
      * @param  {string} params.instance - Name of the instance scoping this request.
-     * @param  {integer=} params.port - Which COM port to retrieve data from.
+     * @param  {integer=} params.port - Specifies which COM or serial port to retrieve data from.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - The name of the zone for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -2203,9 +2860,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - The name of the zone for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -2487,9 +3144,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -2548,9 +3205,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - The name of the zone for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -2671,9 +3328,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -2848,13 +3505,13 @@ function Compute(options) {
     /**
      * compute.regionOperations.delete
      *
-     * @desc Deletes the specified region-specific operation resource.
+     * @desc Deletes the specified region-specific Operations resource.
      *
      * @alias compute.regionOperations.delete
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string} params.operation - Name of the operation resource to delete.
+     * @param  {string} params.operation - Name of the Operations resource to delete.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.region - Name of the region scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -2878,13 +3535,13 @@ function Compute(options) {
     /**
      * compute.regionOperations.get
      *
-     * @desc Retrieves the specified region-specific operation resource.
+     * @desc Retrieves the specified region-specific Operations resource.
      *
      * @alias compute.regionOperations.get
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string} params.operation - Name of the operation resource to return.
+     * @param  {string} params.operation - Name of the Operations resource to return.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.region - Name of the zone scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -2908,15 +3565,15 @@ function Compute(options) {
     /**
      * compute.regionOperations.list
      *
-     * @desc Retrieves the list of operation resources contained within the specified region.
+     * @desc Retrieves the list of Operation resources contained within the specified region.
      *
      * @alias compute.regionOperations.list
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.region - Name of the region scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -2979,9 +3636,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -3101,9 +3758,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -3194,9 +3851,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -3316,9 +3973,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -3381,9 +4038,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -3502,9 +4159,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {string} params.zone - Name of the zone scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -3600,9 +4257,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -3752,9 +4409,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {string} params.region - Name of the region scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -3882,9 +4539,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -4003,9 +4660,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.region - The name of the region for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -4126,9 +4783,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Name of the project scoping this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -4251,9 +4908,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -4372,9 +5029,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.region - The name of the region for this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -4402,13 +5059,13 @@ function Compute(options) {
     /**
      * compute.zoneOperations.delete
      *
-     * @desc Deletes the specified zone-specific operation resource.
+     * @desc Deletes the specified zone-specific Operations resource.
      *
      * @alias compute.zoneOperations.delete
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string} params.operation - Name of the operation resource to delete.
+     * @param  {string} params.operation - Name of the Operations resource to delete.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - Name of the zone scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -4432,13 +5089,13 @@ function Compute(options) {
     /**
      * compute.zoneOperations.get
      *
-     * @desc Retrieves the specified zone-specific operation resource.
+     * @desc Retrieves the specified zone-specific Operations resource.
      *
      * @alias compute.zoneOperations.get
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string} params.operation - Name of the operation resource to return.
+     * @param  {string} params.operation - Name of the Operations resource to return.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - Name of the zone scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -4462,15 +5119,15 @@ function Compute(options) {
     /**
      * compute.zoneOperations.list
      *
-     * @desc Retrieves the list of operation resources contained within the specified zone.
+     * @desc Retrieves the list of Operation resources contained within the specified zone.
      *
      * @alias compute.zoneOperations.list
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {string} params.zone - Name of the zone scoping this request.
      * @param  {callback} callback - The callback that handles the response.
@@ -4533,9 +5190,9 @@ function Compute(options) {
      * @memberOf! compute(v1)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - Project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object

--- a/apis/deploymentmanager/v2beta1.js
+++ b/apis/deploymentmanager/v2beta1.js
@@ -297,7 +297,7 @@ function Deploymentmanager(options) {
      * @param  {object} params - Parameters for request
      * @param  {string} params.deployment - ! The name of the deployment for this request.
      * @param  {string} params.project - ! The project ID for this request.
-     * @param  {string} params.resource - ! The name of the resource for this request.
+     * @param  {string} params.resource_ - ! The name of the resource for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
      */

--- a/apis/deploymentmanager/v2beta2.js
+++ b/apis/deploymentmanager/v2beta2.js
@@ -133,9 +133,9 @@ function Deploymentmanager(options) {
      * @memberOf! deploymentmanager(v2beta2)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - The project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -265,9 +265,9 @@ function Deploymentmanager(options) {
      *
      * @param  {object} params - Parameters for request
      * @param  {string} params.deployment - The name of the deployment for this request.
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - The project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -329,9 +329,9 @@ function Deploymentmanager(options) {
      * @memberOf! deploymentmanager(v2beta2)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - The project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -366,7 +366,7 @@ function Deploymentmanager(options) {
      * @param  {object} params - Parameters for request
      * @param  {string} params.deployment - The name of the deployment for this request.
      * @param  {string} params.project - The project ID for this request.
-     * @param  {string} params.resource - The name of the resource for this request.
+     * @param  {string} params.resource_ - The name of the resource for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
      */
@@ -395,9 +395,9 @@ function Deploymentmanager(options) {
      *
      * @param  {object} params - Parameters for request
      * @param  {string} params.deployment - The name of the deployment for this request.
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - The project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object
@@ -430,9 +430,9 @@ function Deploymentmanager(options) {
      * @memberOf! deploymentmanager(v2beta2)
      *
      * @param  {object} params - Parameters for request
-     * @param  {string=} params.filter - Filter expression for filtering listed resources.
+     * @param  {string=} params.filter - Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must contain the following: FIELD_NAME COMPARISON_STRING LITERAL_STRING   - FIELD_NAME: The name of the field you want to compare. The field name must be valid for the type of resource being filtered. Only atomic field types are supported (string, number, boolean). Array and object fields are not currently supported.  - COMPARISON_STRING: The comparison string, either eq (equals) or ne (not equals).  - LITERAL_STRING: The literal string value to filter to. The literal value must be valid for the type of field (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, you can filter by the name of a resource: filter=name ne example-instance The above filter returns only results whose name field does not equal example-instance. You can also enclose your literal string in single, double, or no quotes.
      * @param  {integer=} params.maxResults - Maximum count of results to be returned.
-     * @param  {string=} params.pageToken - Tag returned by a previous list request when that list was truncated to maxResults. Used to continue a previous list request.
+     * @param  {string=} params.pageToken - Specifies a page token to use. Use this parameter if you want to list the next page of results. Set pageToken to the nextPageToken returned by a previous list request.
      * @param  {string} params.project - The project ID for this request.
      * @param  {callback} callback - The callback that handles the response.
      * @return {object} Request object

--- a/apis/dns/v1.js
+++ b/apis/dns/v1.js
@@ -230,6 +230,7 @@ function Dns(options) {
      * @memberOf! dns(v1)
      *
      * @param  {object} params - Parameters for request
+     * @param  {string=} params.dnsName - Restricts the list to return only zones with this domain name.
      * @param  {integer=} params.maxResults - Optional. Maximum number of results to be returned. If unspecified, the server will decide how many results to return.
      * @param  {string=} params.pageToken - Optional. A tag returned by a previous list request that was truncated. Use this parameter to continue a previous list request.
      * @param  {string} params.project - Identifies the project addressed by this request.

--- a/apis/dns/v1beta1.js
+++ b/apis/dns/v1beta1.js
@@ -230,6 +230,7 @@ function Dns(options) {
      * @memberOf! dns(v1beta1)
      *
      * @param  {object} params - Parameters for request
+     * @param  {string=} params.dnsName - Restricts the list to return only zones with this domain name.
      * @param  {integer=} params.maxResults - Optional. Maximum number of results to be returned. If unspecified, the server will decide how many results to return.
      * @param  {string=} params.pageToken - Optional. A tag returned by a previous list request that was truncated. Use this parameter to continue a previous list request.
      * @param  {string} params.project - Identifies the project addressed by this request.

--- a/apis/genomics/v1.js
+++ b/apis/genomics/v1.js
@@ -1,0 +1,1260 @@
+/**
+ * Copyright 2014 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* jshint maxlen: false */
+
+'use strict';
+
+var createAPIRequest = require('../../lib/apirequest');
+
+/**
+ * Genomics API
+ *
+ * @classdesc An API to store, process, explore, and share DNA sequence reads, reference-based alignments, and variant calls.
+ * @namespace genomics
+ * @version  v1
+ * @variation v1
+ * @this Genomics
+ * @param {object=} options Options for Genomics
+ */
+function Genomics(options) {
+
+  var self = this;
+  this._options = options || {};
+
+  this.datasets = {
+
+    /**
+     * genomics.datasets.list
+     *
+     * @desc Lists datasets within a project.
+     *
+     * @alias genomics.datasets.list
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object=} params - Parameters for request
+     * @param  {string=} params.projectId - Required. The project to list datasets for.
+     * @param  {integer=} params.pageSize - The maximum number of results returned by this request. If unspecified, defaults to 50. The maximum value is 1024.
+     * @param  {string=} params.pageToken - The continuation token, which is used to page through large result sets. To get the next page of results, set this parameter to the value of `nextPageToken` from the previous response.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/datasets',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.datasets.create
+     *
+     * @desc Creates a new dataset.
+     *
+     * @alias genomics.datasets.create
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    create: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/datasets',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.datasets.get
+     *
+     * @desc Gets a dataset by ID.
+     *
+     * @alias genomics.datasets.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.datasetId - The ID of the dataset.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/datasets/{datasetId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['datasetId'],
+        pathParams: ['datasetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.datasets.patch
+     *
+     * @desc Updates a dataset. This method supports patch semantics.
+     *
+     * @alias genomics.datasets.patch
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.datasetId - The ID of the dataset to be updated.
+     * @param  {string=} params.updateMask - An optional mask specifying which fields to update. At this time, the only mutable field is [name][google.genomics.v1.Dataset.name]. The only acceptable value is "name". If unspecified, all mutable fields will be updated.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/datasets/{datasetId}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['datasetId'],
+        pathParams: ['datasetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.datasets.delete
+     *
+     * @desc Deletes a dataset.
+     *
+     * @alias genomics.datasets.delete
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.datasetId - The ID of the dataset to be deleted.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/datasets/{datasetId}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['datasetId'],
+        pathParams: ['datasetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.datasets.undelete
+     *
+     * @desc Undeletes a dataset by restoring a dataset which was deleted via this API. This operation is only possible for a week after the deletion occurred.
+     *
+     * @alias genomics.datasets.undelete
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.datasetId - The ID of the dataset to be undeleted.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    undelete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/datasets/{datasetId}:undelete',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['datasetId'],
+        pathParams: ['datasetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.operations = {
+
+    /**
+     * genomics.operations.get
+     *
+     * @desc Gets the latest state of a long-running operation. Clients may use this method to poll the operation result at intervals as recommended by the API service.
+     *
+     * @alias genomics.operations.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.name - The name of the operation resource.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/{name}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.operations.list
+     *
+     * @desc Lists operations that match the specified filter in the request.
+     *
+     * @alias genomics.operations.list
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.name - The name of the operation collection.
+     * @param  {string=} params.filter - A string for filtering [Operations][google.longrunning.Operation]. The following filter fields are supported: * projectId: Required. Corresponds to [OperationMetadata.projectId][google.genomics.v1.OperationMetadata.project_id]. * createTime: The time this job was created, in seconds from the [epoch](http://en.wikipedia.org/wiki/Unix_time). Can use `>=` and/or `= 1432140000` * `projectId = my-project AND createTime >= 1432140000 AND createTime <= 1432150000 AND status = RUNNING`
+     * @param  {integer=} params.pageSize - The maximum number of results to return. If unspecified, defaults to 256. The maximum value is 2048.
+     * @param  {string=} params.pageToken - The standard List page token.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/{name}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.operations.cancel
+     *
+     * @desc Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. Clients may use [Operations.GetOperation][google.longrunning.Operations.GetOperation] or [Operations.ListOperations][google.longrunning.Operations.ListOperations] to check whether the cancellation succeeded or the operation completed despite cancellation.
+     *
+     * @alias genomics.operations.cancel
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.name - The name of the operation resource to be cancelled.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    cancel: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/{name}:cancel',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.operations.delete
+     *
+     * @desc This method is not implemented. To cancel an operation, please use [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+     *
+     * @alias genomics.operations.delete
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.name - The name of the operation resource to be deleted.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/{name}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.readgroupsets = {
+
+    /**
+     * genomics.readgroupsets.import
+     *
+     * @desc Creates read group sets by asynchronously importing the provided information. Note that currently comments in the input file header are **not** imported and some custom tags will be converted to strings, rather than preserving tag types. The caller must have WRITE permissions to the dataset.
+     *
+     * @alias genomics.readgroupsets.import
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    import: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/readgroupsets:import',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.readgroupsets.export
+     *
+     * @desc Exports a read group set to a BAM file in Google Cloud Storage. Note that currently there may be some differences between exported BAM files and the original BAM file at the time of import. In particular, comments in the input file header will not be preserved, some custom tags will be converted to strings, and original reference sequence order is not necessarily preserved.
+     *
+     * @alias genomics.readgroupsets.export
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.readGroupSetId - Required. The ID of the read group set to export.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    export: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/readgroupsets/{readGroupSetId}:export',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['readGroupSetId'],
+        pathParams: ['readGroupSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.readgroupsets.search
+     *
+     * @desc Searches for read group sets matching the criteria. Implements [GlobalAllianceApi.searchReadGroupSets](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchReadGroupSets).
+     *
+     * @alias genomics.readgroupsets.search
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    search: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/readgroupsets/search',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.readgroupsets.patch
+     *
+     * @desc Updates a read group set. This method supports patch semantics.
+     *
+     * @alias genomics.readgroupsets.patch
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.readGroupSetId - The ID of the read group set to be updated. The caller must have WRITE permissions to the dataset associated with this read group set.
+     * @param  {string=} params.updateMask - An optional mask specifying which fields to update. At this time, mutable fields are [referenceSetId][google.genomics.v1.ReadGroupSet.reference_set_id] and [name][google.genomics.v1.ReadGroupSet.name]. Acceptable values are "referenceSetId" and "name". If unspecified, all mutable fields will be updated.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/readgroupsets/{readGroupSetId}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['readGroupSetId'],
+        pathParams: ['readGroupSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.readgroupsets.delete
+     *
+     * @desc Deletes a read group set.
+     *
+     * @alias genomics.readgroupsets.delete
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.readGroupSetId - The ID of the read group set to be deleted. The caller must have WRITE permissions to the dataset associated with this read group set.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/readgroupsets/{readGroupSetId}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['readGroupSetId'],
+        pathParams: ['readGroupSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.readgroupsets.get
+     *
+     * @desc Gets a read group set by ID.
+     *
+     * @alias genomics.readgroupsets.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.readGroupSetId - The ID of the read group set.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/readgroupsets/{readGroupSetId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['readGroupSetId'],
+        pathParams: ['readGroupSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    coveragebuckets: {
+
+      /**
+       * genomics.readgroupsets.coveragebuckets.list
+       *
+       * @desc Lists fixed width coverage buckets for a read group set, each of which correspond to a range of a reference sequence. Each bucket summarizes coverage information across its corresponding genomic range. Coverage is defined as the number of reads which are aligned to a given base in the reference sequence. Coverage buckets are available at several precomputed bucket widths, enabling retrieval of various coverage 'zoom levels'. The caller must have READ permissions for the target read group set.
+       *
+       * @alias genomics.readgroupsets.coveragebuckets.list
+       * @memberOf! genomics(v1)
+       *
+       * @param  {object} params - Parameters for request
+       * @param  {string} params.readGroupSetId - Required. The ID of the read group set over which coverage is requested.
+       * @param  {string=} params.referenceName - The name of the reference to query, within the reference set associated with this query. Optional.
+       * @param  {string=} params.start - The start position of the range on the reference, 0-based inclusive. If specified, `referenceName` must also be specified. Defaults to 0.
+       * @param  {string=} params.end - The end position of the range on the reference, 0-based exclusive. If specified, `referenceName` must also be specified. If unset or 0, defaults to the length of the reference.
+       * @param  {string=} params.targetBucketWidth - The desired width of each reported coverage bucket in base pairs. This will be rounded down to the nearest precomputed bucket width; the value of which is returned as `bucketWidth` in the response. Defaults to infinity (each bucket spans an entire reference sequence) or the length of the target range, if specified. The smallest precomputed `bucketWidth` is currently 2048 base pairs; this is subject to change.
+       * @param  {string=} params.pageToken - The continuation token, which is used to page through large result sets. To get the next page of results, set this parameter to the value of `nextPageToken` from the previous response.
+       * @param  {integer=} params.pageSize - The maximum number of results to return in a single page. If unspecified, defaults to 1024. The maximum value is 2048.
+       * @param  {callback} callback - The callback that handles the response.
+       * @return {object} Request object
+       */
+      list: function(params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://genomics.googleapis.com/v1/readgroupsets/{readGroupSetId}/coveragebuckets',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['readGroupSetId'],
+          pathParams: ['readGroupSetId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      }
+    }
+  };
+
+  this.reads = {
+
+    /**
+     * genomics.reads.search
+     *
+     * @desc Gets a list of reads for one or more read group sets. Reads search operates over a genomic coordinate space of reference sequence & position defined over the reference sequences to which the requested read group sets are aligned. If a target positional range is specified, search returns all reads whose alignment to the reference genome overlap the range. A query which specifies only read group set IDs yields all reads in those read group sets, including unmapped reads. All reads returned (including reads on subsequent pages) are ordered by genomic coordinate (reference sequence & position). Reads with equivalent genomic coordinates are returned in a deterministic order. Implements [GlobalAllianceApi.searchReads](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchReads).
+     *
+     * @alias genomics.reads.search
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    search: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/reads/search',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.referencesets = {
+
+    /**
+     * genomics.referencesets.search
+     *
+     * @desc Searches for reference sets which match the given criteria. Implements [GlobalAllianceApi.searchReferenceSets](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchReferenceSets)
+     *
+     * @alias genomics.referencesets.search
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    search: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/referencesets/search',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.referencesets.get
+     *
+     * @desc Gets a reference set. Implements [GlobalAllianceApi.getReferenceSet](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.getReferenceSet").
+     *
+     * @alias genomics.referencesets.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.referenceSetId - The ID of the reference set.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/referencesets/{referenceSetId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['referenceSetId'],
+        pathParams: ['referenceSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.references = {
+
+    /**
+     * genomics.references.search
+     *
+     * @desc Searches for references which match the given criteria. Implements [GlobalAllianceApi.searchReferences](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchReferences).
+     *
+     * @alias genomics.references.search
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    search: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/references/search',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.references.get
+     *
+     * @desc Gets a reference. Implements [GlobalAllianceApi.getReference](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.getReference).
+     *
+     * @alias genomics.references.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.referenceId - The ID of the reference.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/references/{referenceId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['referenceId'],
+        pathParams: ['referenceId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    bases: {
+
+      /**
+       * genomics.references.bases.list
+       *
+       * @desc Lists the bases in a reference, optionally restricted to a range. Implements [GlobalAllianceApi.getReferenceBases](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.getReferenceBases).
+       *
+       * @alias genomics.references.bases.list
+       * @memberOf! genomics(v1)
+       *
+       * @param  {object} params - Parameters for request
+       * @param  {string} params.referenceId - The ID of the reference.
+       * @param  {string=} params.start - The start position (0-based) of this query. Defaults to 0.
+       * @param  {string=} params.end - The end position (0-based, exclusive) of this query. Defaults to the length of this reference.
+       * @param  {string=} params.pageToken - The continuation token, which is used to page through large result sets. To get the next page of results, set this parameter to the value of `nextPageToken` from the previous response.
+       * @param  {integer=} params.pageSize - Specifies the maximum number of bases to return in a single page.
+       * @param  {callback} callback - The callback that handles the response.
+       * @return {object} Request object
+       */
+      list: function(params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://genomics.googleapis.com/v1/references/{referenceId}/bases',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['referenceId'],
+          pathParams: ['referenceId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      }
+    }
+  };
+
+  this.variants = {
+
+    /**
+     * genomics.variants.import
+     *
+     * @desc Creates variant data by asynchronously importing the provided information. The variants for import will be merged with any existing data and each other according to the behavior of mergeVariants. In particular, this means for merged VCF variants that have conflicting INFO fields, some data will be arbitrarily discarded. As a special case, for single-sample VCF files, QUAL and FILTER fields will be moved to the call level; these are sometimes interpreted in a call-specific context. Imported VCF headers are appended to the metadata already in a variant set.
+     *
+     * @alias genomics.variants.import
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    import: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variants:import',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variants.search
+     *
+     * @desc Gets a list of variants matching the criteria. Implements [GlobalAllianceApi.searchVariants](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchVariants).
+     *
+     * @alias genomics.variants.search
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    search: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variants/search',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variants.create
+     *
+     * @desc Creates a new variant.
+     *
+     * @alias genomics.variants.create
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    create: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variants',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variants.patch
+     *
+     * @desc Updates a variant. This method supports patch semantics. Returns the modified variant without its calls.
+     *
+     * @alias genomics.variants.patch
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.variantId - The ID of the variant to be updated.
+     * @param  {string=} params.updateMask - An optional mask specifying which fields to update. At this time, mutable fields are [names][google.genomics.v1.Variant.names] and [info][google.genomics.v1.Variant.info]. Acceptable values are "names" and "info". If unspecified, all mutable fields will be updated.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variants/{variantId}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['variantId'],
+        pathParams: ['variantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variants.delete
+     *
+     * @desc Deletes a variant.
+     *
+     * @alias genomics.variants.delete
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.variantId - The ID of the variant to be deleted.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variants/{variantId}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['variantId'],
+        pathParams: ['variantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variants.get
+     *
+     * @desc Gets a variant by ID.
+     *
+     * @alias genomics.variants.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.variantId - The ID of the variant.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variants/{variantId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['variantId'],
+        pathParams: ['variantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variants.merge
+     *
+     * @desc Merges the given variants with existing variants. Each variant will be merged with an existing variant that matches its reference sequence, start, end, reference bases, and alternative bases. If no such variant exists, a new one will be created. When variants are merged, the call information from the new variant is added to the existing variant, and other fields (such as key/value pairs) are discarded.
+     *
+     * @alias genomics.variants.merge
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    merge: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variants:merge',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.variantsets = {
+
+    /**
+     * genomics.variantsets.create
+     *
+     * @desc Creates a new variant set.
+     *
+     * @alias genomics.variantsets.create
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    create: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variantsets',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variantsets.export
+     *
+     * @desc Exports variant set data to an external destination.
+     *
+     * @alias genomics.variantsets.export
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.variantSetId - Required. The ID of the variant set that contains variant data which should be exported. The caller must have READ access to this variant set.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    export: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variantsets/{variantSetId}:export',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['variantSetId'],
+        pathParams: ['variantSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variantsets.get
+     *
+     * @desc Gets a variant set by ID.
+     *
+     * @alias genomics.variantsets.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.variantSetId - Required. The ID of the variant set.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variantsets/{variantSetId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['variantSetId'],
+        pathParams: ['variantSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variantsets.search
+     *
+     * @desc Returns a list of all variant sets matching search criteria. Implements [GlobalAllianceApi.searchVariantSets](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchVariantSets).
+     *
+     * @alias genomics.variantsets.search
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    search: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variantsets/search',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variantsets.delete
+     *
+     * @desc Deletes the contents of a variant set. The variant set object is not deleted.
+     *
+     * @alias genomics.variantsets.delete
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.variantSetId - The ID of the variant set to be deleted.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variantsets/{variantSetId}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['variantSetId'],
+        pathParams: ['variantSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.variantsets.patch
+     *
+     * @desc Updates a variant set. This method supports patch semantics.
+     *
+     * @alias genomics.variantsets.patch
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.variantSetId - The ID of the variant to be updated (must already exist).
+     * @param  {string=} params.updateMask - An optional mask specifying which fields to update. At this time, the only mutable field is [metadata][google.genomics.v1.VariantSet.metadata]. The only acceptable value is "metadata". If unspecified, all mutable fields will be updated.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/variantsets/{variantSetId}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['variantSetId'],
+        pathParams: ['variantSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  this.callsets = {
+
+    /**
+     * genomics.callsets.search
+     *
+     * @desc Gets a list of call sets matching the criteria. Implements [GlobalAllianceApi.searchCallSets](http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchCallSets).
+     *
+     * @alias genomics.callsets.search
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    search: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/callsets/search',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.callsets.create
+     *
+     * @desc Creates a new call set.
+     *
+     * @alias genomics.callsets.create
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    create: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/callsets',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.callsets.patch
+     *
+     * @desc Updates a call set. This method supports patch semantics.
+     *
+     * @alias genomics.callsets.patch
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.callSetId - The ID of the call set to be updated.
+     * @param  {string=} params.updateMask - An optional mask specifying which fields to update. At this time, the only mutable field is [name][google.genomics.v1.CallSet.name]. The only acceptable value is "name". If unspecified, all mutable fields will be updated.
+     * @param  {object} params.resource - Request body data
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/callsets/{callSetId}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['callSetId'],
+        pathParams: ['callSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.callsets.delete
+     *
+     * @desc Deletes a call set.
+     *
+     * @alias genomics.callsets.delete
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.callSetId - The ID of the call set to be deleted.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/callsets/{callSetId}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['callSetId'],
+        pathParams: ['callSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * genomics.callsets.get
+     *
+     * @desc Gets a call set by ID.
+     *
+     * @alias genomics.callsets.get
+     * @memberOf! genomics(v1)
+     *
+     * @param  {object} params - Parameters for request
+     * @param  {string} params.callSetId - The ID of the call set.
+     * @param  {callback} callback - The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function(params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://genomics.googleapis.com/v1/callsets/{callSetId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['callSetId'],
+        pathParams: ['callSetId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+}
+
+/**
+ * Exports Genomics object
+ * @type Genomics
+ */
+module.exports = Genomics;

--- a/apis/pubsub/v1.js
+++ b/apis/pubsub/v1.js
@@ -48,7 +48,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
@@ -77,7 +77,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
        */
@@ -105,7 +105,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
@@ -314,7 +314,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
@@ -343,7 +343,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
        */
@@ -371,7 +371,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object

--- a/apis/pubsub/v1beta2.js
+++ b/apis/pubsub/v1beta2.js
@@ -48,7 +48,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1beta2)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
@@ -77,7 +77,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1beta2)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
        */
@@ -105,7 +105,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1beta2)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
@@ -314,7 +314,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1beta2)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being specified. Resource is usually specified as a path, such as, projects/{project}/zones/{zone}/disks/{disk}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
@@ -343,7 +343,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1beta2)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object
        */
@@ -371,7 +371,7 @@ function Pubsub(options) {
        * @memberOf! pubsub(v1beta2)
        *
        * @param  {object} params - Parameters for request
-       * @param  {string} params.resource - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
+       * @param  {string} params.resource_ - REQUIRED: The resource for which policy detail is being requested. Resource is usually specified as a path, such as, projects/{project}.
        * @param  {object} params.resource - Request body data
        * @param  {callback} callback - The callback that handles the response.
        * @return {object} Request object

--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -115,9 +115,9 @@ function createAPIRequest(parameters, callback) {
 
   // Un-alias parameters that were modified due to conflicts with reserved names
   Object.keys(params).forEach(function(key) {
-	if (key.slice(-1) === '_') {
+    if (key.slice(-1) === '_') {
       var new_key = key.slice(0, -1);
-	  params[new_key] = params[key];
+      params[new_key] = params[key];
       delete params[key];
     }
   });

--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -102,6 +102,26 @@ function createAPIRequest(parameters, callback) {
     params // API call params
   );
 
+  var media = params.media || {};
+  var resource = params.resource;
+  var authClient = params.auth ||
+    parameters.context._options.auth ||
+    parameters.context.google._options.auth;
+
+  var defaultMime = typeof media.body === 'string' ? 'text/plain' : 'application/octet-stream';
+  delete params.media;
+  delete params.resource;
+  delete params.auth;
+
+  // Un-alias parameters that were modified due to conflicts with reserved names
+  Object.keys(params).forEach(function(key) {
+	if (key.slice(-1) === '_') {
+      var new_key = key.slice(0, -1);
+	  params[new_key] = params[key];
+      delete params[key];
+    }
+  });
+  
   // Normalize callback
   callback = createCallback(callback);
 
@@ -114,17 +134,6 @@ function createAPIRequest(parameters, callback) {
 
     return null;
   }
-
-  var media = params.media || {};
-  var resource = params.resource;
-  var authClient = params.auth ||
-    parameters.context._options.auth ||
-    parameters.context.google._options.auth;
-
-  var defaultMime = typeof media.body === 'string' ? 'text/plain' : 'application/octet-stream';
-  delete params.media;
-  delete params.resource;
-  delete params.auth;
 
   // Parse urls and urlescape path params
   options.url = parsePath(options.url, params);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -115,7 +115,7 @@ function getPathParams(params) {
 }
 
 function getSafeParamName(param) {
-  if (RESERVED_PARAMS.indexOf(param) != -1) {
+  if (RESERVED_PARAMS.indexOf(param) !== -1) {
     return param + '_';	  
   }
   return param;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -47,7 +47,7 @@ var BEAUTIFY_OPTIONS = {
   'unescape_strings': false,
   'wrap_line_length': 0
 };
-
+var RESERVED_PARAMS = ['resource', 'media', 'auth'];
 var templateContents = fs.readFileSync(API_TEMPLATE, { encoding: 'utf8' });
 var indexTemplContents = fs.readFileSync(API_INDEX_TEMPLATE, { encoding: 'utf8' });
 var transporter = new DefaultTransporter();
@@ -114,6 +114,13 @@ function getPathParams(params) {
   return pathParams;
 }
 
+function getSafeParamName(param) {
+  if (RESERVED_PARAMS.indexOf(param) != -1) {
+    return param + '_';	  
+  }
+  return param;
+}
+
 /**
  * Disable auto-escaping its output
  * @type {Boolean}
@@ -124,6 +131,7 @@ swig.setFilter('getAPIs', getAPIs);
 swig.setFilter('oneLine', oneLine);
 swig.setFilter('cleanComments', cleanComments);
 swig.setFilter('getPathParams', getPathParams);
+swig.setFilter('getSafeParamName', getSafeParamName);
 swig.setDefaults({ loader: swig.loaders.fs(path.join(__dirname, '..', 'templates'))});
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "author": "Google Inc.",
   "description": "Google APIs Client Library for Node.js",
   "contributors": [

--- a/templates/method-partial.js
+++ b/templates/method-partial.js
@@ -11,7 +11,7 @@
  *
  * @param  {object{% if !m.parameterOrder && !m.request %}={% endif %}} params - Parameters for request
  {% for pname, p in m.parameters -%}
- * @param  {{ lb }}{{ p.type }}{% if ! p.required %}={% endif %}{{ rb }} params.{{ pname }} - {{ p.description|oneLine|cleanComments|safe }}
+ * @param  {{ lb }}{{ p.type }}{% if ! p.required %}={% endif %}{{ rb }} params.{{ pname|getSafeParamName }} - {{ p.description|oneLine|cleanComments|safe }}
  {% endfor -%}
 {% if m.supportsMediaUpload -%}
 {% if m.request -%}

--- a/test/test.query.js
+++ b/test/test.query.js
@@ -58,6 +58,11 @@ describe('Query params', function() {
     assert.equal(req.uri.query, 'madeThisUp=hello');
   });
 
+  it('should be set if params passed are aliased names', function() {
+    var req = drive.files.get({ fileId: '123', resource_: 'hello' }, noop);
+    assert.equal(req.uri.query, 'resource=hello');
+  });
+  
   it('should chain together with & in order', function() {
     var req = drive.files.get({
       fileId: '123',


### PR DESCRIPTION
Simple escape mechanism to allow parameter names that happen to conflict with names the client library uses. Appends "_" to parameters that would otherwise conflict. Currently only a few APIs exhibit this issue, notably cloud APIs with the 'resource' parameter.

