### PR TITLE
Upgrade request dependency, fixes #608

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "async": "~1.5.2",
     "gapitoken": "~0.1.5",
     "google-auth-library": "~0.9.7",
-    "request": "~2.72.0",
+    "request": "^2.74.0",
     "string-template": "~1.0.0",
     "url": "^0.11.0"
   },


### PR DESCRIPTION
Fixes #608.

- [x] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`


`tough-cookie`, a transitive dependency of this module via `request`, has a security vulnerability:

https://nodesecurity.io/advisories/130

`request` has already upgraded its dependency to fix the issue, so it's just a matter of bumping the version depended on here.