### PR TITLE
9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+##### 9.0.0 - 20 June 2016
+
+###### Breaking changes
+- Removed `regionalBackendServices.testIamPermissions` from `compute` `alpha` API
+
+###### Backwards compatible changes
+- Added `appengine` `v1` API
+- Added `instances.setServiceAccount` to `compute` `alpha` API
+- Added `networks.switchToCustomMode` to `compute` `alpha` API
+- Added `regionBackendServices.delete` to `compute` `alpha` API
+- Added `regionBackendServices.get` to `compute` `alpha` API
+- Added `regionBackendServices.getHealth` to `compute` `alpha` API
+- Added `regionBackendServices.insert` to `compute` `alpha` API
+- Added `regionBackendServices.list` to `compute` `alpha` API
+- Added `regionBackendServices.patch` to `compute` `alpha` API
+- Added `regionBackendServices.testIamPermissions` to `compute` `alpha` API
+- Added `regionBackendServices.update` to `compute` `alpha` API
+- Added `subnetworks.expandIpCidrRange` to `compute` `alpha` API
+- Added `subnetworks.getIamPolicy` to `compute` `alpha` API
+- Added `subnetworks.setIamPolicy` to `compute` `alpha` API
+- Added `healthChecks.delete` to `compute` `beta` API
+- Added `healthChecks.get` to `compute` `beta` API
+- Added `healthChecks.insert` to `compute` `beta` API
+- Added `healthChecks.list` to `compute` `beta` API
+- Added `healthChecks.patch` to `compute` `beta` API
+- Added `healthChecks.testIamPermissions` to `compute` `beta` API
+- Added `healthChecks.update` to `compute` `beta` API
+- Added `targetSslProxies.delete` to `compute` `beta` API
+- Added `targetSslProxies.get` to `compute` `beta` API
+- Added `targetSslProxies.insert` to `compute` `beta` API
+- Added `targetSslProxies.list` to `compute` `beta` API
+- Added `targetSslProxies.setBackendService` to `compute` `beta` API
+- Added `targetSslProxies.setProxyHeader` to `compute` `beta` API
+- Added `targetSslProxies.setSslCertificates` to `compute` `beta` API
+- Added `targetSslProxies.testIamPermissions` to `compute` `beta` API
+- Added `urlMaps.invalidateCache` to `compute` `v1` API
+
 ##### 8.2.0 - 14 June 2016
 
 ###### Backwards compatible changes

--- a/apis/appengine/v1.js
+++ b/apis/appengine/v1.js
@@ -27,12 +27,12 @@ var createAPIRequest = require('../../lib/apirequest');
  *
  * @example
  * var google = require('googleapis');
- * var appengine = google.appengine('v1beta5');
+ * var appengine = google.appengine('v1');
  *
  * @namespace appengine
  * @type {Function}
- * @version v1beta5
- * @variation v1beta5
+ * @version v1
+ * @variation v1
  * @param {object=} options Options for Appengine
  */
 function Appengine(options) { // eslint-disable-line
@@ -47,19 +47,47 @@ function Appengine(options) { // eslint-disable-line
      * @desc Gets information about an application.
      *
      * @alias appengine.apps.get
-     * @memberOf! appengine(v1beta5)
+     * @memberOf! appengine(v1)
      *
      * @param {object} params Parameters for request
-     * @param {string} params.appsId Part of `name`. Name of the application to get. For example: "apps/myapp".
-     * @param {boolean=} params.ensureResourcesExist Certain resources associated with an application are created on-demand. Controls whether these resources should be created when performing the `GET` operation. If specified and any resources could not be created, the request will fail with an error code. Additionally, this parameter can cause the request to take longer to complete. Note: This parameter will be deprecated in a future version of the API.
+     * @param {string} params.appsId Part of `name`. The name of the Application resource to get. For example: "apps/myapp".
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     get: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}',
+          url: 'https://appengine.googleapis.com/v1/apps/{appsId}',
           method: 'GET'
+        },
+        params: params,
+        requiredParams: ['appsId'],
+        pathParams: ['appsId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * appengine.apps.repair
+     *
+     * @desc Ensures that all special features required for App Engine, such as the appspot bucket and appengine robot, exist for this project.
+     *
+     * @alias appengine.apps.repair
+     * @memberOf! appengine(v1)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.appsId Part of `name`. Name of the application to repair. For example: "apps/myapp".
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    repair: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://appengine.googleapis.com/v1/apps/{appsId}:repair',
+          method: 'POST'
         },
         params: params,
         requiredParams: ['appsId'],
