### PR TITLE
Replace process.exit with an else block

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -37,19 +37,18 @@ if (args.length) {
       console.log('Generated API for ' + url);
     });
   });
-  process.exit(0);
-}
-
-console.log('Removing old APIs...');
-rimraf(path.join(__dirname, '..', 'apis'), function (err) {
-  if (err) {
-    throw err;
-  }
-  console.log('Generating APIs...');
-  gen.generateAllAPIs(function (err) {
+} else {
+  console.log('Removing old APIs...');
+  rimraf(path.join(__dirname, '..', 'apis'), function (err) {
     if (err) {
       throw err;
     }
-    console.log('Finished generating APIs!');
+    console.log('Generating APIs...');
+    gen.generateAllAPIs(function (err) {
+      if (err) {
+        throw err;
+      }
+      console.log('Finished generating APIs!');
+    });
   });
-});
+}


### PR DESCRIPTION
Fixes #566

- [X ] `npm test` succeeds
- [ X] Pull request has been squashed into 1 commit
- [ X] I did NOT manually make changes to anything in `apis/`
- [ X] Code coverage does not decrease (if any source code was changed)
- [ X] Appropriate JSDoc comments were updated in source code (if applicable)
- [ X] Approprate changes to readme/docs are included in PR

The `process.exit` replaced a `return`that was failing a lint check, but ended up causing the generator to quit before the generation was complete.