### PR TITLE
path segments should be url encoded, closes #476

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -51,6 +51,32 @@ function getMissingParams(params, required) {
   return missing.length > 0 ? missing : null;
 }
 
+// Escaping path segement, please look at: http://blog.lunatech.com/2009/02/03/what-every-web-developer-must-know-about-url-encoding
+var pathSegmentEscapeChars = {
+  '#': '%23',
+  '/': '%2F',
+  '?': '%3F',
+  '[': '%5B',
+  ']': '%5D',
+  '%': '%25',
+  '<': '%3C',
+  '>': '%3E',
+  '\\': '%5C',
+  '^': '%5E',
+  '`': '%60',
+  '{': '%7B',
+  '|': '%7C',
+  '}': '%7D'
+};
+
+var pathSegmentEscapeCharsRegex = /[#\/\?\[\]%<>\\\^`,{\|}]/g;
+
+function pathSegmentEscape(pathSegment) {
+  return pathSegment.replace(pathSegmentEscapeCharsRegex, function(match) {
+    return pathSegmentEscapeChars[match];
+  })
+}
+
 /**
  * Create and send request to Google API
  * @param  {object}   parameters Parameters used to form request
@@ -97,7 +123,7 @@ function createAPIRequest(parameters, callback) {
       delete params[key];
     }
   });
-  
+
   // Normalize callback
   callback = createCallback(callback);
 
@@ -110,6 +136,11 @@ function createAPIRequest(parameters, callback) {
 
     return null;
   }
+
+  // encode path parameters from the params object
+  parameters.pathParams.forEach(function(param) {
+    params[param] = pathSegmentEscape(params[param]);
+  });
 
   // Parse urls
   if (options.url) {

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -18,7 +18,7 @@
 
 var assert = require('assert');
 var googleapis = require('../lib/googleapis.js');
-var google, drive;
+var google, drive, webmasters;
 
 describe('Path params', function() {
 
@@ -27,6 +27,7 @@ describe('Path params', function() {
   beforeEach(function() {
     google = new googleapis.GoogleApis();
     drive = google.drive('v2');
+    webmasters = google.webmasters('v3');
   });
 
   it('should not throw error if not included and required', function(done) {
@@ -91,6 +92,12 @@ describe('Path params', function() {
   it('should not be urlencoded', function () {
     var req = drive.files.get({ fileId: 'p@ram' }, noop);
     assert.equal(req.uri.path.split('/').pop(), 'p@ram');
+  });
+
+  it('should be urlencoded', function () {
+    var req = webmasters.searchanalytics.query({ siteUrl: 'http://www.google.com' }, noop);
+    var p = req.uri.path.split('/');
+    assert.equal(p[4], 'http:%2F%2Fwww.google.com');
   });
 
   it('should keep query params null if only path params', function() {


### PR DESCRIPTION
path segments should be url encoded, please look at the following url
http://blog.lunatech.com/2009/02/03/what-every-web-developer-must-know-about-url-encoding
