### PR TITLE
Added "load" method for discovering an API at runtime.

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -101,7 +101,7 @@ function createAPIRequest(parameters, callback) {
       delete params[key];
     }
   });
-  
+
   // Normalize callback
   callback = createCallback(callback);
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -24,6 +24,8 @@ var path = require('path');
 var mkdirp = require('mkdirp');
 var fs = require('fs');
 var url = require('url');
+var util = require('util');
+var createAPIRequest = require('./apirequest');
 var argv = require('minimist')(process.argv.slice(2));
 var args = argv._;
 
@@ -147,6 +149,101 @@ function handleError(err, callback) {
 }
 
 /**
+ * Given a method schema, add a method to a target.
+ *
+ * @param {object} target The target to which to add the method.
+ * @param {object} schema The top-level schema that contains the rootUrl, etc.
+ * @param {object} method The method schema from which to generate the method.
+ * @param {object} context The context to add to the method.
+ */
+function makeMethod(schema, method, context) {
+  return function (params, callback) {
+    var url = buildurl(schema.rootUrl + schema.servicePath + method.path);
+
+    var parameters = {
+      options: {
+        url: url.substring(1, url.length - 1),
+        method: method.httpMethod
+      },
+      params: params,
+      requiredParams: method.parameterOrder || [],
+      pathParams: getPathParams(method.parameters),
+      context: context
+    };
+
+    if (method.mediaUpload && method.mediaUpload.protocols &&
+      method.mediaUpload.protocols.simple &&
+      method.mediaUpload.protocols.simple.path) {
+      var mediaUrl = buildurl(
+        schema.rootUrl +
+        method.mediaUpload.protocols.simple.path
+      );
+      parameters.mediaUrl = mediaUrl.substring(1, mediaUrl.length - 1);
+    }
+
+    return createAPIRequest(parameters, callback);
+  };
+}
+
+/**
+ * Given a schema, add methods to a target.
+ *
+ * @param {object} target The target to which to apply the methods.
+ * @param {object} rootSchema The top-level schema, so we don't lose track of it
+ * during recursion.
+ * @param {object} schema The current schema from which to extract methods.
+ * @param {object} context The context to add to each method.
+ */
+function applyMethodsFromSchema (target, rootSchema, schema, context) {
+  if (schema.methods) {
+    for (var name in schema.methods) {
+      var method = schema.methods[name];
+      target[name] = makeMethod(rootSchema, method, context);
+    }
+  }
+}
+
+/**
+ * Given a schema, add methods and resources to a target.
+ *
+ * @param {object} target The target to which to apply the schema.
+ * @param {object} rootSchema The top-level schema, so we don't lose track of it
+ * during recursion.
+ * @param {object} schema The current schema from which to extract methods and
+ * resources.
+ * @param {object} context The context to add to each method.
+ */
+function applySchema (target, rootSchema, schema, context) {
+  applyMethodsFromSchema(target, rootSchema, schema, context);
+
+  if (schema.resources) {
+    for (var resourceName in schema.resources) {
+      var resource = schema.resources[resourceName];
+      if (!target[resourceName]) {
+        target[resourceName] = {};
+      }
+      applySchema(target[resourceName], rootSchema, resource, context);
+    }
+  }
+}
+
+/**
+ * Generate and Endpoint from an endpoint schema object.
+ *
+ * @param {object} schema The schema from which to generate the Endpoint.
+ * @return Function The Endpoint.
+ */
+function makeEndpoint(schema) {
+  var Endpoint = function (options) {
+    var self = this;
+    self._options = options || {};
+
+    applySchema(self, schema, schema, self);
+  };
+  return Endpoint;
+}
+
+/**
  * Generator for generating API endpoints
  * @param {object} options Options for generation
  * @this {Generator}
@@ -166,7 +263,8 @@ Generator.prototype.log = function() {
 };
 
 /**
- * Generate all APIs
+ * Generate all APIs and write to files.
+ *
  * @param {function} callback Callback when all APIs have been generated
  * @throws {Error} If there is an error generating any of the APIs
  */
@@ -230,6 +328,111 @@ Generator.prototype.generateAPI = function(apiDiscoveryUrl, callback) {
       return _generate(null, JSON.parse(fs.readFileSync(apiDiscoveryUrl, {
         encoding: 'utf-8'
       })));
+    } catch (err) {
+      return handleError(err, callback);
+    }
+  } else {
+    this.log('Requesting ' + apiDiscoveryUrl);
+    transporter.request({
+      uri: apiDiscoveryUrl
+    }, _generate);
+  }
+};
+
+/**
+ * Generate all APIs and return as in-memory object.
+ *
+ * @param {function} callback Callback when all APIs have been generated
+ * @throws {Error} If there is an error generating any of the APIs
+ */
+Generator.prototype.discoverAllAPIs = function(discoveryUrl, callback) {
+  var self = this;
+  var headers = this.options.includePrivate ? {} : { 'X-User-Ip': '0.0.0.0' };
+  transporter.request({
+    uri: discoveryUrl,
+    headers: headers
+  }, function(err, resp) {
+    if (err) {
+      return handleError(err, callback);
+    }
+
+    async.parallel(resp.items.map(function (api) {
+      return function (cb) {
+        self.discoverAPI(api.discoveryRestUrl, function (err, _api) {
+          if (err) {
+            return cb(err);
+          }
+          api.api = _api;
+          cb(null, api);
+        });
+      };
+    }), function (err, apis) {
+      if (err) {
+        return callback(err);
+      }
+
+      var versionIndex = {};
+      var apisIndex = {};
+
+      apis.forEach(function (api) {
+        if (!apisIndex[api.name]) {
+          versionIndex[api.name] = {};
+          apisIndex[api.name] = function (options) {
+            var type = typeof options;
+            var version;
+            if (type === 'string') {
+              version = options;
+              options = {};
+            } else if (type === 'object') {
+              version = options.version;
+              delete options.version;
+            } else {
+              throw new Error('Argument error: Accepts only string or object');
+            }
+            try {
+              var Endpoint = versionIndex[api.name][version];
+              var ep = new Endpoint(options);
+              ep.google = this; // for drive.google.transporter
+              return Object.freeze(ep); // create new & freeze
+            } catch (e) {
+              throw new Error(util.format('Unable to load endpoint %s("%s"): %s',
+                api.name, version, e.message));
+            }
+          };
+        }
+        versionIndex[api.name][api.version] = api.api;
+      });
+
+      return callback(null, apisIndex);
+    });
+  });
+};
+
+/**
+ * Generate API file given discovery URL
+ * @param  {String} apiDiscoveryUrl URL or filename of discovery doc for API
+ * @param {function} callback Callback when successful write of API
+ * @throws {Error} If there is an error generating the API.
+ */
+Generator.prototype.discoverAPI = function(apiDiscoveryUrl, callback) {
+
+  function _generate(err, resp) {
+    if (err) {
+      return handleError(err, callback);
+    }
+    return callback(null, makeEndpoint(resp));
+  }
+
+  var parts = url.parse(apiDiscoveryUrl);
+
+  if (apiDiscoveryUrl && !parts.protocol) {
+    this.log('Reading from file ' + apiDiscoveryUrl);
+    try {
+      return fs.readFile(apiDiscoveryUrl, {
+        encoding: 'utf8'
+      }, function (err, file) {
+        _generate(err, JSON.parse(file));
+      });
     } catch (err) {
       return handleError(err, callback);
     }

--- a/lib/googleapis.js
+++ b/lib/googleapis.js
@@ -24,6 +24,8 @@
 var path = require('path');
 var fs = require('fs');
 var util = require('util');
+var Generator = require('./generator');
+var gen = new Generator({ debug: false, includePrivate: false });
 
 /**
  * Load the apis from apis index file
@@ -108,6 +110,67 @@ GoogleApis.prototype.addAPIs = function(apis) {
   for (var apiName in apis) {
     this[apiName] = apis[apiName].bind(this);
   }
+};
+
+/**
+ * Dynamically generate an apis object that can provide Endpoint objects for the
+ * discovered APIs.
+ *
+ * @example
+ * var google = require('googleapis');
+ * var discoveryUrl = 'https://myapp.appspot.com/_ah/api/discovery/v1/apis/';
+ * google.discover(discoveryUrl, function (err) {
+ *   var someapi = google.someapi('v1');
+ * });
+ *
+ * @param {string} url Url to the discovery service for a set of APIs. e.g.,
+ * https://www.googleapis.com/discovery/v1/apis
+ * @param {Function} callback Callback function.
+ */
+GoogleApis.prototype.discover = function(url, callback) {
+  var self = this;
+
+  gen.discoverAllAPIs(url, function (err, apis) {
+    if (err) {
+      return callback(err);
+    }
+    self.addAPIs(apis);
+    callback();
+  });
+};
+
+/**
+ * Dynamically generate an Endpoint object from a discovery doc.
+ *
+ * @example
+ * var google = require('google');
+ * var discoveryDocUrl = 'https://myapp.appspot.com/_ah/api/discovery/v1/apis/someapi/v1/rest';
+ * google.discoverApi(discoveryDocUrl, function (err, someapi) {
+ *   // use someapi
+ * });
+ *
+ * @param {string} path Url or file path to discover doc for a single API.
+ * @param {object} [options] Options to configure the Endpoint object generated
+ * from the discovery doc.
+ * @param {Function} callback Callback function.
+ */
+GoogleApis.prototype.discoverAPI = function(path, options, callback) {
+  var self = this;
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  if (!options) {
+    options = {};
+  }
+  gen.discoverAPI(path, function (err, Endpoint) {
+    if (err) {
+      return callback(err);
+    }
+    var ep = new Endpoint(options);
+    ep.google = self; // for drive.google.transporter
+    return callback(null, Object.freeze(ep)); // create new & freeze
+  });
 };
 
 var google = new GoogleApis();

--- a/package.json
+++ b/package.json
@@ -68,11 +68,11 @@
   },
   "scripts": {
     "lint": "jshint lib test scripts apis",
-    "test": "mocha --reporter spec --timeout 4000",
+    "test": "mocha --reporter spec --timeout 10000",
     "generate-apis": "node scripts/generate",
     "generate-docs": "jsdoc -c jsdoc-conf.json",
     "prepare": "npm run generate-apis && npm test && npm run lint",
-    "coverage": "istanbul cover -x 'apis/**' _mocha -- --reporter spec --timeout 4000",
-    "codecov": "istanbul cover -x 'apis/**' _mocha --report lcovonly -- --reporter spec --timeout 4000 && cat coverage/lcov.info | codecov"
+    "coverage": "istanbul cover -x 'apis/**' _mocha -- --reporter spec --timeout 10000",
+    "codecov": "istanbul cover -x 'apis/**' _mocha --report lcovonly -- --reporter spec --timeout 10000 && cat coverage/lcov.info | codecov"
   }
 }

