### PR TITLE
Implement backwards compatible promise support.

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -17,6 +17,7 @@ var utils = require('./utils.js');
 var DefaultTransporter = require('./transporters.js');
 var stream = require('stream');
 var parseString = require('string-template');
+var Promise = require('bluebird');
 
 function isReadableStream (obj) {
   return obj instanceof stream.Stream &&
@@ -175,16 +176,37 @@ function createAPIRequest (parameters, callback) {
   delete options.auth; // is overridden by our auth code
   delete options.params; // We handle params ourselves and Request does not recognise 'params'
 
+  var resolve, reject;
+
+  // Promisify the results, but also call the node-style callback
+  var promise = new Promise(function () {
+    resolve = arguments[0];
+    reject = arguments[1];
+  }).asCallback(callback, { spread: true });
+
+  // Capture err and/or results
+  var promiseBack = function (err) {
+    if (err) {
+      return reject(err);
+    }
+    return resolve(Array.prototype.slice.call(arguments, 1));
+  };
+
   // create request (using authClient or otherwise and return request obj)
   if (authClient) {
-    req = authClient.request(options, callback);
+    req = authClient.request(options, promiseBack);
   } else {
-    req = new DefaultTransporter().request(options, callback);
+    req = new DefaultTransporter().request(options, promiseBack);
   }
 
-  if (body) {
-    body.pipe(req);
+  if (req) {
+    // Make promise available
+    req.promise = promise;
+    if (body) {
+      body.pipe(req);
+    }
   }
+
   return req;
 }
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "async": "~1.5.2",
+    "bluebird": "^3.3.5",
     "gapitoken": "~0.1.5",
     "google-auth-library": "~0.9.7",
     "request": "~2.72.0",

--- a/test/test.promises.js
+++ b/test/test.promises.js
@@ -1,0 +1,106 @@
+// Copyright 2013-2016, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var assert = require('assert');
+var googleapis = require('../');
+var nock = require('nock');
+var utils = require('./utils');
+
+function testInsert (urlshortener) {
+  var obj = { longUrl: 'http://google.com/' };
+  return urlshortener
+    .url
+    .insert({ resource: obj })
+    .promise
+    .spread(function (result) {
+      assert.notEqual(result, null);
+      assert.notEqual(result.kind, null);
+      assert.notEqual(result.id, null);
+      assert.equal(result.longUrl, 'http://google.com/');
+    });
+}
+
+function testBackendError (urlshortener) {
+  var obj = { longUrl: 'http://google.com/' };
+  return urlshortener
+    .url
+    .insert({ resource: obj })
+    .promise
+    .then(function () {
+      throw new Error('should have failed!');
+    }, function (err) {
+      assert(err instanceof Error);
+      assert.equal(err.code, 500);
+      assert.equal(err.message, 'There was an error!');
+    });
+}
+
+describe('Request#toPromise', function () {
+  var localUrlshortener, remoteUrlshortener;
+
+  before(function (done) {
+    nock.cleanAll();
+    var google = new googleapis.GoogleApis();
+    nock.enableNetConnect();
+    utils.loadApi(google, 'urlshortener', 'v1', function (err, urlshortener) {
+      nock.disableNetConnect();
+      if (err) {
+        return done(err);
+      }
+      remoteUrlshortener = urlshortener;
+      done();
+    });
+  });
+
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    var google = new googleapis.GoogleApis();
+    localUrlshortener = google.urlshortener('v1');
+  });
+
+  it('should return a single response object for single requests (promises)', function () {
+    var scope = nock('https://www.googleapis.com', {
+      allowUnmocked: true
+    })
+      .post('/urlshortener/v1/url')
+      .times(2)
+      .replyWithFile(200, __dirname + '/fixtures/urlshort-insert-res.json');
+
+    return testInsert(localUrlshortener).then(function () {
+      return testInsert(remoteUrlshortener);
+    }).then(function () {
+      scope.done();
+    });
+  });
+
+  it('should return 5xx responses as errors', function () {
+    var scope = nock('https://www.googleapis.com', { allowUnmocked: true })
+      .post('/urlshortener/v1/url')
+      .times(2)
+      .reply(500, 'There was an error!');
+
+    return testBackendError(localUrlshortener).then(function () {
+      return testBackendError(remoteUrlshortener);
+    }).then(function () {
+      scope.done();
+    });
+  });
+
+  after(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+});


### PR DESCRIPTION
This addresses #197 and #523 by adding backwards compatible promise support for API requests only. No changes were made to google-auth-library-nodejs. Promise support will need to be added separately to that library.

In a future release we may introduce breaking changes that improve promise support. This PR only requires a minor version bump. With this PR there are still edge cases where no `request` object is returned by the method call, in which case there is obviously no `request.promise` available. For example, when you try to make an API request but you haven't provided all the required params, no request object is returned, so no promise. =(

I'm not sure how useful this feature is until breaking changes can be made, unless you're sure you're passing in all required params and you can avoid the cases where no request object is returned by the method call.

I believe passing in an auth client with no tokens might be another case where no request object is returned...

Usage:

``` js
var req = urlshortener.url.insert({ resource: obj });

req.promise.spread((body, response) => {
  // ...
});
```

Example edge case with no promise available:

``` js
var req = adexchangebuyer.accounts.get({});
req // null, oh no!
```

have to pass a callback to get the error =(

``` js
var req = adexchangebuyer.accounts.get({}, function (err) {
  err; // Error: missing id
});
req // null, oh no!
```