@@ -78,7 +106,7 @@ function Appengine(options) { // eslint-disable-line
        * @desc Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.
        *
        * @alias appengine.apps.operations.get
-       * @memberOf! appengine(v1beta5)
+       * @memberOf! appengine(v1)
        *
        * @param {object} params Parameters for request
        * @param {string} params.appsId Part of `name`. The name of the operation resource.
@@ -89,7 +117,7 @@ function Appengine(options) { // eslint-disable-line
       get: function (params, callback) {
         var parameters = {
           options: {
-            url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/operations/{operationsId}',
+            url: 'https://appengine.googleapis.com/v1/apps/{appsId}/operations/{operationsId}',
             method: 'GET'
           },
           params: params,
@@ -107,7 +135,7 @@ function Appengine(options) { // eslint-disable-line
        * @desc Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`. NOTE: the `name` binding below allows API services to override the binding to use different resource name schemes, such as `users/x/operations`.
        *
        * @alias appengine.apps.operations.list
-       * @memberOf! appengine(v1beta5)
+       * @memberOf! appengine(v1)
        *
        * @param {object} params Parameters for request
        * @param {string} params.appsId Part of `name`. The name of the operation collection.
@@ -120,7 +148,7 @@ function Appengine(options) { // eslint-disable-line
       list: function (params, callback) {
         var parameters = {
           options: {
-            url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/operations',
+            url: 'https://appengine.googleapis.com/v1/apps/{appsId}/operations',
             method: 'GET'
           },
           params: params,
@@ -136,73 +164,15 @@ function Appengine(options) { // eslint-disable-line
     services: {
 
       /**
-       * appengine.apps.services.delete
-       *
-       * @desc Deletes a service and all enclosed versions.
-       *
-       * @alias appengine.apps.services.delete
-       * @memberOf! appengine(v1beta5)
-       *
-       * @param {object} params Parameters for request
-       * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-       * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
-       * @param {callback} callback The callback that handles the response.
-       * @return {object} Request object
-       */
-      delete: function (params, callback) {
-        var parameters = {
-          options: {
-            url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}',
-            method: 'DELETE'
-          },
-          params: params,
-          requiredParams: ['appsId', 'servicesId'],
-          pathParams: ['appsId', 'servicesId'],
-          context: self
-        };
-
-        return createAPIRequest(parameters, callback);
-      },
-
-      /**
-       * appengine.apps.services.get
-       *
-       * @desc Gets the current configuration of the service.
-       *
-       * @alias appengine.apps.services.get
-       * @memberOf! appengine(v1beta5)
-       *
-       * @param {object} params Parameters for request
-       * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-       * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
-       * @param {callback} callback The callback that handles the response.
-       * @return {object} Request object
-       */
-      get: function (params, callback) {
-        var parameters = {
-          options: {
-            url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}',
-            method: 'GET'
-          },
-          params: params,
-          requiredParams: ['appsId', 'servicesId'],
-          pathParams: ['appsId', 'servicesId'],
-          context: self
-        };
-
-        return createAPIRequest(parameters, callback);
-      },
-
-      /**
        * appengine.apps.services.list
        *
        * @desc Lists all the services in the application.
        *
        * @alias appengine.apps.services.list
-       * @memberOf! appengine(v1beta5)
+       * @memberOf! appengine(v1)
        *
        * @param {object} params Parameters for request
-       * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp".
+       * @param {string} params.appsId Part of `parent`. Name of the parent Application resource. For example: "apps/myapp".
        * @param {integer=} params.pageSize Maximum results to return per page.
        * @param {string=} params.pageToken Continuation token for fetching the next page of results.
        * @param {callback} callback The callback that handles the response.
@@ -211,7 +181,7 @@ function Appengine(options) { // eslint-disable-line
       list: function (params, callback) {
         var parameters = {
           options: {
-            url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services',
+            url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services',
             method: 'GET'
           },
           params: params,
@@ -224,18 +194,47 @@ function Appengine(options) { // eslint-disable-line
       },
 
       /**
+       * appengine.apps.services.get
+       *
+       * @desc Gets the current configuration of the specified service.
+       *
+       * @alias appengine.apps.services.get
+       * @memberOf! appengine(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
+       * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['appsId', 'servicesId'],
+          pathParams: ['appsId', 'servicesId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
        * appengine.apps.services.patch
        *
        * @desc Updates the configuration of the specified service.
        *
        * @alias appengine.apps.services.patch
-       * @memberOf! appengine(v1beta5)
+       * @memberOf! appengine(v1)
        *
        * @param {object} params Parameters for request
        * @param {string} params.appsId Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
        * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
-       * @param {string=} params.mask Standard field mask for the set of fields to be updated.
-       * @param {boolean=} params.migrateTraffic Whether to use Traffic Migration to shift traffic gradually. Traffic can only be migrated from a single version to another single version.
+       * @param {string=} params.updateMask Standard field mask for the set of fields to be updated.
+       * @param {boolean=} params.migrateTraffic Whether to use traffic migration to shift traffic gradually. Traffic can only be migrated from a single version to another single version. More information is available in the documentation for traffic migration: https://cloud.google.com/appengine/docs/python/migrating-traffic
        * @param {object} params.resource Request body data
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
@@ -243,8 +242,37 @@ function Appengine(options) { // eslint-disable-line
       patch: function (params, callback) {
         var parameters = {
           options: {
-            url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}',
+            url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}',
             method: 'PATCH'
+          },
+          params: params,
+          requiredParams: ['appsId', 'servicesId'],
+          pathParams: ['appsId', 'servicesId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * appengine.apps.services.delete
+       *
+       * @desc Deletes the specified service and all enclosed versions.
+       *
+       * @alias appengine.apps.services.delete
+       * @memberOf! appengine(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
+       * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}',
+            method: 'DELETE'
           },
           params: params,
           requiredParams: ['appsId', 'servicesId'],
@@ -258,25 +286,27 @@ function Appengine(options) { // eslint-disable-line
       versions: {
 
         /**
-         * appengine.apps.services.versions.create
+         * appengine.apps.services.versions.list
          *
-         * @desc Deploys new code and resource files to a version.
+         * @desc Lists the versions of a service.
          *
-         * @alias appengine.apps.services.versions.create
-         * @memberOf! appengine(v1beta5)
+         * @alias appengine.apps.services.versions.list
+         * @memberOf! appengine(v1)
          *
          * @param {object} params Parameters for request
-         * @param {string} params.appsId Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-         * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
-         * @param {object} params.resource Request body data
+         * @param {string} params.appsId Part of `parent`. Name of the parent resource to list versions on. For example: "apps/myapp/services/default".
+         * @param {string} params.servicesId Part of `parent`. See documentation of `appsId`.
+         * @param {string=} params.view Controls the set of fields returned in the `List` response.
+         * @param {integer=} params.pageSize Maximum results to return per page.
+         * @param {string=} params.pageToken Continuation token for fetching the next page of results.
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create: function (params, callback) {
+        list: function (params, callback) {
           var parameters = {
             options: {
-              url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}/versions',
-              method: 'POST'
+              url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}/versions',
+              method: 'GET'
             },
             params: params,
             requiredParams: ['appsId', 'servicesId'],
@@ -288,42 +318,12 @@ function Appengine(options) { // eslint-disable-line
         },
 
         /**
-         * appengine.apps.services.versions.delete
-         *
-         * @desc Deletes an existing version.
-         *
-         * @alias appengine.apps.services.versions.delete
-         * @memberOf! appengine(v1beta5)
-         *
-         * @param {object} params Parameters for request
-         * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default/versions/v1".
-         * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
-         * @param {string} params.versionsId Part of `name`. See documentation of `appsId`.
-         * @param {callback} callback The callback that handles the response.
-         * @return {object} Request object
-         */
-        delete: function (params, callback) {
-          var parameters = {
-            options: {
-              url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}/versions/{versionsId}',
-              method: 'DELETE'
-            },
-            params: params,
-            requiredParams: ['appsId', 'servicesId', 'versionsId'],
-            pathParams: ['appsId', 'servicesId', 'versionsId'],
-            context: self
-          };
-
-          return createAPIRequest(parameters, callback);
-        },
-
-        /**
          * appengine.apps.services.versions.get
          *
-         * @desc Gets application deployment information.
+         * @desc Gets the specified Version resource. By default, only a BASIC_VIEW will be returned. Please specify the FULL_VIEW parameter to get the full resource.
          *
          * @alias appengine.apps.services.versions.get
-         * @memberOf! appengine(v1beta5)
+         * @memberOf! appengine(v1)
          *
          * @param {object} params Parameters for request
          * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default/versions/v1".
@@ -336,7 +336,7 @@ function Appengine(options) { // eslint-disable-line
         get: function (params, callback) {
           var parameters = {
             options: {
-              url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}/versions/{versionsId}',
+              url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}',
               method: 'GET'
             },
             params: params,
@@ -349,27 +349,25 @@ function Appengine(options) { // eslint-disable-line
         },
 
         /**
-         * appengine.apps.services.versions.list
+         * appengine.apps.services.versions.create
          *
-         * @desc Lists the versions of a service.
+         * @desc Deploys code and resource files to a new version.
          *
-         * @alias appengine.apps.services.versions.list
-         * @memberOf! appengine(v1beta5)
+         * @alias appengine.apps.services.versions.create
+         * @memberOf! appengine(v1)
          *
          * @param {object} params Parameters for request
-         * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-         * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
-         * @param {string=} params.view Controls the set of fields returned in the `List` response.
-         * @param {integer=} params.pageSize Maximum results to return per page.
-         * @param {string=} params.pageToken Continuation token for fetching the next page of results.
+         * @param {string} params.appsId Part of `parent`. Name of the parent resource to create this version under. For example: "apps/myapp/services/default".
+         * @param {string} params.servicesId Part of `parent`. See documentation of `appsId`.
+         * @param {object} params.resource Request body data
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list: function (params, callback) {
+        create: function (params, callback) {
           var parameters = {
             options: {
-              url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}/versions',
-              method: 'GET'
+              url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}/versions',
+              method: 'POST'
             },
             params: params,
             requiredParams: ['appsId', 'servicesId'],
@@ -383,16 +381,16 @@ function Appengine(options) { // eslint-disable-line
         /**
          * appengine.apps.services.versions.patch
          *
-         * @desc Updates the specified Version resource. You can specify the following fields depending on the App Engine environment and type of scaling that the version resource uses: * [`serving_status`](/appengine/docs/admin-api/reference/rest/v1beta5/apps.services.versions#Version.FIELDS.serving_status): For Version resources that use basic scaling, manual scaling, or run in the App Engine flexible environment. * [`instance_class`](/appengine/docs/admin-api/reference/rest/v1beta5/apps.services.versions#Version.FIELDS.instance_class): For Version resources that run in the App Engine standard environment. * [`automatic_scaling.min_idle_instances`](/appengine/docs/admin-api/reference/rest/v1beta5/apps.services.versions#Version.FIELDS.automatic_scaling): For Version resources that use automatic scaling and run in the App Engine standard environment. * [`automatic_scaling.max_idle_instances`](/appengine/docs/admin-api/reference/rest/v1beta5/apps.services.versions#Version.FIELDS.automatic_scaling): For Version resources that use automatic scaling and run in the App Engine standard environment.
+         * @desc Updates the specified Version resource. You can specify the following fields depending on the App Engine environment and type of scaling that the version resource uses: * [`serving_status`](/appengine/docs/admin-api/reference/rest/v1/apps.services.versions#Version.FIELDS.serving_status): For Version resources that use basic scaling, manual scaling, or run in the App Engine flexible environment. * [`instance_class`](/appengine/docs/admin-api/reference/rest/v1/apps.services.versions#Version.FIELDS.instance_class): For Version resources that run in the App Engine standard environment. * [`automatic_scaling.min_idle_instances`](/appengine/docs/admin-api/reference/rest/v1/apps.services.versions#Version.FIELDS.automatic_scaling): For Version resources that use automatic scaling and run in the App Engine standard environment. * [`automatic_scaling.max_idle_instances`](/appengine/docs/admin-api/reference/rest/v1/apps.services.versions#Version.FIELDS.automatic_scaling): For Version resources that use automatic scaling and run in the App Engine standard environment.
          *
          * @alias appengine.apps.services.versions.patch
-         * @memberOf! appengine(v1beta5)
+         * @memberOf! appengine(v1)
          *
          * @param {object} params Parameters for request
          * @param {string} params.appsId Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default/versions/1".
          * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
          * @param {string} params.versionsId Part of `name`. See documentation of `appsId`.
-         * @param {string=} params.mask Standard field mask for the set of fields to be updated.
+         * @param {string=} params.updateMask Standard field mask for the set of fields to be updated.
          * @param {object} params.resource Request body data
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
@@ -400,8 +398,38 @@ function Appengine(options) { // eslint-disable-line
         patch: function (params, callback) {
           var parameters = {
             options: {
-              url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}/versions/{versionsId}',
+              url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}',
               method: 'PATCH'
+            },
+            params: params,
+            requiredParams: ['appsId', 'servicesId', 'versionsId'],
+            pathParams: ['appsId', 'servicesId', 'versionsId'],
+            context: self
+          };
+
+          return createAPIRequest(parameters, callback);
+        },
+
+        /**
+         * appengine.apps.services.versions.delete
+         *
+         * @desc Deletes an existing Version resource.
+         *
+         * @alias appengine.apps.services.versions.delete
+         * @memberOf! appengine(v1)
+         *
+         * @param {object} params Parameters for request
+         * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default/versions/v1".
+         * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
+         * @param {string} params.versionsId Part of `name`. See documentation of `appsId`.
+         * @param {callback} callback The callback that handles the response.
+         * @return {object} Request object
+         */
+        delete: function (params, callback) {
+          var parameters = {
+            options: {
+              url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}',
+              method: 'DELETE'
             },
             params: params,
             requiredParams: ['appsId', 'servicesId', 'versionsId'],
@@ -420,12 +448,12 @@ function Appengine(options) { // eslint-disable-line
            * @desc Lists the instances of a version.
            *
            * @alias appengine.apps.services.versions.instances.list
-           * @memberOf! appengine(v1beta5)
+           * @memberOf! appengine(v1)
            *
            * @param {object} params Parameters for request
-           * @param {string} params.appsId Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default/versions/v1".
-           * @param {string} params.servicesId Part of `name`. See documentation of `appsId`.
-           * @param {string} params.versionsId Part of `name`. See documentation of `appsId`.
+           * @param {string} params.appsId Part of `parent`. Name of the parent Version resource to list instances for. For example: "apps/myapp/services/default/versions/v1".
+           * @param {string} params.servicesId Part of `parent`. See documentation of `appsId`.
+           * @param {string} params.versionsId Part of `parent`. See documentation of `appsId`.
            * @param {integer=} params.pageSize Maximum results to return per page.
            * @param {string=} params.pageToken Continuation token for fetching the next page of results.
            * @param {callback} callback The callback that handles the response.
@@ -434,7 +462,7 @@ function Appengine(options) { // eslint-disable-line
           list: function (params, callback) {
             var parameters = {
               options: {
-                url: 'https://appengine.googleapis.com/v1beta5/apps/{appsId}/services/{servicesId}/versions/{versionsId}/instances',
+                url: 'https://appengine.googleapis.com/v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}/instances',
                 method: 'GET'
               },
               params: params,

--- a/apis/appengine/v1beta4.js
+++ b/apis/appengine/v1beta4.js
@@ -320,7 +320,7 @@ function Appengine(options) { // eslint-disable-line
         /**
          * appengine.apps.modules.versions.patch
          *
-         * @desc Updates an existing version. Note: UNIMPLEMENTED.
+         * @desc Updates the specified Version resource. You can specify the following fields depending on the App Engine environment and type of scaling that the version resource uses: * [`serving_status`](/appengine/docs/admin-api/reference/rest/v1beta4/apps.services.versions#Version.FIELDS.serving_status): For Version resources that use basic scaling, manual scaling, or run in the App Engine flexible environment. * [`instance_class`](/appengine/docs/admin-api/reference/rest/v1beta4/apps.services.versions#Version.FIELDS.instance_class): For Version resources that run in the App Engine standard environment. * [`automatic_scaling.min_idle_instances`](/appengine/docs/admin-api/reference/rest/v1beta4/apps.services.versions#Version.FIELDS.automatic_scaling): For Version resources that use automatic scaling and run in the App Engine standard environment. * [`automatic_scaling.max_idle_instances`](/appengine/docs/admin-api/reference/rest/v1beta4/apps.services.versions#Version.FIELDS.automatic_scaling): For Version resources that use automatic scaling and run in the App Engine standard environment.
          *
          * @alias appengine.apps.modules.versions.patch
          * @memberOf! appengine(v1beta4)

--- a/apis/books/v1.js
+++ b/apis/books/v1.js
@@ -23,7 +23,7 @@ var createAPIRequest = require('../../lib/apirequest');
 /**
  * Books API
  *
- * Lets you search for books and manage your Google Books library.
+ * Searches for books and manages your Google Books library.
  *
  * @example
  * var google = require('googleapis');

--- a/apis/clouderrorreporting/v1beta1.js
+++ b/apis/clouderrorreporting/v1beta1.js
@@ -51,7 +51,7 @@ function Clouderrorreporting(options) { // eslint-disable-line
      * @memberOf! clouderrorreporting(v1beta1)
      *
      * @param {object} params Parameters for request
-     * @param {string} params.projectName The resource name of the Google Cloud Platform project. Required. Example: `projects/my-project`.
+     * @param {string} params.projectName [Required] The resource name of the Google Cloud Platform project. Written as `projects/` plus the [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840). Example: `projects/my-project-123`.
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
@@ -82,12 +82,12 @@ function Clouderrorreporting(options) { // eslint-disable-line
        *
        * @param {object} params Parameters for request
        * @param {string=} params.timeRange.period Restricts the query to the specified time range.
-       * @param {string} params.projectName The resource name of the Google Cloud Platform project. Required. Example: projects/my-project
-       * @param {string=} params.serviceFilter.service The exact value to match against [`ServiceContext.service`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
-       * @param {string=} params.groupId The group for which events shall be returned. Required.
-       * @param {string=} params.serviceFilter.version The exact value to match against [`ServiceContext.version`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
-       * @param {integer=} params.pageSize The maximum number of results to return per response.
-       * @param {string=} params.pageToken A `next_page_token` provided by a previous response.
+       * @param {string} params.projectName [Required] The resource name of the Google Cloud Platform project. Written as `projects/` plus the [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840). Example: `projects/my-project-123`.
+       * @param {string=} params.serviceFilter.service [Optional] The exact value to match against [`ServiceContext.service`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
+       * @param {string=} params.groupId [Required] The group for which events shall be returned.
+       * @param {string=} params.serviceFilter.version [Optional] The exact value to match against [`ServiceContext.version`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
+       * @param {integer=} params.pageSize [Optional] The maximum number of results to return per response.
+       * @param {string=} params.pageToken [Optional] A `next_page_token` provided by a previous response.
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
@@ -118,7 +118,7 @@ function Clouderrorreporting(options) { // eslint-disable-line
        * @memberOf! clouderrorreporting(v1beta1)
        *
        * @param {object} params Parameters for request
-       * @param {string} params.name Group resource name. Example: `projects/my-project-123/groups/my-groupid`
+       * @param {string} params.name The group resource name. Example: <code>projects/my-project-123/groups/my-groupid</code>
        * @param {object} params.resource Request body data
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
@@ -147,7 +147,7 @@ function Clouderrorreporting(options) { // eslint-disable-line
        * @memberOf! clouderrorreporting(v1beta1)
        *
        * @param {object} params Parameters for request
-       * @param {string} params.groupName Group resource name. Required. Example: `projects/my-project-123/groups/my-group`
+       * @param {string} params.groupName [Required] The group resource name. Written as <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>. Call <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list"> <code>groupStats.list</code></a> to return a list of groups belonging to this project.  Example: <code>projects/my-project-123/groups/my-group</code>
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
@@ -178,17 +178,17 @@ function Clouderrorreporting(options) { // eslint-disable-line
        * @memberOf! clouderrorreporting(v1beta1)
        *
        * @param {object} params Parameters for request
-       * @param {string=} params.alignment The alignment of the timed counts to be returned. Default is `ALIGNMENT_EQUAL_AT_END`.
+       * @param {string=} params.alignment [Optional] The alignment of the timed counts to be returned. Default is `ALIGNMENT_EQUAL_AT_END`.
        * @param {string=} params.timeRange.period Restricts the query to the specified time range.
-       * @param {string} params.projectName The resource name of the Google Cloud Platform project. Written as `projects/` plus the [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840). Required. Example: `projects/my-project-123`.
-       * @param {string=} params.order The sort order in which the results are returned. Default is `COUNT_DESC`.
-       * @param {string=} params.groupId List all `ErrorGroupStats` with these IDs. If not specified, all error group stats with a non-zero error count for the given selection criteria are returned.
-       * @param {string=} params.serviceFilter.service The exact value to match against [`ServiceContext.service`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
-       * @param {string=} params.alignmentTime Time where the timed counts shall be aligned if rounded alignment is chosen. Default is 00:00 UTC.
-       * @param {string=} params.serviceFilter.version The exact value to match against [`ServiceContext.version`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
-       * @param {integer=} params.pageSize The maximum number of results to return per response. Default is 20.
-       * @param {string=} params.timedCountDuration The preferred duration for a single returned `TimedCount`. If not set, no timed counts are returned.
-       * @param {string=} params.pageToken A `next_page_token` provided by a previous response. To view additional results, pass this token along with the identical query parameters as the first request.
+       * @param {string} params.projectName [Required] The resource name of the Google Cloud Platform project. Written as <code>projects/</code> plus the <a href="https://support.google.com/cloud/answer/6158840">Google Cloud Platform project ID</a>.  Example: <code>projects/my-project-123</code>.
+       * @param {string=} params.order [Optional] The sort order in which the results are returned. Default is `COUNT_DESC`.
+       * @param {string=} params.groupId [Optional] List all <code>ErrorGroupStats</code> with these IDs. If not specified, all error group stats with a non-zero error count for the given selection criteria are returned.
+       * @param {string=} params.serviceFilter.service [Optional] The exact value to match against [`ServiceContext.service`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
+       * @param {string=} params.alignmentTime [Optional] Time where the timed counts shall be aligned if rounded alignment is chosen. Default is 00:00 UTC.
+       * @param {string=} params.serviceFilter.version [Optional] The exact value to match against [`ServiceContext.version`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
+       * @param {integer=} params.pageSize [Optional] The maximum number of results to return per response. Default is 20.
+       * @param {string=} params.timedCountDuration [Optional] The preferred duration for a single returned `TimedCount`. If not set, no timed counts are returned.
+       * @param {string=} params.pageToken [Optional] A `next_page_token` provided by a previous response. To view additional results, pass this token along with the identical query parameters as the first request.
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */

--- a/apis/cloudresourcemanager/v1.js
+++ b/apis/cloudresourcemanager/v1.js
@@ -131,7 +131,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.projects.delete
      *
-     * @desc Marks the Project identified by the specified `project_id` (for example, `my-project-123`) for deletion. This method will only affect the Project if the following criteria are met: + The Project does not have a billing account associated with it. + The Project has a lifecycle state of ACTIVE. This method changes the Project's lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts at an unspecified time, at which point the lifecycle state changes to DELETE_IN_PROGRESS. Until the deletion completes, you can check the lifecycle state checked by retrieving the Project with GetProject, and the Project remains visible to ListProjects. However, you cannot update the project. After the deletion completes, the Project is not retrievable by the GetProject and ListProjects methods. The caller must have modify permissions for this Project.
+     * @desc Marks the Project identified by the specified `project_id` (for example, `my-project-123`) for deletion. This method will only affect the Project if the following criteria are met: + The Project does not have a billing account associated with it. + The Project has a lifecycle state of ACTIVE. This method changes the Project's lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts at an unspecified time, at which point the Project is no longer accessible. Until the deletion completes, you can check the lifecycle state checked by retrieving the Project with GetProject, and the Project remains visible to ListProjects. However, you cannot update the project. After the deletion completes, the Project is not retrievable by the GetProject and ListProjects methods. The caller must have modify permissions for this Project.
      *
      * @alias cloudresourcemanager.projects.delete
      * @memberOf! cloudresourcemanager(v1)
@@ -159,7 +159,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.projects.undelete
      *
-     * @desc Restores the Project identified by the specified `project_id` (for example, `my-project-123`). You can only use this method for a Project that has a lifecycle state of DELETE_REQUESTED. After deletion starts, as indicated by a lifecycle state of DELETE_IN_PROGRESS, the Project cannot be restored. The caller must have modify permissions for this Project.
+     * @desc Restores the Project identified by the specified `project_id` (for example, `my-project-123`). You can only use this method for a Project that has a lifecycle state of DELETE_REQUESTED. After deletion starts, the Project cannot be restored. The caller must have modify permissions for this Project.
      *
      * @alias cloudresourcemanager.projects.undelete
      * @memberOf! cloudresourcemanager(v1)
@@ -217,7 +217,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.projects.setIamPolicy
      *
-     * @desc Sets the IAM access control policy for the specified Project. Replaces any existing policy. The following constraints apply when using `setIamPolicy()`: + Project currently supports only `user:{emailid}` and `serviceAccount:{emailid}` members in a `Binding` of a `Policy`. + To be added as an `owner`, a user must be invited via Cloud Platform console and must accept the invitation. + Members cannot be added to more than one role in the same policy. + There must be at least one owner who has accepted the Terms of Service (ToS) agreement in the policy. Calling `setIamPolicy()` to to remove the last ToS-accepted owner from the policy will fail. + Calling this method requires enabling the App Engine Admin API. Note: Removing service accounts from policies or changing their roles can render services completely inoperable. It is important to understand how the service account is being used before removing or updating its roles.
+     * @desc Sets the IAM access control policy for the specified Project. Replaces any existing policy. The following constraints apply when using `setIamPolicy()`: + Project does not support `allUsers` and `allAuthenticatedUsers` as `members` in a `Binding` of a `Policy`. + The owner role can be granted only to `user` and `serviceAccount`. + Service accounts can be made owners of a project directly without any restrictions. However, to be added as an owner, a user must be invited via Cloud Platform console and must accept the invitation. + A user cannot be granted the owner role using `setIamPolicy()`. The user must be granted the owner role using the Cloud Platform Console and must explicitly accept the invitation. + Invitations to grant the owner role cannot be sent using `setIamPolicy()`; they must be sent only using the Cloud Platform Console. + Membership changes that leave the project without any owners that have accepted the Terms of Service (ToS) will be rejected. + Members cannot be added to more than one role in the same policy. + There must be at least one owner who has accepted the Terms of Service (ToS) agreement in the policy. Calling `setIamPolicy()` to to remove the last ToS-accepted owner from the policy will fail. This restriction also applies to legacy projects that no longer have owners who have accepted the ToS. Edits to IAM policies will be rejected until the lack of a ToS-accepting owner is rectified. + Calling this method requires enabling the App Engine Admin API. Note: Removing service accounts from policies or changing their roles can render services completely inoperable. It is important to understand how the service account is being used before removing or updating its roles.
      *
      * @alias cloudresourcemanager.projects.setIamPolicy
      * @memberOf! cloudresourcemanager(v1)
@@ -266,6 +266,38 @@ function Cloudresourcemanager(options) { // eslint-disable-line
         params: params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  self.operations = {
+
+    /**
+     * cloudresourcemanager.operations.get
+     *
+     * @desc Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.
+     *
+     * @alias cloudresourcemanager.operations.get
+     * @memberOf! cloudresourcemanager(v1)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.name The name of the operation resource.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://cloudresourcemanager.googleapis.com/v1/{name}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
         context: self
       };
 

--- a/apis/cloudresourcemanager/v1beta1.js
+++ b/apis/cloudresourcemanager/v1beta1.js
@@ -159,7 +159,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.projects.delete
      *
-     * @desc Marks the Project identified by the specified `project_id` (for example, `my-project-123`) for deletion. This method will only affect the Project if the following criteria are met: + The Project does not have a billing account associated with it. + The Project has a lifecycle state of ACTIVE. This method changes the Project's lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts at an unspecified time, at which point the lifecycle state changes to DELETE_IN_PROGRESS. Until the deletion completes, you can check the lifecycle state checked by retrieving the Project with GetProject, and the Project remains visible to ListProjects. However, you cannot update the project. After the deletion completes, the Project is not retrievable by the GetProject and ListProjects methods. The caller must have modify permissions for this Project.
+     * @desc Marks the Project identified by the specified `project_id` (for example, `my-project-123`) for deletion. This method will only affect the Project if the following criteria are met: + The Project does not have a billing account associated with it. + The Project has a lifecycle state of ACTIVE. This method changes the Project's lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts at an unspecified time, at which point the project is no longer accessible. Until the deletion completes, you can check the lifecycle state checked by retrieving the Project with GetProject, and the Project remains visible to ListProjects. However, you cannot update the project. After the deletion completes, the Project is not retrievable by the GetProject and ListProjects methods. The caller must have modify permissions for this Project.
      *
      * @alias cloudresourcemanager.projects.delete
      * @memberOf! cloudresourcemanager(v1beta1)
@@ -187,7 +187,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.projects.undelete
      *
-     * @desc Restores the Project identified by the specified `project_id` (for example, `my-project-123`). You can only use this method for a Project that has a lifecycle state of DELETE_REQUESTED. After deletion starts, as indicated by a lifecycle state of DELETE_IN_PROGRESS, the Project cannot be restored. The caller must have modify permissions for this Project.
+     * @desc Restores the Project identified by the specified `project_id` (for example, `my-project-123`). You can only use this method for a Project that has a lifecycle state of DELETE_REQUESTED. After deletion starts, the Project cannot be restored. The caller must have modify permissions for this Project.
      *
      * @alias cloudresourcemanager.projects.undelete
      * @memberOf! cloudresourcemanager(v1beta1)
@@ -274,7 +274,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.projects.setIamPolicy
      *
-     * @desc Sets the IAM access control policy for the specified Project. Replaces any existing policy. The following constraints apply when using `setIamPolicy()`: + Project currently supports only `user:{emailid}` and `serviceAccount:{emailid}` members in a `Binding` of a `Policy`. + To be added as an `owner`, a user must be invited via Cloud Platform console and must accept the invitation. + Members cannot be added to more than one role in the same policy. + There must be at least one owner who has accepted the Terms of Service (ToS) agreement in the policy. Calling `setIamPolicy()` to to remove the last ToS-accepted owner from the policy will fail. + Calling this method requires enabling the App Engine Admin API. Note: Removing service accounts from policies or changing their roles can render services completely inoperable. It is important to understand how the service account is being used before removing or updating its roles.
+     * @desc Sets the IAM access control policy for the specified Project. Replaces any existing policy. The following constraints apply when using `setIamPolicy()`: + Project does not support `allUsers` and `allAuthenticatedUsers` as `members` in a `Binding` of a `Policy`. + The owner role can be granted only to `user` and `serviceAccount`. + Service accounts can be made owners of a project directly without any restrictions. However, to be added as an owner, a user must be invited via Cloud Platform console and must accept the invitation. + A user cannot be granted the owner role using `setIamPolicy()`. The user must be granted the owner role using the Cloud Platform Console and must explicitly accept the invitation. + Invitations to grant the owner role cannot be sent using `setIamPolicy()`; they must be sent only using the Cloud Platform Console. + Membership changes that leave the project without any owners that have accepted the Terms of Service (ToS) will be rejected. + Members cannot be added to more than one role in the same policy. + There must be at least one owner who has accepted the Terms of Service (ToS) agreement in the policy. Calling `setIamPolicy()` to to remove the last ToS-accepted owner from the policy will fail. This restriction also applies to legacy projects that no longer have owners who have accepted the ToS. Edits to IAM policies will be rejected until the lack of a ToS-accepting owner is rectified. + Calling this method requires enabling the App Engine Admin API. Note: Removing service accounts from policies or changing their roles can render services completely inoperable. It is important to understand how the service account is being used before removing or updating its roles.
      *
      * @alias cloudresourcemanager.projects.setIamPolicy
      * @memberOf! cloudresourcemanager(v1beta1)
@@ -366,25 +366,26 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.organizations.get
      *
-     * @desc Fetches an Organization resource identified by the specified `organization_id`.
+     * @desc Fetches an Organization resource identified by the specified resource name.
      *
      * @alias cloudresourcemanager.organizations.get
      * @memberOf! cloudresourcemanager(v1beta1)
      *
      * @param {object} params Parameters for request
-     * @param {string} params.organizationId The id of the Organization resource to fetch.
+     * @param {string} params.name The resource name of the Organization to fetch. Its format is "organizations/[organization_id]". For example, "organizations/1234".
+     * @param {string=} params.organizationId The id of the Organization resource to fetch. This field is deprecated and will be removed in v1. Use name instead.
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     get: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/organizations/{organizationId}',
+          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/{name}',
           method: 'GET'
         },
         params: params,
-        requiredParams: ['organizationId'],
-        pathParams: ['organizationId'],
+        requiredParams: ['name'],
+        pathParams: ['name'],
         context: self
       };
 
@@ -394,13 +395,13 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.organizations.update
      *
-     * @desc Updates an Organization resource identified by the specified `organization_id`.
+     * @desc Updates an Organization resource identified by the specified resource name.
      *
      * @alias cloudresourcemanager.organizations.update
      * @memberOf! cloudresourcemanager(v1beta1)
      *
      * @param {object} params Parameters for request
-     * @param {string} params.organizationId An immutable id for the Organization that is assigned on creation. This should be omitted when creating a new Organization. This field is read-only.
+     * @param {string} params.name Output Only. The resource name of the organization. This is the organization's relative path in the API. Its format is "organizations/[organization_id]". For example, "organizations/1234".
      * @param {object} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
@@ -408,12 +409,12 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     update: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/organizations/{organizationId}',
+          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/{name}',
           method: 'PUT'
         },
         params: params,
-        requiredParams: ['organizationId'],
-        pathParams: ['organizationId'],
+        requiredParams: ['name'],
+        pathParams: ['name'],
         context: self
       };
 
@@ -423,7 +424,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.organizations.setIamPolicy
      *
-     * @desc Sets the access control policy on an Organization resource. Replaces any existing policy.
+     * @desc Sets the access control policy on an Organization resource. Replaces any existing policy. The `resource` field should be the organization's resource name, e.g. "organizations/123". For backward compatibility, the resource provided may also be the organization_id. This will not be supported in v1.
      *
      * @alias cloudresourcemanager.organizations.setIamPolicy
      * @memberOf! cloudresourcemanager(v1beta1)
@@ -437,7 +438,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     setIamPolicy: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/organizations/{resource}:setIamPolicy',
+          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/{resource}:setIamPolicy',
           method: 'POST'
         },
         params: params,
@@ -452,7 +453,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.organizations.getIamPolicy
      *
-     * @desc Gets the access control policy for an Organization resource. May be empty if no such policy or resource exists.
+     * @desc Gets the access control policy for an Organization resource. May be empty if no such policy or resource exists. The `resource` field should be the organization's resource name, e.g. "organizations/123". For backward compatibility, the resource provided may also be the organization_id. This will not be supported in v1.
      *
      * @alias cloudresourcemanager.organizations.getIamPolicy
      * @memberOf! cloudresourcemanager(v1beta1)
@@ -466,7 +467,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     getIamPolicy: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/organizations/{resource}:getIamPolicy',
+          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/{resource}:getIamPolicy',
           method: 'POST'
         },
         params: params,
@@ -481,7 +482,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     /**
      * cloudresourcemanager.organizations.testIamPermissions
      *
-     * @desc Returns permissions that a caller has on the specified Organization.
+     * @desc Returns permissions that a caller has on the specified Organization. The `resource` field should be the organization's resource name, e.g. "organizations/123". For backward compatibility, the resource provided may also be the organization_id. This will not be supported in v1.
      *
      * @alias cloudresourcemanager.organizations.testIamPermissions
      * @memberOf! cloudresourcemanager(v1beta1)
@@ -495,7 +496,7 @@ function Cloudresourcemanager(options) { // eslint-disable-line
     testIamPermissions: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/organizations/{resource}:testIamPermissions',
+          url: 'https://cloudresourcemanager.googleapis.com/v1beta1/{resource}:testIamPermissions',
           method: 'POST'
         },
         params: params,

--- a/apis/compute/alpha.js
+++ b/apis/compute/alpha.js
@@ -4659,6 +4659,37 @@ function Compute(options) { // eslint-disable-line
     },
 
     /**
+     * compute.instances.setServiceAccount
+     *
+     * @desc Sets the service account on the instance.
+     *
+     * @alias compute.instances.setServiceAccount
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.instance Name of the instance resource to start.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.zone The name of the zone for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    setServiceAccount: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/zones/{zone}/instances/{instance}/setServiceAccount',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'zone', 'instance'],
+        pathParams: ['instance', 'project', 'zone'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
      * compute.instances.setTags
      *
      * @desc Sets tags for the specified instance to the data included in the request.
@@ -5097,6 +5128,35 @@ function Compute(options) { // eslint-disable-line
     },
 
     /**
+     * compute.networks.switchToCustomMode
+     *
+     * @desc Switches the network mode from auto subnet mode to custom subnet mode.
+     *
+     * @alias compute.networks.switchToCustomMode
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.network Name of the network to be updated.
+     * @param {string} params.project Project ID for this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    switchToCustomMode: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/global/networks/{network}/switchToCustomMode',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'network'],
+        pathParams: ['network', 'project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
      * compute.networks.testIamPermissions
      *
      * @desc Returns permissions that a caller has on the specified resource.
@@ -5488,6 +5548,257 @@ function Compute(options) { // eslint-disable-line
         params: params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  self.regionBackendServices = {
+
+    /**
+     * compute.regionBackendServices.delete
+     *
+     * @desc Deletes the specified regional BackendService resource.
+     *
+     * @alias compute.regionBackendServices.delete
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.backendService Name of the BackendService resource to delete.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices/{backendService}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'backendService'],
+        pathParams: ['backendService', 'project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionBackendServices.get
+     *
+     * @desc Returns the specified regional BackendService resource.
+     *
+     * @alias compute.regionBackendServices.get
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.backendService Name of the BackendService resource to return.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices/{backendService}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'backendService'],
+        pathParams: ['backendService', 'project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionBackendServices.getHealth
+     *
+     * @desc Gets the most recent health check results for this regional BackendService.
+     *
+     * @alias compute.regionBackendServices.getHealth
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.backendService Name of the BackendService resource to which the queried instance belongs.
+     * @param {string} params.project 
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    getHealth: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices/{backendService}/getHealth',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'backendService'],
+        pathParams: ['backendService', 'project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionBackendServices.insert
+     *
+     * @desc Creates a regional BackendService resource in the specified project using the data included in the request. There are several restrictions and guidelines to keep in mind when creating a regional backend service. Read  Restrictions and Guidelines for more information.
+     *
+     * @alias compute.regionBackendServices.insert
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    insert: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'region'],
+        pathParams: ['project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionBackendServices.list
+     *
+     * @desc Retrieves the list of regional BackendService resources available to the specified project in the given region.
+     *
+     * @alias compute.regionBackendServices.list
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string=} params.filter Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use filter=name ne example-instance.  Compute Engine Beta API Only: When filtering in the Beta API, you can also filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  The Beta API also supports filtering on multiple expressions by providing each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+     * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.
+     * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+     * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'region'],
+        pathParams: ['project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionBackendServices.patch
+     *
+     * @desc Update the entire content of the regional BackendService resource. There are several restrictions and guidelines to keep in mind when updating a backend service. Read  Restrictions and Guidelines for more information. This method supports patch semantics.
+     *
+     * @alias compute.regionBackendServices.patch
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.backendService Name of the BackendService resource to update.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices/{backendService}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'backendService'],
+        pathParams: ['backendService', 'project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionBackendServices.testIamPermissions
+     *
+     * @desc Returns permissions that a caller has on the specified resource.
+     *
+     * @alias compute.regionBackendServices.testIamPermissions
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region The name of the region for this request.
+     * @param {string} params.resource_ Name of the resource for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    testIamPermissions: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices/{resource}/testIamPermissions',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'resource'],
+        pathParams: ['project', 'region', 'resource'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionBackendServices.update
+     *
+     * @desc Update the entire content of the regional BackendService resource. There are several restrictions and guidelines to keep in mind when updating a backend service. Read  Restrictions and Guidelines for more information.
+     *
+     * @alias compute.regionBackendServices.update
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.backendService Name of the BackendService resource to update.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    update: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices/{backendService}',
+          method: 'PUT'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'backendService'],
+        pathParams: ['backendService', 'project', 'region'],
         context: self
       };
 
@@ -6154,41 +6465,6 @@ function Compute(options) { // eslint-disable-line
         params: params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: self
-      };
-
-      return createAPIRequest(parameters, callback);
-    }
-
-  };
-
-  self.regionalBackendServices = {
-
-    /**
-     * compute.regionalBackendServices.testIamPermissions
-     *
-     * @desc Returns permissions that a caller has on the specified resource.
-     *
-     * @alias compute.regionalBackendServices.testIamPermissions
-     * @memberOf! compute(alpha)
-     *
-     * @param {object} params Parameters for request
-     * @param {string} params.project Project ID for this request.
-     * @param {string} params.region The name of the region for this request.
-     * @param {string} params.resource_ Name of the resource for this request.
-     * @param {object} params.resource Request body data
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    testIamPermissions: function (params, callback) {
-      var parameters = {
-        options: {
-          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/backendServices/{resource}/testIamPermissions',
-          method: 'POST'
-        },
-        params: params,
-        requiredParams: ['project', 'region', 'resource'],
-        pathParams: ['project', 'region', 'resource'],
         context: self
       };
 
@@ -7100,6 +7376,37 @@ function Compute(options) { // eslint-disable-line
     },
 
     /**
+     * compute.subnetworks.expandIpCidrRange
+     *
+     * @desc Expands the IP CIDR range of the subnetwork to a specified value.
+     *
+     * @alias compute.subnetworks.expandIpCidrRange
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {string} params.subnetwork Name of the Subnetwork resource to update.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    expandIpCidrRange: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/subnetworks/{subnetwork}/expandIpCidrRange',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'subnetwork'],
+        pathParams: ['project', 'region', 'subnetwork'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
      * compute.subnetworks.get
      *
      * @desc Returns the specified subnetwork. Get a list of available subnetworks list() request.
@@ -7123,6 +7430,36 @@ function Compute(options) { // eslint-disable-line
         params: params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.subnetworks.getIamPolicy
+     *
+     * @desc Gets the access control policy for a resource. May be empty if no such policy or resource exists.
+     *
+     * @alias compute.subnetworks.getIamPolicy
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region The name of the region for this request.
+     * @param {string} params.resource_ Name of the resource for this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    getIamPolicy: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/subnetworks/{resource}/getIamPolicy',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'resource'],
+        pathParams: ['project', 'region', 'resource'],
         context: self
       };
 
@@ -7186,6 +7523,37 @@ function Compute(options) { // eslint-disable-line
         params: params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.subnetworks.setIamPolicy
+     *
+     * @desc Sets the access control policy on the specified resource. Replaces any existing policy.
+     *
+     * @alias compute.subnetworks.setIamPolicy
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region The name of the region for this request.
+     * @param {string} params.resource_ Name of the resource for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    setIamPolicy: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/subnetworks/{resource}/setIamPolicy',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'resource'],
+        pathParams: ['project', 'region', 'resource'],
         context: self
       };
 

--- a/apis/compute/beta.js
+++ b/apis/compute/beta.js
@@ -2003,6 +2003,219 @@ function Compute(options) { // eslint-disable-line
 
   };
 
+  self.healthChecks = {
+
+    /**
+     * compute.healthChecks.delete
+     *
+     * @desc Deletes the specified HealthCheck resource.
+     *
+     * @alias compute.healthChecks.delete
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.healthCheck Name of the HealthCheck resource to delete.
+     * @param {string} params.project Project ID for this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/healthChecks/{healthCheck}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['project', 'healthCheck'],
+        pathParams: ['healthCheck', 'project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.healthChecks.get
+     *
+     * @desc Returns the specified HealthCheck resource. Get a list of available health checks by making a list() request.
+     *
+     * @alias compute.healthChecks.get
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.healthCheck Name of the HealthCheck resource to return.
+     * @param {string} params.project Project ID for this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/healthChecks/{healthCheck}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'healthCheck'],
+        pathParams: ['healthCheck', 'project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.healthChecks.insert
+     *
+     * @desc Creates a HealthCheck resource in the specified project using the data included in the request.
+     *
+     * @alias compute.healthChecks.insert
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    insert: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/healthChecks',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project'],
+        pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.healthChecks.list
+     *
+     * @desc Retrieves the list of HealthCheck resources available to the specified project.
+     *
+     * @alias compute.healthChecks.list
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string=} params.filter Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use filter=name ne example-instance.  Compute Engine Beta API Only: When filtering in the Beta API, you can also filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  The Beta API also supports filtering on multiple expressions by providing each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+     * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.
+     * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+     * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+     * @param {string} params.project Project ID for this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/healthChecks',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project'],
+        pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.healthChecks.patch
+     *
+     * @desc Updates a HealthCheck resource in the specified project using the data included in the request. This method supports patch semantics.
+     *
+     * @alias compute.healthChecks.patch
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.healthCheck Name of the HealthCheck resource to update.
+     * @param {string} params.project Project ID for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/healthChecks/{healthCheck}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['project', 'healthCheck'],
+        pathParams: ['healthCheck', 'project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.healthChecks.testIamPermissions
+     *
+     * @desc Returns permissions that a caller has on the specified resource.
+     *
+     * @alias compute.healthChecks.testIamPermissions
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.resource_ Name of the resource for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    testIamPermissions: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/healthChecks/{resource}/testIamPermissions',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'resource'],
+        pathParams: ['project', 'resource'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.healthChecks.update
+     *
+     * @desc Updates a HealthCheck resource in the specified project using the data included in the request.
+     *
+     * @alias compute.healthChecks.update
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.healthCheck Name of the HealthCheck resource to update.
+     * @param {string} params.project Project ID for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    update: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/healthChecks/{healthCheck}',
+          method: 'PUT'
+        },
+        params: params,
+        requiredParams: ['project', 'healthCheck'],
+        pathParams: ['healthCheck', 'project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
   self.httpHealthChecks = {
 
     /**
@@ -6748,6 +6961,249 @@ function Compute(options) { // eslint-disable-line
         params: params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
+
+  self.targetSslProxies = {
+
+    /**
+     * compute.targetSslProxies.delete
+     *
+     * @desc Deletes the specified TargetSslProxy resource.
+     *
+     * @alias compute.targetSslProxies.delete
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.targetSslProxy Name of the TargetSslProxy resource to delete.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies/{targetSslProxy}',
+          method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['project', 'targetSslProxy'],
+        pathParams: ['project', 'targetSslProxy'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.targetSslProxies.get
+     *
+     * @desc Returns the specified TargetSslProxy resource. Get a list of available target SSL proxies by making a list() request.
+     *
+     * @alias compute.targetSslProxies.get
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.targetSslProxy Name of the TargetSslProxy resource to return.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies/{targetSslProxy}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project', 'targetSslProxy'],
+        pathParams: ['project', 'targetSslProxy'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.targetSslProxies.insert
+     *
+     * @desc Creates a TargetSslProxy resource in the specified project using the data included in the request.
+     *
+     * @alias compute.targetSslProxies.insert
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    insert: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project'],
+        pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.targetSslProxies.list
+     *
+     * @desc Retrieves the list of TargetSslProxy resources available to the specified project.
+     *
+     * @alias compute.targetSslProxies.list
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string=} params.filter Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use filter=name ne example-instance.  Compute Engine Beta API Only: When filtering in the Beta API, you can also filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  The Beta API also supports filtering on multiple expressions by providing each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+     * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.
+     * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+     * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+     * @param {string} params.project Project ID for this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project'],
+        pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.targetSslProxies.setBackendService
+     *
+     * @desc Changes the BackendService for TargetSslProxy.
+     *
+     * @alias compute.targetSslProxies.setBackendService
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.targetSslProxy Name of the TargetSslProxy resource whose BackendService resource is to be set.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    setBackendService: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies/{targetSslProxy}/setBackendService',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'targetSslProxy'],
+        pathParams: ['project', 'targetSslProxy'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.targetSslProxies.setProxyHeader
+     *
+     * @desc Changes the ProxyHeaderType for TargetSslProxy.
+     *
+     * @alias compute.targetSslProxies.setProxyHeader
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.targetSslProxy Name of the TargetSslProxy resource whose ProxyHeader is to be set.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    setProxyHeader: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies/{targetSslProxy}/setProxyHeader',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'targetSslProxy'],
+        pathParams: ['project', 'targetSslProxy'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.targetSslProxies.setSslCertificates
+     *
+     * @desc Changes SslCertificates for TargetSslProxy.
+     *
+     * @alias compute.targetSslProxies.setSslCertificates
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.targetSslProxy Name of the TargetSslProxy resource whose SslCertificate resource is to be set.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    setSslCertificates: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies/{targetSslProxy}/setSslCertificates',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'targetSslProxy'],
+        pathParams: ['project', 'targetSslProxy'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.targetSslProxies.testIamPermissions
+     *
+     * @desc Returns permissions that a caller has on the specified resource.
+     *
+     * @alias compute.targetSslProxies.testIamPermissions
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.resource_ Name of the resource for this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    testIamPermissions: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/targetSslProxies/{resource}/testIamPermissions',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'resource'],
+        pathParams: ['project', 'resource'],
         context: self
       };
 

--- a/apis/compute/v1.js
+++ b/apis/compute/v1.js
@@ -14568,6 +14568,36 @@ function Compute(options) { // eslint-disable-line
     },
 
     /**
+     * compute.urlMaps.invalidateCache
+     *
+     * @desc Initiates a cache invalidation operation, invalidating the specified path, scoped to the specified UrlMap.
+     *
+     * @alias compute.urlMaps.invalidateCache
+     * @memberOf! compute(v1)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.urlMap Name of the UrlMap scoping this request.
+     * @param {object} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    invalidateCache: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/v1/projects/{project}/global/urlMaps/{urlMap}/invalidateCache',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'urlMap'],
+        pathParams: ['project', 'urlMap'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
      * compute.urlMaps.list
      *
      * @desc Retrieves the list of UrlMap resources available to the specified project.

--- a/apis/fitness/v1.js
+++ b/apis/fitness/v1.js
@@ -23,7 +23,7 @@ var createAPIRequest = require('../../lib/apirequest');
 /**
  * Fitness
  *
- * Google Fit API
+ * Stores and accesses user data in the fitness store from apps on any platform.
  *
  * @example
  * var google = require('googleapis');
@@ -75,7 +75,7 @@ function Fitness(options) { // eslint-disable-line
       /**
        * fitness.users.dataSources.delete
        *
-       * @desc Delete the data source if there are no datapoints associated with it
+       * @desc Deletes the specified data source. The request will fail if the data source contains any data points.
        *
        * @alias fitness.users.dataSources.delete
        * @memberOf! fitness(v1)
@@ -104,7 +104,7 @@ function Fitness(options) { // eslint-disable-line
       /**
        * fitness.users.dataSources.get
        *
-       * @desc Returns a data source identified by a data stream ID.
+       * @desc Returns the specified data source.
        *
        * @alias fitness.users.dataSources.get
        * @memberOf! fitness(v1)
@@ -133,7 +133,7 @@ function Fitness(options) { // eslint-disable-line
       /**
        * fitness.users.dataSources.list
        *
-       * @desc Lists all data sources that are visible to the developer, using the OAuth scopes provided. The list is not exhaustive: the user may have private data sources that are only visible to other developers or calls using other scopes.
+       * @desc Lists all data sources that are visible to the developer, using the OAuth scopes provided. The list is not exhaustive; the user may have private data sources that are only visible to other developers, or calls using other scopes.
        *
        * @alias fitness.users.dataSources.list
        * @memberOf! fitness(v1)
@@ -162,7 +162,7 @@ function Fitness(options) { // eslint-disable-line
       /**
        * fitness.users.dataSources.patch
        *
-       * @desc Updates a given data source. It is an error to modify the data source's data stream ID, data type, type, stream name or device information apart from the device version. Changing these fields would require a new unique data stream ID and separate data source.  Data sources are identified by their data stream ID. This method supports patch semantics.
+       * @desc Updates the specified data source. The dataStreamId, dataType, type, dataStreamName, and device properties with the exception of version, cannot be modified.  Data sources are identified by their dataStreamId. This method supports patch semantics.
        *
        * @alias fitness.users.dataSources.patch
        * @memberOf! fitness(v1)
@@ -192,7 +192,7 @@ function Fitness(options) { // eslint-disable-line
       /**
        * fitness.users.dataSources.update
        *
-       * @desc Updates a given data source. It is an error to modify the data source's data stream ID, data type, type, stream name or device information apart from the device version. Changing these fields would require a new unique data stream ID and separate data source.  Data sources are identified by their data stream ID.
+       * @desc Updates the specified data source. The dataStreamId, dataType, type, dataStreamName, and device properties with the exception of version, cannot be modified.  Data sources are identified by their dataStreamId.
        *
        * @alias fitness.users.dataSources.update
        * @memberOf! fitness(v1)

--- a/apis/genomics/v1.js
+++ b/apis/genomics/v1.js
@@ -23,7 +23,7 @@ var createAPIRequest = require('../../lib/apirequest');
 /**
  * Genomics API
  *
- * Stores, processes, explores and shares genomic data. This API implements the Global Alliance for Genomics and Health (GA4GH) v0.5.1 API as well as several extensions.
+ * Stores, processes, explores and shares genomic data.
  *
  * @example
  * var google = require('googleapis');

--- a/apis/genomics/v1alpha2.js
+++ b/apis/genomics/v1alpha2.js
@@ -23,7 +23,7 @@ var createAPIRequest = require('../../lib/apirequest');
 /**
  * Genomics API
  *
- * Stores, processes, explores and shares genomic data. This API implements the Global Alliance for Genomics and Health (GA4GH) v0.5.1 API as well as several extensions.
+ * Stores, processes, explores and shares genomic data.
  *
  * @example
  * var google = require('googleapis');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "description": "Google APIs Client Library for Node.js",


### PR DESCRIPTION
##### 9.0.0 - 20 June 2016

###### Breaking changes
- Removed `regionalBackendServices.testIamPermissions` from `compute` `alpha` API

###### Backwards compatible changes
- Added `appengine` `v1` API
- Added `instances.setServiceAccount` to `compute` `alpha` API
- Added `networks.switchToCustomMode` to `compute` `alpha` API
- Added `regionBackendServices.delete` to `compute` `alpha` API
- Added `regionBackendServices.get` to `compute` `alpha` API
- Added `regionBackendServices.getHealth` to `compute` `alpha` API
- Added `regionBackendServices.insert` to `compute` `alpha` API
- Added `regionBackendServices.list` to `compute` `alpha` API
- Added `regionBackendServices.patch` to `compute` `alpha` API
- Added `regionBackendServices.testIamPermissions` to `compute` `alpha` API
- Added `regionBackendServices.update` to `compute` `alpha` API
- Added `subnetworks.expandIpCidrRange` to `compute` `alpha` API
- Added `subnetworks.getIamPolicy` to `compute` `alpha` API
- Added `subnetworks.setIamPolicy` to `compute` `alpha` API
- Added `healthChecks.delete` to `compute` `beta` API
- Added `healthChecks.get` to `compute` `beta` API
- Added `healthChecks.insert` to `compute` `beta` API
- Added `healthChecks.list` to `compute` `beta` API
- Added `healthChecks.patch` to `compute` `beta` API
- Added `healthChecks.testIamPermissions` to `compute` `beta` API
- Added `healthChecks.update` to `compute` `beta` API
- Added `targetSslProxies.delete` to `compute` `beta` API
- Added `targetSslProxies.get` to `compute` `beta` API
- Added `targetSslProxies.insert` to `compute` `beta` API
- Added `targetSslProxies.list` to `compute` `beta` API
- Added `targetSslProxies.setBackendService` to `compute` `beta` API
- Added `targetSslProxies.setProxyHeader` to `compute` `beta` API
- Added `targetSslProxies.setSslCertificates` to `compute` `beta` API
- Added `targetSslProxies.testIamPermissions` to `compute` `beta` API
- Added `urlMaps.invalidateCache` to `compute` `v1` API