--- a/test/test.auth.js
+++ b/test/test.auth.js
@@ -17,25 +17,17 @@
 'use strict';
 
 var assert = require('assert');
+var async = require('async');
 var googleapis = require('../');
 var nock = require('nock');
-var JWT = require('../lib/auth/jwtclient.js');
-var Compute = require('../lib/auth/computeclient.js');
+var utils = require('./utils');
 
-nock.disableNetConnect();
-
-describe('JWT client', function() {
-
+describe('JWT client', function () {
   it('should expose the default auth module', function () {
-    var defaultAuthExists = false;
-    if (googleapis.auth.getApplicationDefault) {
-      defaultAuthExists = true;
-    }
-
-    assert.equal(true, defaultAuthExists);
+    assert(googleapis.auth.getApplicationDefault);
   });
-
   it('should create a jwt', function () {
+    var JWT = require('../lib/auth/jwtclient.js');
     var jwt = new JWT('someone@somewhere.com', 'file1', 'key1', 'scope1', 'subject1');
     assert.equal(jwt.email, 'someone@somewhere.com');
     assert.equal(jwt.keyFile, 'file1');
@@ -43,7 +35,6 @@ describe('JWT client', function() {
     assert.equal(jwt.scopes, 'scope1');
     assert.equal(jwt.subject, 'subject1');
   });
-
   it('should create a jwt through googleapis', function () {
     var jwt = new googleapis.auth.JWT(
       'someone@somewhere.com', 'file1', 'key1', 'scope1', 'subject1');
@@ -53,7 +44,6 @@ describe('JWT client', function() {
     assert.equal(jwt.scopes, 'scope1');
     assert.equal(jwt.subject, 'subject1');
   });
-
   it('should create scoped JWT', function () {
     var jwt = new googleapis.auth.JWT('someone@somewhere.com', 'file1', 'key1', null, 'subject1');
     assert.equal(jwt.scopes, null);
@@ -72,91 +62,200 @@ describe('JWT client', function() {
   });
 });
 
-describe('Compute client', function() {
+describe('Compute client', function () {
+  var Compute = require('../lib/auth/computeclient.js');
 
   it('should create a computeclient', function () {
     var compute = new Compute();
     assert.equal(compute.createScopedRequired(), false);
   });
-
   it('should create a computeclient', function () {
     var compute = new googleapis.auth.Compute();
     assert.equal(compute.createScopedRequired(), false);
   });
 });
 
-describe('OAuth2 client', function() {
+function testNoTokens (urlshortener, oauth2client, cb) {
+  urlshortener.url.get({
+    shortUrl: '123',
+    auth: oauth2client
+  }, function (err, result) {
+    assert.equal(err.message, 'No access or refresh token is set.');
+    assert.equal(result, null);
+    cb();
+  });
+}
 
-  function noop() {}
+function testNoBearer (urlshortener, oauth2client, cb) {
+  urlshortener.url.list({
+    auth: oauth2client
+  }, function (err) {
+    assert.equal(oauth2client.credentials.token_type, 'Bearer');
+    cb(err);
+  });
+}
+
+function testExpired (drive, oauth2client, now, cb) {
+  drive.files.get({
+    fileId: 'wat',
+    auth: oauth2client
+  }, function () {
+    var expiry_date = oauth2client.credentials.expiry_date;
+    assert.notEqual(expiry_date, undefined);
+    assert(expiry_date > now);
+    assert(expiry_date < now + 5000);
+    assert.equal(oauth2client.credentials.refresh_token, 'abc');
+    assert.equal(oauth2client.credentials.access_token, 'abc123');
+    cb();
+  });
+}
+
+function testNoAccessToken (drive, oauth2client, now, cb) {
+  drive.files.get({
+    fileId: 'wat',
+    auth: oauth2client
+  }, function () {
+    var expiry_date = oauth2client.credentials.expiry_date;
+    assert.notEqual(expiry_date, undefined);
+    assert(expiry_date > now);
+    assert(expiry_date < now + 4000);
+    assert.equal(oauth2client.credentials.refresh_token, 'abc');
+    assert.equal(oauth2client.credentials.access_token, 'abc123');
+    cb();
+  });
+}
+
+describe('OAuth2 client', function () {
+  var localDrive, remoteDrive;
+  var localUrlshortener, remoteUrlshortener;
+
+  before(function (done) {
+    nock.cleanAll();
+    var google = new googleapis.GoogleApis();
+    nock.enableNetConnect();
+    async.parallel([
+      function (cb) {
+        utils.loadApi(google, 'drive', 'v2', cb);
+      },
+      function (cb) {
+        utils.loadApi(google, 'urlshortener', 'v1', cb);
+      }
+    ], function (err, apis) {
+      if (err) {
+        return done(err);
+      }
+      remoteDrive = apis[0];
+      remoteUrlshortener = apis[1];
+      nock.disableNetConnect();
+      done();
+    });
+  });
+
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    var google = new googleapis.GoogleApis();
+    localDrive = google.drive('v2');
+    localUrlshortener = google.urlshortener('v1');
+  });
 
   var CLIENT_ID = 'CLIENT_ID';
   var CLIENT_SECRET = 'CLIENT_SECRET';
   var REDIRECT_URI = 'REDIRECT';
 
-  it('should return err no access or refresh token is set before making a request', function(done) {
-    var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    new googleapis.GoogleApis()
-      .urlshortener('v1').url.get({ shortUrl: '123', auth: oauth2client }, function(err, result) {
-        assert.equal(err.message, 'No access or refresh token is set.');
-        assert.equal(result, null);
+  it('should return err if no access or refresh token is set', function (done) {
+    var oauth2client = new googleapis.auth.OAuth2(
+      CLIENT_ID,
+      CLIENT_SECRET,
+      REDIRECT_URI
+    );
+    testNoTokens(localUrlshortener, oauth2client, function () {
+      testNoTokens(remoteUrlshortener, oauth2client, done);
+    });
+  });
+
+  it('should not error if only refresh token is set', function () {
+    var oauth2client = new googleapis.auth.OAuth2(
+      CLIENT_ID,
+      CLIENT_SECRET,
+      REDIRECT_URI
+    );
+    oauth2client.credentials = { refresh_token: 'refresh_token' };
+    assert.doesNotThrow(function () {
+      var options = { auth: oauth2client, shortUrl: '...' };
+      localUrlshortener.url.get(options, utils.noop);
+      remoteUrlshortener.url.get(options, utils.noop);
+    });
+  });
+
+  it('should set access token type to Bearer if none is set', function (done) {
+    var oauth2client = new googleapis.auth.OAuth2(
+      CLIENT_ID,
+      CLIENT_SECRET,
+      REDIRECT_URI
+    );
+    oauth2client.credentials = { access_token: 'foo', refresh_token: '' };
+    var scope = nock('https://www.googleapis.com')
+      .get('/urlshortener/v1/url/history')
+      .times(2)
+      .reply(200);
+
+    testNoBearer(localUrlshortener, oauth2client, function (err) {
+      if (err) {
+        return done(err);
+      }
+      testNoBearer(remoteUrlshortener, oauth2client, function (err) {
+        if (err) {
+          return done(err);
+        }
+        scope.done();
         done();
       });
-  });
-
-  it('should not throw any exceptions if only refresh token is set', function() {
-    var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    oauth2client.credentials = { refresh_token: 'refresh_token' };
-    assert.doesNotThrow(function() {
-      var google = new googleapis.GoogleApis();
-      var options = { auth: oauth2client, shortUrl: '...' };
-      google.urlshortener('v1').url.get(options, noop);
     });
   });
 
-  it('should set access token type to Bearer if none is set', function(done) {
-    var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    oauth2client.credentials = { access_token: 'foo', refresh_token: '' };
-
-    var scope = nock('https://www.googleapis.com').get('/urlshortener/v1/url/history').reply(200);
-
-    var google = new googleapis.GoogleApis();
-    var urlshortener = google.urlshortener('v1');
-    urlshortener.url.list({ auth: oauth2client }, function(err) {
-      assert.equal(oauth2client.credentials.token_type, 'Bearer');
-      scope.done();
-      done(err);
-    });
-  });
-
-  it('should refresh if access token is expired', function(done) {
+  it('should refresh if access token is expired', function (done) {
     var scope = nock('https://accounts.google.com')
         .post('/o/oauth2/token')
+        .times(2)
         .reply(200, { access_token: 'abc123', expires_in: 1 });
-    var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    var google = new googleapis.GoogleApis();
-    var drive = google.drive({ version: 'v2', auth: oauth2client });
-    var now = (new Date()).getTime();
+    var oauth2client = new googleapis.auth.OAuth2(
+      CLIENT_ID,
+      CLIENT_SECRET,
+      REDIRECT_URI
+    );
+    var now = new Date().getTime();
     var twoSecondsAgo = now - 2000;
     oauth2client.credentials = { refresh_token: 'abc', expiry_date: twoSecondsAgo };
-    drive.files.get({ fileId: 'wat' }, function() {
-      var expiry_date = oauth2client.credentials.expiry_date;
-      assert.notEqual(expiry_date, undefined);
-      assert(expiry_date > now);
-      assert(expiry_date < now + 5000);
-      assert.equal(oauth2client.credentials.refresh_token, 'abc');
-      assert.equal(oauth2client.credentials.access_token, 'abc123');
-      scope.done();
-      done();
+    testExpired(localDrive, oauth2client, now, function () {
+      oauth2client = new googleapis.auth.OAuth2(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        REDIRECT_URI
+      );
+      now = new Date().getTime();
+      twoSecondsAgo = now - 2000;
+      oauth2client.credentials = {
+        refresh_token: 'abc',
+        expiry_date: twoSecondsAgo
+      };
+      testExpired(remoteDrive, oauth2client, now, function () {
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should make request if access token not expired', function(done) {
+  it('should make request if access token not expired', function (done) {
     var scope = nock('https://accounts.google.com')
         .post('/o/oauth2/token')
+        .times(2)
         .reply(200, { access_token: 'abc123', expires_in: 10000 });
-    var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    var google = new googleapis.GoogleApis();
-    var drive = google.drive({ version: 'v2', auth: oauth2client });
+    var oauth2client = new googleapis.auth.OAuth2(
+      CLIENT_ID,
+      CLIENT_SECRET,
+      REDIRECT_URI
+    );
     var now = (new Date()).getTime();
     var tenSecondsFromNow = now + 10000;
     oauth2client.credentials = {
@@ -164,7 +263,7 @@ describe('OAuth2 client', function() {
       refresh_token: 'abc',
       expiry_date: tenSecondsFromNow
     };
-    drive.files.get({ fileId: 'wat' }, function() {
+    localDrive.files.get({ fileId: 'wat', auth: oauth2client }, function () {
       assert.equal(JSON.stringify(oauth2client.credentials), JSON.stringify({
         access_token: 'abc123',
         refresh_token: 'abc',
@@ -172,43 +271,69 @@ describe('OAuth2 client', function() {
         token_type: 'Bearer'
       }));
 
-      assert.throws(function() {
+      assert.throws(function () {
         scope.done();
       }, 'AssertionError');
-      nock.cleanAll();
-      done();
+      oauth2client = new googleapis.auth.OAuth2(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        REDIRECT_URI
+      );
+      now = (new Date()).getTime();
+      tenSecondsFromNow = now + 10000;
+      oauth2client.credentials = {
+        access_token: 'abc123',
+        refresh_token: 'abc',
+        expiry_date: tenSecondsFromNow
+      };
+
+      remoteDrive.files.get({ fileId: 'wat', auth: oauth2client }, function () {
+        assert.equal(JSON.stringify(oauth2client.credentials), JSON.stringify({
+          access_token: 'abc123',
+          refresh_token: 'abc',
+          expiry_date: tenSecondsFromNow,
+          token_type: 'Bearer'
+        }));
+
+        assert.throws(function () {
+          scope.done();
+        }, 'AssertionError');
+        nock.cleanAll();
+        done();
+      });
     });
   });
 
-  it('should refresh if have refresh token but no access token', function(done) {
+  it('should refresh if have refresh token but no access token', function (done) {
     var scope = nock('https://accounts.google.com')
         .post('/o/oauth2/token')
+        .times(2)
         .reply(200, { access_token: 'abc123', expires_in: 1 });
-    var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-    var google = new googleapis.GoogleApis();
-    var drive = google.drive({ version: 'v2', auth: oauth2client });
+    var oauth2client = new googleapis.auth.OAuth2(
+      CLIENT_ID,
+      CLIENT_SECRET,
+      REDIRECT_URI
+    );
     var now = (new Date()).getTime();
     oauth2client.credentials = { refresh_token: 'abc' };
-    drive.files.get({ fileId: 'wat' }, function() {
-      var expiry_date = oauth2client.credentials.expiry_date;
-      assert.notEqual(expiry_date, undefined);
-      assert(expiry_date > now);
-      assert(expiry_date < now + 4000);
-      assert.equal(oauth2client.credentials.refresh_token, 'abc');
-      assert.equal(oauth2client.credentials.access_token, 'abc123');
-      scope.done();
-      done();
+    testNoAccessToken(localDrive, oauth2client, now, function () {
+      now = (new Date()).getTime();
+      oauth2client.credentials = { refresh_token: 'abc' };
+      testNoAccessToken(remoteDrive, oauth2client, now, function () {
+        scope.done();
+        done();
+      });
     });
   });
 
-  describe('revokeCredentials()', function() {
-    it('should revoke credentials if access token present', function(done) {
+  describe('revokeCredentials()', function () {
+    it('should revoke credentials if access token present', function (done) {
       var scope = nock('https://accounts.google.com')
           .get('/o/oauth2/revoke?token=abc')
           .reply(200, { success: true });
       var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.credentials = { access_token: 'abc', refresh_token: 'abc' };
-      oauth2client.revokeCredentials(function(err, result) {
+      oauth2client.revokeCredentials(function (err, result) {
         assert.equal(err, null);
         assert.equal(result.success, true);
         assert.equal(JSON.stringify(oauth2client.credentials), '{}');
@@ -217,10 +342,10 @@ describe('OAuth2 client', function() {
       });
     });
 
-    it('should clear credentials and return error if no access token to revoke', function(done) {
+    it('should clear credentials and return error if no access token to revoke', function (done) {
       var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
       oauth2client.credentials = { refresh_token: 'abc' };
-      oauth2client.revokeCredentials(function(err, result) {
+      oauth2client.revokeCredentials(function (err, result) {
         assert.equal(err.message, 'No access token to revoke.');
         assert.equal(result, null);
         assert.equal(JSON.stringify(oauth2client.credentials), '{}');
@@ -229,19 +354,24 @@ describe('OAuth2 client', function() {
     });
   });
 
-  describe('getToken()', function() {
-    it('should return expiry_date', function(done) {
+  describe('getToken()', function () {
+    it('should return expiry_date', function (done) {
       var now = (new Date()).getTime();
       var scope = nock('https://accounts.google.com')
           .post('/o/oauth2/token')
           .reply(200, { access_token: 'abc', refresh_token: '123', expires_in: 10 });
       var oauth2client = new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
-      oauth2client.getToken('code here', function(err, tokens) {
+      oauth2client.getToken('code here', function (err, tokens) {
         assert(tokens.expiry_date >= now + (10 * 1000));
         assert(tokens.expiry_date <= now + (15 * 1000));
         scope.done();
         done();
       });
     });
+  });
+
+  after(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 });

--- a/test/test.clients.js
+++ b/test/test.clients.js
@@ -17,40 +17,93 @@
 'use strict';
 
 var assert = require('assert');
+var async = require('async');
 var fs = require('fs');
 var googleapis = require('../');
+var nock = require('nock');
+var utils = require('./utils');
 
-function noop() {}
+describe('Clients', function () {
+  var localPlus, remotePlus;
+  var localOauth2, remoteOauth2;
+  var localFreebase, remoteFreebase;
 
-describe('Clients', function() {
+  before(function (done) {
+    nock.cleanAll();
+    var google = new googleapis.GoogleApis();
+    nock.enableNetConnect();
+    async.parallel([
+      function (cb) {
+        utils.loadApi(google, 'plus', 'v1', cb);
+      },
+      function (cb) {
+        utils.loadApi(google, 'oauth2', 'v2', cb);
+      },
+      function (cb) {
+        utils.loadApi(google, 'freebase', 'v1', cb);
+      }
+    ], function (err, apis) {
+      if (err) {
+        return done(err);
+      }
+      remotePlus = apis[0];
+      remoteOauth2 = apis[1];
+      remoteFreebase = apis[2];
+      nock.disableNetConnect();
+      done();
+    });
+  });
 
-  it('should create request helpers according to resource on discovery API response', function() {
-      var plus = googleapis.plus('v1');
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    var google = new googleapis.GoogleApis();
+    localPlus = google.plus('v1');
+    localOauth2 = google.oauth2('v2');
+    localFreebase = google.freebase('v1');
+  });
+
+  it('should create request helpers according to resource on discovery API response', function () {
+      var plus = localPlus;
+      assert.equal(typeof plus.people.get, 'function');
+      assert.equal(typeof plus.activities.search, 'function');
+      assert.equal(typeof plus.comments.list, 'function');
+      plus = remotePlus;
       assert.equal(typeof plus.people.get, 'function');
       assert.equal(typeof plus.activities.search, 'function');
       assert.equal(typeof plus.comments.list, 'function');
   });
 
-  it('should be able to gen top level methods', function() {
-    assert.equal(typeof googleapis.oauth2('v2').tokeninfo, 'function');
-    assert.equal(typeof googleapis.freebase('v1').reconcile, 'function');
+  it('should be able to gen top level methods', function () {
+    assert.equal(typeof localOauth2.tokeninfo, 'function');
+    assert.equal(typeof remoteOauth2.tokeninfo, 'function');
+    assert.equal(typeof localFreebase.reconcile, 'function');
+    assert.equal(typeof remoteFreebase.reconcile, 'function');
   });
 
-  it('should be able to gen top level methods and resources', function() {
-    var oauth2 = googleapis.oauth2('v2');
+  it('should be able to gen top level methods and resources', function () {
+    var oauth2 = localOauth2;
+    assert.equal(typeof oauth2.tokeninfo, 'function');
+    assert.equal(typeof oauth2.userinfo, 'object');
+    oauth2 = remoteOauth2;
     assert.equal(typeof oauth2.tokeninfo, 'function');
     assert.equal(typeof oauth2.userinfo, 'object');
   });
 
-  it('should be able to gen nested resources and methods', function() {
-    var oauth2 = googleapis.oauth2('v2');
+  it('should be able to gen nested resources and methods', function () {
+    var oauth2 = localOauth2;
+    assert.equal(typeof oauth2.userinfo, 'object');
+    assert.equal(typeof oauth2.userinfo.v2, 'object');
+    assert.equal(typeof oauth2.userinfo.v2.me, 'object');
+    assert.equal(typeof oauth2.userinfo.v2.me.get, 'function');
+    oauth2 = remoteOauth2;
     assert.equal(typeof oauth2.userinfo, 'object');
     assert.equal(typeof oauth2.userinfo.v2, 'object');
     assert.equal(typeof oauth2.userinfo.v2.me, 'object');
     assert.equal(typeof oauth2.userinfo.v2.me.get, 'function');
   });
 
-  it('should be able to require all api files without error', function() {
+  it('should be able to require all api files without error', function () {
     function getFiles(dir, files_) {
       files_ = files_ || [];
       if (typeof files_ === 'undefined') {
@@ -73,49 +126,139 @@ describe('Clients', function() {
 
     var api_files = getFiles(__dirname + '/../apis');
 
-    assert.doesNotThrow(function() {
+    assert.doesNotThrow(function () {
       for (var i in api_files) {
         require(api_files[i]);
       }
     });
   });
 
-  it('should support default params', function() {
-    var store = googleapis.datastore({ version: 'v1beta2', params: { myParam: '123' } });
-    var req = store.datasets.lookup({ datasetId: '123' }, noop);
-    // If the default param handling is broken, query might be undefined, thus concealing the
-    // assertion message with some generic "cannot call .indexOf of undefined"
+  it('should support default params', function (done) {
+    var google = new googleapis.GoogleApis();
+    var datastore = google.datastore({
+      version: 'v1beta2',
+      params: { myParam: '123' }
+    });
+    var req = datastore.datasets.lookup({ datasetId: '123' }, utils.noop);
+    // If the default param handling is broken, query might be undefined, thus
+    // concealing the assertion message with some generic "cannot call .indexOf
+    // of undefined"
     var query = req.uri.query || '';
 
-    assert.notEqual(query.indexOf('myParam=123'), -1, 'Default param not found in query');
+    assert.notEqual(
+      query.indexOf('myParam=123'),
+      -1,
+      'Default param in query'
+    );
+    nock.enableNetConnect();
+    utils.loadApi(google, 'datastore', 'v1beta2', {
+      params: { myParam: '123' }
+    }, function (err, datastore) {
+      nock.disableNetConnect();
+      if (err) {
+        return done(err);
+      }
+      var req = datastore.datasets.lookup({ datasetId: '123' }, utils.noop);
+      var query = req.uri.query || '';
+
+      assert.notEqual(
+        query.indexOf('myParam=123'),
+        -1,
+        'Default param in query'
+      );
+      done();
+    });
   });
 
-  it('should allow default params to be overriden per-request', function() {
-    var store = googleapis.datastore({ version: 'v1beta2', params: { myParam: '123' } });
+  it('should allow default params to be overriden per-request', function (done) {
+    var google = new googleapis.GoogleApis();
+    var datastore = google.datastore({
+      version: 'v1beta2',
+      params: { myParam: '123' }
+    });
     // Override the default datasetId param for this particular API call
-    var req = store.datasets.lookup({ datasetId: '123', myParam: '456' }, noop);
-    // If the default param handling is broken, query might be undefined, thus concealing the
-    // assertion message with some generic "cannot call .indexOf of undefined"
+    var req = datastore.datasets.lookup({
+      datasetId: '123', myParam: '456'
+    }, utils.noop);
+    // If the default param handling is broken, query might be undefined, thus
+    // concealing the assertion message with some generic "cannot call .indexOf
+    // of undefined"
     var query = req.uri.query || '';
 
-    assert.notEqual(query.indexOf('myParam=456'), -1, 'Default param not found in query');
+    assert.notEqual(
+      query.indexOf('myParam=456'),
+      -1,
+      'Default param not found in query'
+    );
+
+    nock.enableNetConnect();
+    utils.loadApi(google, 'datastore', 'v1beta2', {
+      params: { myParam: '123' }
+    }, function (err, datastore) {
+      nock.disableNetConnect();
+      if (err) {
+        return done(err);
+      }
+      // Override the default datasetId param for this particular API call
+      var req = datastore.datasets.lookup({
+        datasetId: '123', myParam: '456'
+      }, utils.noop);
+      // If the default param handling is broken, query might be undefined, thus
+      // concealing the assertion message with some generic "cannot call .indexOf
+      // of undefined"
+      var query = req.uri.query || '';
+
+      assert.notEqual(
+        query.indexOf('myParam=456'),
+        -1,
+        'Default param not found in query'
+      );
+      done();
+    });
   });
 
-  it('should include default params when only callback is provided to API call', function() {
-    var store = googleapis.datastore({
+  it('should include default params when only callback is provided to API call', function (done) {
+    var google = new googleapis.GoogleApis();
+    var datastore = google.datastore({
       version: 'v1beta2',
       params: {
         datasetId: '123', // We must set this here - it is a required param
         myParam: '123'
       }
     });
-
     // No params given - only callback
-    var req = store.datasets.lookup(noop);
+    var req = datastore.datasets.lookup(utils.noop);
     // If the default param handling is broken, req or query might be undefined, thus concealing the
     // assertion message with some generic "cannot call .indexOf of undefined"
     var query = (req && req.uri.query) || '';
 
     assert.notEqual(query.indexOf('myParam=123'), -1, 'Default param not found in query');
+
+    nock.enableNetConnect();
+    utils.loadApi(google, 'datastore', 'v1beta2', {
+      params: {
+        datasetId: '123', // We must set this here - it is a required param
+        myParam: '123'
+      }
+    }, function (err, datastore) {
+      nock.disableNetConnect();
+      if (err) {
+        return done(err);
+      }
+      // No params given - only callback
+      var req = datastore.datasets.lookup(utils.noop);
+      // If the default param handling is broken, req or query might be
+      // undefined, thus concealing the assertion message with some generic
+      // "cannot call .indexOf of undefined"
+      var query = (req && req.uri.query) || '';
+
+      assert.notEqual(query.indexOf('myParam=123'), -1, 'Default param not found in query');
+      done();
+    });
+  });
+
+  after(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 });

--- a/test/test.discover.js
+++ b/test/test.discover.js
@@ -1,0 +1,58 @@
+// Copyright 2016, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var assert = require('assert');
+var fs = require('fs');
+var googleapis = require('../');
+var path = require('path');
+
+describe('GoogleApis#discover', function () {
+  it('should generate all apis', function (done) {
+    this.timeout(60000);
+
+    var localApis = fs.readdirSync(path.join(__dirname, '../apis'));
+    var google = new googleapis.GoogleApis();
+    var localDrive = google.drive('v2');
+
+    assert.equal(typeof google.drive, 'function');
+    assert.equal(typeof localDrive, 'object');
+
+    localApis.forEach(function (name) {
+      assert(google[name]);
+      google[name] = undefined;
+    });
+
+    assert.equal(google.drive, undefined);
+
+    google.discover('https://www.googleapis.com/discovery/v1/apis', function (err) {
+      if (err) {
+        return done(err);
+      }
+      // APIs have all been re-added
+      localApis.forEach(function (name) {
+        assert(google[name]);
+      });
+
+      var remoteDrive = google.drive('v2');
+      assert.equal(typeof google.drive, 'function');
+      assert.equal(typeof remoteDrive, 'object');
+
+      for (var key in localDrive) {
+        assert(remoteDrive[key], 'generated drive has same keys');
+      }
+      done();
+    });
+  });
+});

--- a/test/test.media.js
+++ b/test/test.media.js
@@ -17,191 +17,329 @@
 'use strict';
 
 var assert = require('assert');
+var async = require('async');
 var fs = require('fs');
 var googleapis = require('../');
 var nock = require('nock');
-var google, drive;
-
-nock.disableNetConnect();
+var utils = require('./utils');
 
 var boundaryPrefix = 'multipart/related; boundary=';
 
-describe('Media', function() {
+function testMultpart (drive, cb) {
+  var resource = { title: 'title', mimeType: 'text/plain' };
+  var media = { body: 'hey' };
+  var expectedResp = fs.readFileSync(
+    __dirname + '/fixtures/media-response.txt',
+    { encoding: 'utf8' }
+  );
+  var req = drive.files.insert({ resource: resource, media: media }, function (err, body) {
+    if (err) {
+      return cb(err);
+    }
+    assert.equal(req.method, 'POST');
+    assert.equal(
+      req.uri.href,
+      'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'
+    );
+    assert.equal(req.headers['content-type'].indexOf('multipart/related;'), 0);
+    var boundary = req.headers['content-type'].replace(boundaryPrefix, '');
+    expectedResp = expectedResp
+        .replace(/\n/g, '\r\n')
+        .replace(/\$boundary/g, boundary)
+        .replace('$media', media.body)
+        .replace('$resource', JSON.stringify(resource))
+        .replace('$mimeType', 'text/plain')
+        .trim();
+    assert.strictEqual(expectedResp, body);
+    cb();
+  });
+}
 
-  function noop() {}
+function testMediaBody (drive, cb) {
+  var resource = { title: 'title' };
+  var media = { body: 'hey' };
+  var expectedResp = fs.readFileSync(
+    __dirname + '/fixtures/media-response.txt',
+    { encoding: 'utf8' }
+  );
+  var req = drive.files.insert({ resource: resource, media: media }, function (err, body) {
+    if (err) {
+      return cb(err);
+    }
+    assert.equal(req.method, 'POST');
+    assert.equal(
+      req.uri.href,
+      'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'
+    );
+    assert.equal(req.headers['content-type'].indexOf('multipart/related;'), 0);
+    var boundary = req.headers['content-type'].replace(boundaryPrefix, '');
+    expectedResp = expectedResp
+        .replace(/\n/g, '\r\n')
+        .replace(/\$boundary/g, boundary)
+        .replace('$media', media.body)
+        .replace('$resource', JSON.stringify(resource))
+        .replace('$mimeType', 'text/plain')
+        .trim();
+    assert.strictEqual(expectedResp, body);
+    cb();
+  });
+}
 
-  beforeEach(function() {
-    google = new googleapis.GoogleApis();
-    drive = google.drive('v2');
+describe('Media', function () {
+  var localDrive, remoteDrive;
+  var localGmail, remoteGmail;
+
+  before(function (done) {
+    nock.cleanAll();
+    var google = new googleapis.GoogleApis();
+    nock.enableNetConnect();
+    async.parallel([
+      function (cb) {
+        utils.loadApi(google, 'drive', 'v2', cb);
+      },
+      function (cb) {
+        utils.loadApi(google, 'gmail', 'v1', cb);
+      }
+    ], function (err, apis) {
+      if (err) {
+        return done(err);
+      }
+      remoteDrive = apis[0];
+      remoteGmail = apis[1];
+      nock.disableNetConnect();
+      done();
+    });
   });
 
-  it('should post with uploadType=multipart if resource and media set', function(done) {
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    var google = new googleapis.GoogleApis();
+    localDrive = google.drive('v2');
+    localGmail = google.gmail('v1');
+  });
+
+  it('should post with uploadType=multipart if resource and media set', function (done) {
     var scope = nock('https://www.googleapis.com')
         .post('/upload/drive/v2/files?uploadType=multipart')
+        .times(2)
         .reply(200, { fileId: 'abc123' });
-    drive.files.insert({ resource: {}, media: { body: 'hello' }}, function(err, body) {
+
+    localDrive.files.insert({ resource: {}, media: { body: 'hello' }}, function (err, body) {
+      if (err) {
+        return done(err);
+      }
       assert.equal(JSON.stringify(body), JSON.stringify({ fileId: 'abc123' }));
-      scope.done();
-      done();
+      remoteDrive.files.insert({ resource: {}, media: { body: 'hello' }}, function (err, body) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(JSON.stringify(body), JSON.stringify({ fileId: 'abc123' }));
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should post with uploadType=media media set but not resource', function(done) {
+  it('should post with uploadType=media media set but not resource', function (done) {
     var scope = nock('https://www.googleapis.com')
         .post('/upload/drive/v2/files?uploadType=media')
+        .times(2)
         .reply(200, { fileId: 'abc123' });
-    drive.files.insert({ media: { body: 'hello' }}, function(err, body) {
+    localDrive.files.insert({ media: { body: 'hello' }}, function (err, body) {
+      if (err) {
+        return done(err);
+      }
       assert.equal(JSON.stringify(body), JSON.stringify({ fileId: 'abc123' }));
-      scope.done();
-      done();
+      remoteDrive.files.insert({ media: { body: 'hello' }}, function (err, body) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(JSON.stringify(body), JSON.stringify({ fileId: 'abc123' }));
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should generate a valid media upload if media is set, metadata is not set', function(done) {
+  it('should generate a valid media upload if media is set, metadata is not set', function (done) {
     var scope = nock('https://www.googleapis.com')
         .post('/upload/drive/v2/files?uploadType=media')
-        .reply(201, function(uri, reqBody) {
+        .times(2)
+        .reply(201, function (uri, reqBody) {
       return reqBody; // return request body as response for testing purposes
     });
     var media = { body: 'hey' };
-    var req = drive.files.insert({ media: media }, function(err, body) {
+    var req = localDrive.files.insert({ media: media }, function (err, body) {
+      if (err) {
+        return done(err);
+      }
       assert.equal(req.method, 'POST');
       assert.equal(
         req.uri.href,
         'https://www.googleapis.com/upload/drive/v2/files?uploadType=media'
       );
       assert.strictEqual(media.body, body);
-      scope.done();
-      done();
-    });
-  });
-
-  it('should generate valid multipart upload if media and metadata are both set', function(done) {
-      var scope = nock('https://www.googleapis.com')
-          .post('/upload/drive/v2/files?uploadType=multipart')
-          .reply(201, function(uri, reqBody) {
-        return reqBody; // return request body as response for testing purposes
-      });
-      var resource = { title: 'title', mimeType: 'text/plain' };
-      var media = { body: 'hey' };
-      var expectedResp = fs.readFileSync(
-        __dirname + '/fixtures/media-response.txt',
-        { encoding: 'utf8' }
-      );
-      var req = drive.files.insert({ resource: resource, media: media }, function(err, body) {
+      req = remoteDrive.files.insert({ media: media }, function (err, body) {
+        if (err) {
+          return done(err);
+        }
         assert.equal(req.method, 'POST');
         assert.equal(
           req.uri.href,
-          'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'
+          'https://www.googleapis.com/upload/drive/v2/files?uploadType=media'
         );
-        assert.equal(req.headers['content-type'].indexOf('multipart/related;'), 0);
-        var boundary = req.headers['content-type'].replace(boundaryPrefix, '');
-        expectedResp = expectedResp
-            .replace(/\n/g, '\r\n')
-            .replace(/\$boundary/g, boundary)
-            .replace('$media', media.body)
-            .replace('$resource', JSON.stringify(resource))
-            .replace('$mimeType', 'text/plain')
-            .trim();
-        assert.strictEqual(expectedResp, body);
+        assert.strictEqual(media.body, body);
         scope.done();
         done();
-      }
-    );
+      });
+    });
   });
 
-  it('should not require parameters for insertion requests', function() {
-    var req = drive.files.insert({ someAttr: 'someValue', media: { body: 'wat' } }, noop);
+  it('should generate valid multipart upload if media and metadata are both set', function (done) {
+    var scope = nock('https://www.googleapis.com')
+        .post('/upload/drive/v2/files?uploadType=multipart')
+        .times(2)
+        .reply(201, function (uri, reqBody) {
+      return reqBody; // return request body as response for testing purposes
+    });
+
+    testMultpart(localDrive, function (err) {
+      if (err) {
+        return done(err);
+      }
+      testMultpart(remoteDrive, function (err) {
+        if (err) {
+          return done(err);
+        }
+        scope.done();
+        done();
+      });
+    });
+  });
+
+  it('should not require parameters for insertion requests', function () {
+    var req = localDrive.files.insert({
+      someAttr: 'someValue',
+      media: { body: 'wat' }
+    }, utils.noop);
+    assert.equal(req.uri.query, 'someAttr=someValue&uploadType=media');
+    req = remoteDrive.files.insert({
+      someAttr: 'someValue',
+      media: { body: 'wat' }
+    }, utils.noop);
     assert.equal(req.uri.query, 'someAttr=someValue&uploadType=media');
   });
 
-  it('should not multipart upload if no media body given', function() {
-    var req = drive.files.insert({ someAttr: 'someValue' }, noop);
+  it('should not multipart upload if no media body given', function () {
+    var req = localDrive.files.insert({ someAttr: 'someValue' }, utils.noop);
+    assert.equal(req.uri.query, 'someAttr=someValue');
+    req = remoteDrive.files.insert({ someAttr: 'someValue' }, utils.noop);
     assert.equal(req.uri.query, 'someAttr=someValue');
   });
 
-  it('should set text/plain when passed a string as media body', function(done) {
+  it('should set text/plain when passed a string as media body', function (done) {
     var scope = nock('https://www.googleapis.com')
         .post('/upload/drive/v2/files?uploadType=multipart')
-        .reply(201, function(uri, reqBody) {
+        .times(2)
+        .reply(201, function (uri, reqBody) {
       return reqBody; // return request body as response for testing purposes
     });
-    var resource = { title: 'title' };
-    var media = { body: 'hey' };
-    var expectedResp = fs.readFileSync(
-      __dirname + '/fixtures/media-response.txt',
-      { encoding: 'utf8' }
-    );
-    var req = drive.files.insert({ resource: resource, media: media }, function(err, body) {
-      assert.equal(req.method, 'POST');
-      assert.equal(
-        req.uri.href,
-        'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'
-      );
-      assert.equal(req.headers['content-type'].indexOf('multipart/related;'), 0);
-      var boundary = req.headers['content-type'].replace(boundaryPrefix, '');
-      expectedResp = expectedResp
-          .replace(/\n/g, '\r\n')
-          .replace(/\$boundary/g, boundary)
-          .replace('$media', media.body)
-          .replace('$resource', JSON.stringify(resource))
-          .replace('$mimeType', 'text/plain')
-          .trim();
-      assert.strictEqual(expectedResp, body);
-      scope.done();
-      done();
+
+    testMediaBody(localDrive, function (err) {
+      if (err) {
+        return done(err);
+      }
+      testMediaBody(remoteDrive, function (err) {
+        if (err) {
+          return done(err);
+        }
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should handle metadata-only media requests properly', function(done) {
-    nock('https://www.googleapis.com')
+  it('should handle metadata-only media requests properly', function (done) {
+    var scope = nock('https://www.googleapis.com')
         .post('/gmail/v1/users/me/drafts')
-        .reply(201, function(uri, reqBody) {
+        .times(2)
+        .reply(201, function (uri, reqBody) {
       return reqBody; // return request body as response for testing purposes
     });
-    var gmail = google.gmail('v1');
     var resource = { message: { raw: (new Buffer('hello', 'binary')).toString('base64') } };
-    var req = gmail.users.drafts.create(
+    var req = localGmail.users.drafts.create(
       { userId: 'me', resource: resource, media: { mimeType: 'message/rfc822' } },
-      function(err, resp) {
+      function (err, resp) {
+        if (err) {
+          return done(err);
+        }
         assert.equal(req.headers['content-type'], 'application/json');
         assert.equal(JSON.stringify(resp), JSON.stringify(resource));
-        done();
+        req = remoteGmail.users.drafts.create(
+        { userId: 'me', resource: resource, media: { mimeType: 'message/rfc822' } },
+        function (err, resp) {
+          if (err) {
+            return done(err);
+          }
+          assert.equal(req.headers['content-type'], 'application/json');
+          assert.equal(JSON.stringify(resp), JSON.stringify(resource));
+          scope.done();
+          done();
+        }
+      );
       }
     );
   });
 
-  it('should accept readable stream as media body without metadata', function(done) {
+  it('should accept readable stream as media body without metadata', function (done) {
     var scope = nock('https://www.googleapis.com')
         .post('/upload/gmail/v1/users/me/drafts?uploadType=media')
-        .reply(201, function(uri, reqBody) {
+        .times(2)
+        .reply(201, function (uri, reqBody) {
       return reqBody; // return request body as response for testing purposes
     });
 
-    var gmail = google.gmail('v1');
     var body = fs.createReadStream(__dirname + '/fixtures/mediabody.txt');
     var expectedBody = fs.readFileSync(__dirname + '/fixtures/mediabody.txt');
-    gmail.users.drafts.create({
+    localGmail.users.drafts.create({
       userId: 'me',
       media: {
         mimeType: 'message/rfc822',
         body: body
       }
-    }, function(err, resp) {
+    }, function (err, resp) {
+      if (err) {
+        return done(err);
+      }
       assert.equal(resp, expectedBody);
-      scope.done();
-      done();
+      body = fs.createReadStream(__dirname + '/fixtures/mediabody.txt');
+      expectedBody = fs.readFileSync(__dirname + '/fixtures/mediabody.txt');
+      remoteGmail.users.drafts.create({
+        userId: 'me',
+        media: {
+          mimeType: 'message/rfc822',
+          body: body
+        }
+      }, function (err, resp) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(resp, expectedBody);
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should accept readable stream as media body with metadata', function(done) {
+  it('should accept readable stream as media body with metadata', function (done) {
     var scope = nock('https://www.googleapis.com')
         .post('/upload/gmail/v1/users/me/drafts?uploadType=multipart')
-        .reply(201, function(uri, reqBody) {
+        .times(2)
+        .reply(201, function (uri, reqBody) {
       return reqBody; // return request body as response for testing purposes
     });
 
-    var gmail = google.gmail('v1');
     var resource = { message: { raw: (new Buffer('hello', 'binary')).toString('base64') } };
     var body = fs.createReadStream(__dirname + '/fixtures/mediabody.txt');
     var bodyString = fs.readFileSync(__dirname + '/fixtures/mediabody.txt', { encoding: 'utf8' });
@@ -210,11 +348,14 @@ describe('Media', function() {
       __dirname + '/fixtures/media-response.txt',
       { encoding: 'utf8' }
     );
-    var req = gmail.users.drafts.create({
+    var req = localGmail.users.drafts.create({
       userId: 'me',
       resource: resource,
       media: media
-    }, function(err, resp) {
+    }, function (err, resp) {
+      if (err) {
+        return done(err);
+      }
       var boundary = req.headers['content-type'].replace(boundaryPrefix, '');
       expectedBody = expectedBody
           .replace(/\n/g, '\r\n')
@@ -224,33 +365,83 @@ describe('Media', function() {
           .replace('$mimeType', 'message/rfc822')
           .trim();
       assert.strictEqual(expectedBody, resp);
-      scope.done();
-      done();
+      resource = { message: { raw: (new Buffer('hello', 'binary')).toString('base64') } };
+      body = fs.createReadStream(__dirname + '/fixtures/mediabody.txt');
+      bodyString = fs.readFileSync(__dirname + '/fixtures/mediabody.txt', { encoding: 'utf8' });
+      media = { mimeType: 'message/rfc822', body: body };
+      expectedBody = fs.readFileSync(
+        __dirname + '/fixtures/media-response.txt',
+        { encoding: 'utf8' }
+      );
+      req = remoteGmail.users.drafts.create({
+        userId: 'me',
+        resource: resource,
+        media: media
+      }, function (err, resp) {
+        if (err) {
+          return done(err);
+        }
+        var boundary = req.headers['content-type'].replace(boundaryPrefix, '');
+        expectedBody = expectedBody
+            .replace(/\n/g, '\r\n')
+            .replace(/\$boundary/g, boundary)
+            .replace('$media', bodyString)
+            .replace('$resource', JSON.stringify(resource))
+            .replace('$mimeType', 'message/rfc822')
+            .trim();
+        assert.strictEqual(expectedBody, resp);
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should return err, {object}body, resp for streaming media requests', function(done) {
+  it('should return err, {object}body, resp for streaming media requests', function (done) {
     var scope = nock('https://www.googleapis.com')
         .post('/upload/gmail/v1/users/me/drafts?uploadType=multipart')
-        .reply(201, function() {
+        .times(2)
+        .reply(201, function () {
       return JSON.stringify({ hello: 'world' });
     });
 
-    var gmail = google.gmail('v1');
     var resource = { message: { raw: (new Buffer('hello', 'binary')).toString('base64') } };
     var body = fs.createReadStream(__dirname + '/fixtures/mediabody.txt');
     var media = { mimeType: 'message/rfc822', body: body };
-    gmail.users.drafts.create({
+    localGmail.users.drafts.create({
       userId: 'me',
       resource: resource,
       media: media
-    }, function(err, body, resp) {
+    }, function (err, body, resp) {
+      if (err) {
+        return done(err);
+      }
       assert.equal(typeof body, 'object');
       assert.equal(body.hello, 'world');
       assert.equal(typeof resp, 'object');
       assert.equal(resp.body, JSON.stringify(body));
-      scope.done();
-      done();
+      resource = { message: { raw: (new Buffer('hello', 'binary')).toString('base64') } };
+      body = fs.createReadStream(__dirname + '/fixtures/mediabody.txt');
+      media = { mimeType: 'message/rfc822', body: body };
+      remoteGmail.users.drafts.create({
+        userId: 'me',
+        resource: resource,
+        media: media
+      }, function (err, body, resp) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(typeof body, 'object');
+        assert.equal(body.hello, 'world');
+        assert.equal(typeof resp, 'object');
+        assert.equal(resp.body, JSON.stringify(body));
+        scope.done();
+        done();
+      });
     });
+  });
+
+  after(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 });

--- a/test/test.options.js
+++ b/test/test.options.js
@@ -18,80 +18,123 @@
 
 var assert = require('assert');
 var googleapis = require('../');
-var OAuth2 = googleapis.auth.OAuth2;
-var google, drive, authClient;
+var nock = require('nock');
+var utils = require('./utils');
 
-describe('Options', function() {
+describe('Options', function () {
+  var localDrive, remoteDrive;
+  var authClient;
 
-  function noop() {}
-
-  beforeEach(function() {
-    google = new googleapis.GoogleApis();
-    drive = google.drive('v2');
-
+  before(function (done) {
+    nock.cleanAll();
+    var google = new googleapis.GoogleApis();
+    nock.enableNetConnect();
+    utils.loadApi(google, 'drive', 'v2', function (err, drive) {
+      nock.disableNetConnect();
+      if (err) {
+        return done(err);
+      }
+      remoteDrive = drive;
+      done();
+    });
   });
 
-  it('should be a function', function() {
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    var google = new googleapis.GoogleApis();
+    localDrive = google.drive('v2');
+  });
+
+  it('should be a function', function () {
+    var google = new googleapis.GoogleApis();
     assert.equal(typeof google.options, 'function');
   });
 
-  it('should expose _options', function() {
+  it('should expose _options', function () {
+    var google = new googleapis.GoogleApis();
     google.options({ hello: 'world' });
     assert.equal(JSON.stringify(google._options), JSON.stringify({ hello: 'world' }));
   });
 
-  it('should expose _options values', function() {
+  it('should expose _options values', function () {
+    var google = new googleapis.GoogleApis();
     google.options({ hello: 'world' });
     assert.equal(google._options.hello, 'world');
   });
 
-  it('should promote endpoint options over global options', function() {
+  it('should promote endpoint options over global options', function () {
+    var google = new googleapis.GoogleApis();
     google.options({ hello: 'world' });
     var drive = google.drive({ version: 'v2', hello: 'changed' });
-    var req = drive.files.get({ fileId: '123' }, noop);
+    var req = drive.files.get({ fileId: '123' }, utils.noop);
     assert.equal(req.hello, 'changed');
   });
 
-  it('should support global request params', function() {
+  it('should support global request params', function (done) {
+    var google = new googleapis.GoogleApis();
     google.options({ params: { myParam: '123' } });
-    var req = drive.files.get({ fileId: '123' }, noop);
+    var drive = google.drive('v2');
+    var req = drive.files.get({ fileId: '123' }, utils.noop);
     // If the default param handling is broken, query might be undefined, thus concealing the
     // assertion message with some generic "cannot call .indexOf of undefined"
     var query = req.uri.query || '';
-
     assert.notEqual(query.indexOf('myParam=123'), -1, 'Default param not found in query');
+    nock.enableNetConnect();
+    utils.loadApi(google, 'drive', 'v2', function (err, drive) {
+      nock.disableNetConnect();
+      if (err) {
+        return done(err);
+      }
+      req = drive.files.get({ fileId: '123' }, utils.noop);
+      // If the default param handling is broken, query might be undefined, thus concealing the
+      // assertion message with some generic "cannot call .indexOf of undefined"
+      query = req.uri.query || '';
+      assert.notEqual(query.indexOf('myParam=123'), -1, 'Default param not found in query');
+      done();
+    });
   });
 
-  it('should promote auth apikey options on request basis', function() {
+  it('should promote auth apikey options on request basis', function () {
+    var google = new googleapis.GoogleApis();
     google.options({ auth: 'apikey1' });
     var drive = google.drive({ version: 'v2', auth: 'apikey2' });
-    var req = drive.files.get({ auth: 'apikey3', fileId: 'woot' }, noop);
+    var req = drive.files.get({ auth: 'apikey3', fileId: 'woot' }, utils.noop);
     assert.equal(req.uri.query, 'key=apikey3');
   });
 
-  it('should apply google options to request object like proxy', function() {
+  it('should apply google options to request object like proxy', function () {
+    var google = new googleapis.GoogleApis();
     google.options({ proxy: 'http://proxy.example.com' });
     var drive = google.drive({ version: 'v2', auth: 'apikey2' });
-    var req = drive.files.get({ auth: 'apikey3', fileId: 'woot' }, noop);
+    var req = drive.files.get({ auth: 'apikey3', fileId: 'woot' }, utils.noop);
     assert.equal(req.proxy.host, 'proxy.example.com');
     assert.equal(req.proxy.protocol, 'http:');
   });
 
-  it('should apply endpoint options to request object like proxy', function() {
+  it('should apply endpoint options to request object like proxy', function () {
+    var google = new googleapis.GoogleApis();
     var drive = google.drive({ version: 'v2', auth: 'apikey2', proxy: 'http://proxy.example.com' });
-    var req = drive.files.get({ auth: 'apikey3', fileId: 'woot' }, noop);
+    var req = drive.files.get({ auth: 'apikey3', fileId: 'woot' }, utils.noop);
     assert.equal(req.proxy.host, 'proxy.example.com');
     assert.equal(req.proxy.protocol, 'http:');
     assert.equal(req.uri.query, 'key=apikey3');
   });
 
-  it('should apply endpoint options like proxy to oauth transporter', function() {
+  it('should apply endpoint options like proxy to oauth transporter', function () {
+    var google = new googleapis.GoogleApis();
+    var OAuth2 = google.auth.OAuth2;
     authClient = new OAuth2('CLIENTID', 'CLIENTSECRET', 'REDIRECTURI');
     authClient.setCredentials({ access_token: 'abc' });
     var drive = google.drive({ version: 'v2', auth: 'apikey2', proxy: 'http://proxy.example.com' });
-    var req = drive.files.get({ auth: authClient, fileId: 'woot' }, noop);
+    var req = drive.files.get({ auth: authClient, fileId: 'woot' }, utils.noop);
     assert.equal(req.proxy.host, 'proxy.example.com');
     assert.equal(req.proxy.protocol, 'http:');
     assert.equal(req.headers.Authorization, 'Bearer abc');
+  });
+
+  after(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 });

--- a/test/test.query.js
+++ b/test/test.query.js
@@ -17,75 +17,138 @@
 'use strict';
 
 var assert = require('assert');
+var async = require('async');
 var googleapis = require('../');
-var google, drive, authClient, OAuth2, gmail;
+var nock = require('nock');
+var utils = require('./utils');
 
 describe('Query params', function() {
+  var localDrive, remoteDrive;
+  var localGmail, remoteGmail;
 
-  function noop() {}
+  before(function (done) {
+    nock.cleanAll();
+    var google = new googleapis.GoogleApis();
+    nock.enableNetConnect();
+    async.parallel([
+      function (cb) {
+        utils.loadApi(google, 'drive', 'v2', cb);
+      },
+      function (cb) {
+        utils.loadApi(google, 'gmail', 'v1', cb);
+      }
+    ], function (err, apis) {
+      if (err) {
+        return done(err);
+      }
+      remoteDrive = apis[0];
+      remoteGmail = apis[1];
+      nock.disableNetConnect();
+      done();
+    });
+  });
 
-  beforeEach(function() {
-    google = new googleapis.GoogleApis();
-    OAuth2 = google.auth.OAuth2;
-    authClient = new OAuth2('CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_URL');
-    authClient.setCredentials({ access_token: 'abc123' });
-    drive = google.drive('v2');
-    gmail = google.gmail('v1');
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    var google = new googleapis.GoogleApis();
+    localDrive = google.drive('v2');
+    localGmail = google.gmail('v1');
   });
 
   it('should not append ? with no query parameters', function() {
-    var uri = drive.files.get({ fileId: 'ID' }, noop).uri;
+    var uri = localDrive.files.get({ fileId: 'ID' }, utils.noop).uri;
+    assert.equal(-1, uri.href.indexOf('?'));
+    uri = remoteDrive.files.get({ fileId: 'ID' }, utils.noop).uri;
     assert.equal(-1, uri.href.indexOf('?'));
   });
 
   it('should be null if no object passed', function() {
-    var req = drive.files.list(noop);
+    var req = localDrive.files.list(utils.noop);
+    assert.equal(req.uri.query, null);
+    req = remoteDrive.files.list(utils.noop);
     assert.equal(req.uri.query, null);
   });
 
   it('should be null if params passed are in path', function() {
-    var req = drive.files.get({ fileId: '123' }, noop);
+    var req = localDrive.files.get({ fileId: '123' }, utils.noop);
+    assert.equal(req.uri.query, null);
+    req = remoteDrive.files.get({ fileId: '123' }, utils.noop);
     assert.equal(req.uri.query, null);
   });
 
   it('should be set if params passed are optional query params', function() {
-    var req = drive.files.get({ fileId: '123', updateViewedDate: true }, noop);
+    var req = localDrive.files.get({ fileId: '123', updateViewedDate: true }, utils.noop);
+    assert.equal(req.uri.query, 'updateViewedDate=true');
+    req = remoteDrive.files.get({ fileId: '123', updateViewedDate: true }, utils.noop);
     assert.equal(req.uri.query, 'updateViewedDate=true');
   });
 
   it('should be set if params passed are unknown params', function() {
-    var req = drive.files.get({ fileId: '123', madeThisUp: 'hello' }, noop);
+    var req = localDrive.files.get({ fileId: '123', madeThisUp: 'hello' }, utils.noop);
+    assert.equal(req.uri.query, 'madeThisUp=hello');
+    req = remoteDrive.files.get({ fileId: '123', madeThisUp: 'hello' }, utils.noop);
     assert.equal(req.uri.query, 'madeThisUp=hello');
   });
 
   it('should be set if params passed are aliased names', function() {
-    var req = drive.files.get({ fileId: '123', resource_: 'hello' }, noop);
+    var req = localDrive.files.get({ fileId: '123', resource_: 'hello' }, utils.noop);
+    assert.equal(req.uri.query, 'resource=hello');
+    req = remoteDrive.files.get({ fileId: '123', resource_: 'hello' }, utils.noop);
     assert.equal(req.uri.query, 'resource=hello');
   });
 
   it('should chain together with & in order', function() {
-    var req = drive.files.get({
+    var req = localDrive.files.get({
       fileId: '123',
       madeThisUp: 'hello',
       thisToo: 'world'
-    }, noop);
+    }, utils.noop);
+    assert.equal(req.uri.query, 'madeThisUp=hello&thisToo=world');
+    req = remoteDrive.files.get({
+      fileId: '123',
+      madeThisUp: 'hello',
+      thisToo: 'world'
+    }, utils.noop);
     assert.equal(req.uri.query, 'madeThisUp=hello&thisToo=world');
   });
 
   it('should not include auth if auth is an OAuth2Client object', function() {
-    var req = drive.files.get({
+    var oauth2client = new googleapis.auth.OAuth2(
+      'CLIENT_ID',
+      'CLIENT_SECRET',
+      'REDIRECT_URI'
+    );
+    oauth2client.setCredentials({ access_token: 'abc123' });
+    var req = localDrive.files.get({
       fileId: '123',
-      auth: authClient
-    }, noop);
+      auth: oauth2client
+    }, utils.noop);
+    assert.equal(req.uri.query, null);
+    req = remoteDrive.files.get({
+      fileId: '123',
+      auth: oauth2client
+    }, utils.noop);
     assert.equal(req.uri.query, null);
   });
 
   it('should handle multi-value query params properly', function() {
-    var req = gmail.users.messages.get({
+    var req = localGmail.users.messages.get({
       userId: 'me',
       id: 'abc123',
       metadataHeaders: ['To', 'Date']
-    }, noop);
+    }, utils.noop);
     assert.equal(req.uri.query, 'metadataHeaders=To&metadataHeaders=Date');
+    req = remoteGmail.users.messages.get({
+      userId: 'me',
+      id: 'abc123',
+      metadataHeaders: ['To', 'Date']
+    }, utils.noop);
+    assert.equal(req.uri.query, 'metadataHeaders=To&metadataHeaders=Date');
+  });
+
+  after(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 });

--- a/test/test.transporters.js
+++ b/test/test.transporters.js
@@ -17,149 +17,217 @@
 'use strict';
 
 var assert = require('assert');
+var async = require('async');
+var googleapis = require('../');
 var nock = require('nock');
+var utils = require('./utils');
 
-nock.disableNetConnect();
+function testHeaders (drive) {
+  var req = drive.comments.insert({
+    fileId: 'a',
+    headers: {
+      'If-None-Match': '12345'
+    }
+  }, utils.noop);
+  assert.equal(req.headers['If-None-Match'], '12345');
+}
 
-describe('Transporters', function() {
+function testContentType (drive) {
+  var req = drive.comments.insert({
+      fileId: 'a'
+  }, utils.noop);
+  assert.equal(req.headers['content-type'], 'application/json');
+}
 
-  function noop() {}
+function testBody (drive) {
+  var req = drive.files.list(utils.noop);
+  assert.equal(req.headers['content-type'], null);
+  assert.equal(req.body, null);
+}
 
-  it('should add headers to the request from params', function() {
-    var google = require('../lib/googleapis');
-    var drive = google.drive('v2');
-    var req = drive.comments.insert({
-        fileId: 'a',
-        headers: {
-          'If-None-Match': '12345'
-        }
-    }, noop);
-    assert.equal(req.headers['If-None-Match'], '12345');
+function testBodyDelete (drive) {
+  var req = drive.files.delete({
+      fileId: 'test'
+  }, utils.noop);
+  assert.equal(req.headers['content-type'], null);
+  assert.equal(req.body, null);
+}
+
+function testResponseError (drive, cb) {
+  drive.files.list({ q: 'hello' }, function (err) {
+    assert(err instanceof Error);
+    assert.equal(err.message, 'Error!');
+    assert.equal(err.code, 400);
+    cb();
+  });
+}
+
+function testNotObjectError (oauth2, cb) {
+  oauth2.tokeninfo({ access_token: 'hello' }, function (err) {
+    assert(err instanceof Error);
+    assert.equal(err.message, 'invalid_grant');
+    assert.equal(err.code, 400);
+    cb();
+  });
+}
+
+function testBackendError (urlshortener, cb) {
+  var obj = { longUrl: 'http://google.com/' };
+  urlshortener.url.insert({ resource: obj }, function (err, result) {
+    assert(err instanceof Error);
+    assert.equal(err.code, 500);
+    assert.equal(err.message, 'There was an error!');
+    assert.equal(result, null);
+    cb();
+  });
+}
+
+describe('Transporters', function () {
+  var localDrive, remoteDrive;
+  var localOauth2, remoteOauth2;
+  var localUrlshortener, remoteUrlshortener;
+
+  before(function (done) {
+    nock.cleanAll();
+    var google = new googleapis.GoogleApis();
+    nock.enableNetConnect();
+    async.parallel([
+      function (cb) {
+        utils.loadApi(google, 'drive', 'v2', cb);
+      },
+      function (cb) {
+        utils.loadApi(google, 'oauth2', 'v2', cb);
+      },
+      function (cb) {
+        utils.loadApi(google, 'urlshortener', 'v1', cb);
+      }
+    ], function (err, apis) {
+      if (err) {
+        return done(err);
+      }
+      remoteDrive = apis[0];
+      remoteOauth2 = apis[1];
+      remoteUrlshortener = apis[2];
+      nock.disableNetConnect();
+      done();
+    });
   });
 
-  it('should automatically add content-type for POST requests', function() {
-    var google = require('../lib/googleapis');
-    var drive = google.drive('v2');
-    var req = drive.comments.insert({
-        fileId: 'a'
-    }, noop);
-    assert.equal(req.headers['content-type'], 'application/json');
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    var google = new googleapis.GoogleApis();
+    localDrive = google.drive('v2');
+    localOauth2 = google.oauth2('v2');
+    localUrlshortener = google.urlshortener('v1');
   });
 
-  it('should not add body for GET requests', function() {
-    var google = require('../lib/googleapis');
-    var drive = google.drive('v2');
-    var req = drive.files.list(noop);
-    assert.equal(req.headers['content-type'], null);
-    assert.equal(req.body, null);
+  it('should add headers to the request from params', function () {
+    testHeaders(localDrive);
+    testHeaders(remoteDrive);
   });
 
-  it('should not add body for DELETE requests', function() {
-    var google = require('../lib/googleapis');
-    var drive = google.drive('v2');
-    var req = drive.files.delete({
-        fileId: 'test'
-    }, noop);
-    assert.equal(req.headers['content-type'], null);
-    assert.equal(req.body, null);
+  it('should automatically add content-type for POST requests', function () {
+    testContentType(localDrive);
+    testContentType(remoteDrive);
   });
 
-  it('should return errors within response body as instances of Error', function(done) {
-    var google = require('../lib/googleapis');
-    var drive = google.drive('v2');
+  it('should not add body for GET requests', function () {
+    testBody(localDrive);
+    testBody(remoteDrive);
+  });
 
-    var scope = nock('https://www.googleapis.com')
+  it('should not add body for DELETE requests', function () {
+    testBodyDelete(localDrive);
+    testBodyDelete(remoteDrive);
+  });
+
+  it('should return errors within response body as instances of Error', function (done) {
+    var scope = nock('https://www.googleapis.com', { allowUnmocked: true })
       .get('/drive/v2/files?q=hello')
+      .times(2)
       // Simulate an error returned via response body from Google's API endpoint
       .reply(400, { error: { code: 400, message: 'Error!'} });
 
-    drive.files.list({ q: 'hello' }, function(err) {
-      assert(err instanceof Error);
-      assert.equal(err.message, 'Error!');
-      assert.equal(err.code, 400);
-      scope.done();
-      done();
+    testResponseError(localDrive, function () {
+      testResponseError(remoteDrive, function () {
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should return error message correctly when error is not an object', function(done) {
-    var google = require('../lib/googleapis');
-    var oauth2 = google.oauth2('v2');
-
-    var scope = nock('https://www.googleapis.com')
+  it('should return error message correctly when error is not an object', function (done) {
+    var scope = nock('https://www.googleapis.com', { allowUnmocked: true })
       .post('/oauth2/v2/tokeninfo?access_token=hello')
+      .times(2)
       // Simulate an error returned via response body from Google's tokeninfo endpoint
       .reply(400, { error: 'invalid_grant', error_description: 'Code was already redeemed.' });
 
-    oauth2.tokeninfo({ access_token: 'hello' }, function(err) {
-      assert(err instanceof Error);
-      assert.equal(err.message, 'invalid_grant');
-      assert.equal(err.code, 400);
-      scope.done();
-      done();
+    testNotObjectError(localOauth2, function () {
+      testNotObjectError(remoteOauth2, function () {
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should return 5xx responses as errors', function(done) {
-    var google = require('../lib/googleapis');
-    var scope = nock('https://www.googleapis.com')
+  it('should return 5xx responses as errors', function (done) {
+    var scope = nock('https://www.googleapis.com', { allowUnmocked: true })
       .post('/urlshortener/v1/url')
+      .times(2)
       .reply(500, 'There was an error!');
-    var urlshortener = google.urlshortener('v1');
-    var obj = { longUrl: 'http://google.com/' };
-    urlshortener.url.insert({ resource: obj }, function(err, result) {
-      assert(err instanceof Error);
-      assert.equal(err.code, 500);
-      assert.equal(err.message, 'There was an error!');
-      assert.equal(result, null);
-      scope.done();
-      done();
+
+    testBackendError(localUrlshortener, function () {
+      testBackendError(remoteUrlshortener, function () {
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should handle 5xx responses that include errors', function(done) {
-    var google = require('../lib/googleapis');
-    var scope = nock('https://www.googleapis.com')
+  it('should handle 5xx responses that include errors', function (done) {
+    var scope = nock('https://www.googleapis.com', { allowUnmocked: true })
       .post('/urlshortener/v1/url')
+      .times(2)
       .reply(500, { error: {message: 'There was an error!'}});
-    var urlshortener = google.urlshortener('v1');
-    var obj = { longUrl: 'http://google.com/' };
-    urlshortener.url.insert({ resource: obj }, function(err, result) {
-      assert(err instanceof Error);
-      assert.equal(err.code, 500);
-      assert.equal(err.message, 'There was an error!');
-      assert.equal(result, null);
-      scope.done();
-      done();
+
+    testBackendError(localUrlshortener, function () {
+      testBackendError(remoteUrlshortener, function () {
+        scope.done();
+        done();
+      });
     });
   });
 
-  it('should handle a Backend Error', function(done) {
-    var google = require('../lib/googleapis');
-    var scope = nock('https://www.googleapis.com')
+  it('should handle a Backend Error', function (done) {
+    var scope = nock('https://www.googleapis.com', { allowUnmocked: true })
       .post('/urlshortener/v1/url')
+      .times(2)
       .reply(500, {
         error: {
          errors: [
            {
              domain: 'global',
              reason: 'backendError',
-             message: 'Backend Error'
+             message: 'There was an error!'
            }
          ],
          code: 500,
-         message: 'Backend Error'
+         message: 'There was an error!'
        }
       });
-    var urlshortener = google.urlshortener('v1');
-    var obj = { longUrl: 'http://google.com/' };
-    urlshortener.url.insert({ resource: obj }, function(err, result) {
-      assert(err instanceof Error);
-      assert.equal(err.code, 500);
-      assert.equal(err.message, 'Backend Error');
-      assert.equal(result, null);
-      scope.done();
-      done();
+
+    testBackendError(localUrlshortener, function () {
+      testBackendError(remoteUrlshortener, function () {
+        scope.done();
+        done();
+      });
     });
+  });
+
+  after(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,31 @@
+// Copyright 2016, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function getDiscoveryUrl(name, version) {
+  return 'https://www.googleapis.com/discovery/v1/apis/' + name +
+    '/' + version + '/rest';
+}
+
+function loadApi(google, name, version, options, cb) {
+  if (typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+  return google.discoverAPI(getDiscoveryUrl(name, version), options, cb);
+}
+
+exports.getDiscoveryUrl = getDiscoveryUrl;
+exports.loadApi = loadApi;
+exports.noop = function () {};


### PR DESCRIPTION
Addresses:

- #416

What this PR adds:

Let's say that the latest `googleapis` in NPM supports `someapi` `v1`, you would do:

```js
var google = require('googleapis');
var someapi = google.someapi('v1');
```

But, what if `v2` of `someapi` is available, but the discovery doc isn't available in the main discovery index yet, or maybe it is and a new release of `googleapis` hasn't been generated yet. You can now do this:

```js
var google = require('googleapis');
google.load('http://domain.com/path/to/someapi/v2/discovery.json', function (err, someapi) {
  // use someapi
});
```

It also works for Cloud Endpoints v1:

```js
var google = require('googleapis');
google.discover('https://myapp.appspot.com/_ah/api/discovery/v1/apis', function (err, apis) {
  var myapi = google.myapi('v3');
  // use myapi
});
```

or

```js
var google = require('googleapis');
google.discoverAPI('https://myapp.appspot.com/_ah/api/discovery/v1/apis/myapi/v3/rest', function (err, myapi) {
  // use myapi
});
```