### PR TITLE
add etag support with samples and test

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -89,6 +89,10 @@ function createAPIRequest(parameters, callback) {
   delete params.resource;
   delete params.auth;
 
+  // Grab headers from user provided options
+  var headers = params.headers || {};
+  delete params.headers;
+
   // Un-alias parameters that were modified due to conflicts with reserved names
   Object.keys(params).forEach(function(key) {
     if (key.slice(-1) === '_') {
@@ -146,9 +150,9 @@ function createAPIRequest(parameters, callback) {
       ];
     } else {
       params.uploadType = 'media';
-      options.headers = {
+      utils.extend(headers, {
         'Content-Type': media.mimeType || defaultMime
-      };
+      });
 
       if (isReadableStream(media.body)) {
         body = media.body;
@@ -162,6 +166,7 @@ function createAPIRequest(parameters, callback) {
     );
   }
 
+  options.headers = headers;
   options.qs = params;
   options.useQuerystring = true;
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     {
       "name": "Tim Emiola",
       "email": "tbetbetbe@google.com"
+    },
+    {
+      "name": "Justin Beckwith",
+      "email": "beckwith@google.com"
     }
   ],
   "keywords": [

--- a/samples/README.md
+++ b/samples/README.md
@@ -86,3 +86,18 @@ Documentation for the URL Shortener API in
     <td>Shortens a URL with the URL Shortener API</td>
   </tr>
 </table>
+
+
+## ![](http://www.google.com/images/icons/product/youtube-32.png) YouTube API
+
+With the YouTube Data API, you can add a variety of YouTube features to your application. Use the API to upload videos, manage playlists and subscriptions, update channel settings, and more.
+
+Documentation for the YouTube Data API in
+[JSDoc](http://google.github.io/google-api-nodejs-client/2.1.7/youtube.html).
+
+<table>
+  <tr>
+    <td><a href="youtube">samples/youtube</a></td>
+    <td>Samples for working with playlists and search.</td>
+  </tr>
+</table>

--- a/samples/youtube/README.md
+++ b/samples/youtube/README.md
@@ -1,0 +1,12 @@
+# YouTube API Samples
+
+With the YouTube Data API, you can add a variety of YouTube features to your application. Use the API to upload videos, manage playlists and subscriptions, update channel settings, and more.
+
+[Learn more](https://developers.google.com/youtube/v3/)
+
+## Running the samples
+
+To run this sample, add your client id, client secret, and redirect url in secrets.json.  You can also download this file directly from the Google Developers console.  The samples include:
+
+- `node playlist`
+- `node search`

--- a/samples/youtube/playlist.js
+++ b/samples/youtube/playlist.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var google = require('../../lib/googleapis');
+var sampleClient = require('../sampleclient')
+var util = require('util');
+
+// initialize the Youtube API library 
+var youtube = google.youtube({ version: 'v3', auth: sampleClient.oAuth2Client});
+
+// a very simple example of getting data from a playlist
+function runSamples() {
+  // the first query will return data with an etag
+  getPlaylistData(null, function(err, data, response) {
+    var etag = data.etag;
+
+    // the second query will (likely) return no data, and an HTTP 304
+    // since the If-None-Match header was set with a matching eTag
+    getPlaylistData(etag, function(err, data, response) {
+      console.log(response.status);
+    });
+
+  });
+}
+
+function getPlaylistData(etag, callback) {
+  
+  // Create custom HTTP headers for the request to enable
+  // use of eTags
+  var headers = {};
+  if (etag) {
+    headers['If-None-Match'] = etag;
+  }
+  youtube.playlists.list({
+    part: 'id,snippet',
+    id: 'PLIivdWyY5sqIij_cgINUHZDMnGjVx3rxi',
+    headers: headers
+  }, function (err, data, response) {
+    if (err) console.error('Error: ' + err);
+    if (data) console.log(util.inspect(data, false, null));
+    if (response) console.log('Status code: ' + response.statusCode);
+    callback(err, data, response);
+  });
+}
+
+var scopes = [
+  'https://www.googleapis.com/auth/youtube'
+];
+
+sampleClient.execute(scopes, runSamples);

--- a/samples/youtube/search.js
+++ b/samples/youtube/search.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var google = require('../../lib/googleapis');
+var sampleClient = require('../sampleclient')
+var util = require('util');
+
+// initialize the Youtube API library 
+var youtube = google.youtube({ version: 'v3', auth: sampleClient.oAuth2Client});
+
+// a very simple example of searching for youtube videos
+function runSamples() {
+  
+  youtube.search.list({
+    part: 'id,snippet',
+    q: 'Node.js on Google Cloud'
+  }, function (err, data) {
+    if (err) console.error('Error: ' + err);
+    if (data) console.log(util.inspect(data, false, null));
+    process.exit();
+  });
+}
+
+var scopes = [
+  'https://www.googleapis.com/auth/youtube'
+];
+
+sampleClient.execute(scopes, runSamples);

--- a/test/test.transporters.js
+++ b/test/test.transporters.js
@@ -25,6 +25,18 @@ describe('Transporters', function() {
 
   function noop() {}
 
+  it('should add headers to the request from params', function() {
+    var google = require('../lib/googleapis');
+    var drive = google.drive('v2');
+    var req = drive.comments.insert({
+        fileId: 'a',
+        headers: {
+          'If-None-Match': '12345'
+        }
+    }, noop);
+    assert.equal(req.headers['If-None-Match'], '12345');
+  });
+
   it('should automatically add content-type for POST requests', function() {
     var google = require('../lib/googleapis');
     var drive = google.drive('v2');


### PR DESCRIPTION
Fixes #414 - This adds etag support by allowing consumers to append their own HTTP headers to the request.  It also shows how to read details from the resulting HTTP response.  

- [x] - `npm test` succeeds
- [x] - Pull request has been squashed into 1 commit
- [x] - I did NOT manually make changes to anything in `apis/`
- [x] - Code coverage does not decrease (if any source code was changed)
- [x] - Appropriate JSDoc comments were updated in source code (if applicable)
- [x] - Appropriate changes to readme/docs are included in PR

