### PR TITLE
Restore --discovery-url functionality to scripts/generate

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -21,10 +21,12 @@ var rimraf = require('rimraf');
 var path = require('path');
 var debug = false;
 
-var args = process.argv.slice(2);
+var argv = require('minimist')(process.argv.slice(2));
 
 // constructors
-var gen = new Generator({ debug: debug, includePrivate: false });
+var gen = new Generator({ debug: debug, includePrivate: true });
+
+var args = argv._;
 
 if (args.length) {
   args.forEach(function(url) {
@@ -32,11 +34,9 @@ if (args.length) {
       if (err) {
         throw err;
       }
-      console.log('Finished generating the API!');
+      console.log('Generated API for ' + url);
     });
   });
-
-  return;
 }
 
 console.log('Removing old APIs...');

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -24,7 +24,7 @@ var debug = false;
 var argv = require('minimist')(process.argv.slice(2));
 
 // constructors
-var gen = new Generator({ debug: debug, includePrivate: true });
+var gen = new Generator({ debug: debug, includePrivate: false });
 
 var args = argv._;
 


### PR DESCRIPTION
scripts/generate.js attempts to parse all arguments as api urls.  This breaks the existing functionality of being able to provide a `--discovery-url` flag.  This patch restores this functionality while keeping the new behavior of generating apis for each un-named argument.

```
➜  google-api-nodejs-client git:(master) node scripts/generate --discovery-url "https://my.discovery.json" 
/Users/phaedrus/reference/javascript/google-api-nodejs-client/scripts/generate.js:33
        throw err;
              ^
Error: Invalid URI "--discovery-url"
```
An issue still exists where the apis generated will not be included in apis/index.js, as this file is generated from the discovery url file.  
