### PR TITLE
12.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+##### 12.3.0 - 17 August 2016
+
+###### Backwards compatible changes
+- Added `management.remarketingAudience.get` to `analytics` `v3` API
+- Added `management.remarketingAudience.insert` to `analytics` `v3` API
+- Added `management.remarketingAudience.list` to `analytics` `v3` API
+- Added `management.remarketingAudience.patch` to `analytics` `v3` API
+- Added `management.remarketingAudience.update` to `analytics` `v3` API
+- Added `userProfiles.guardianInvitations.list` to `classroom` `v1` API
+- Added `userProfiles.guardianInvitations.get` to `classroom` `v1` API
+- Added `userProfiles.guardianInvitations.create` to `classroom` `v1` API
+- Added `userProfiles.guardianInvitations.patch` to `classroom` `v1` API
+- Added `userProfiles.guardians.list` to `classroom` `v1` API
+- Added `userProfiles.guardians.get` to `classroom` `v1` API
+- Added `userProfiles.guardians.delete` to `classroom` `v1` API
+- Added `projects.triggers.create` to `cloudbuild` `v1` API
+- Added `projects.triggers.get` to `cloudbuild` `v1` API
+- Added `projects.triggers.list` to `cloudbuild` `v1` API
+- Added `projects.triggers.delete` to `cloudbuild` `v1` API
+- Added `projects.triggers.patch` to `cloudbuild` `v1` API
+- Added `backendServices.aggregatedList` to `compute` `alpha` API
+- Added `regionInstanceGroupManagers.patch` to `compute` `alpha` API
+- Added `regionInstanceGroupManagers.update` to `compute` `alpha` API
+- Added `networks.switchToCustomMode` to `compute` `beta` API
+- Added `subnetworks.expandIpCidrRange` to `compute` `beta` API
+- Added `shippingsettings.custombatch` to `content` `v2` API
+- Added `shippingsettings.get` to `content` `v2` API
+- Added `shippingsettings.getsupportedcarriers` to `content` `v2` API
+- Added `shippingsettings.list` to `content` `v2` API
+- Added `shippingsettings.patch` to `content` `v2` API
+- Added `shippingsettings.update` to `content` `v2` API
+- Added `datastore` `v1` API
+
 ##### 12.2.0 - 08 August 2016
 
 ###### Backwards compatible changes

--- a/apis/analytics/v3.js
+++ b/apis/analytics/v3.js
@@ -1738,6 +1738,163 @@ function Analytics(options) { // eslint-disable-line
       }
     },
 
+    remarketingAudience: {
+
+      /**
+       * analytics.management.remarketingAudience.get
+       *
+       * @desc Gets remarketing audiences to which the user has access.
+       *
+       * @alias analytics.management.remarketingAudience.get
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID for the remarketing audience to retrieve.
+       * @param {string} params.remarketingAudienceId The ID to retrieve the Remarketing Audience for.
+       * @param {string} params.webPropertyId Web property ID for the remarketing audience to retrieve.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://www.googleapis.com/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
+          pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * analytics.management.remarketingAudience.insert
+       *
+       * @desc Creates a new remarketing audiences.
+       *
+       * @alias analytics.management.remarketingAudience.insert
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to create the remarketing audience for.
+       * @param {string} params.webPropertyId Web property ID to create the remarketing audience for.
+       * @param {analytics(v3).RemarketingAudience} params.resource Request body data
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      insert: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://www.googleapis.com/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences',
+            method: 'POST'
+          },
+          params: params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * analytics.management.remarketingAudience.list
+       *
+       * @desc Lists remarketing audiences to which the user has access.
+       *
+       * @alias analytics.management.remarketingAudience.list
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID for the remarketing audience to retrieve.
+       * @param {integer=} params.max-results The maximum number of remarketing audiences to include in this response.
+       * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+       * @param {string=} params.type 
+       * @param {string} params.webPropertyId Web property ID for the remarketing audience to retrieve.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://www.googleapis.com/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * analytics.management.remarketingAudience.patch
+       *
+       * @desc Updates an existing remarketing audiences. This method supports patch semantics.
+       *
+       * @alias analytics.management.remarketingAudience.patch
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID for the remarketing audience to update.
+       * @param {string} params.remarketingAudienceId Remarketing audience ID of the remarketing audience to update.
+       * @param {string} params.webPropertyId Web property ID for the remarketing audience to update.
+       * @param {analytics(v3).RemarketingAudience} params.resource Request body data
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      patch: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://www.googleapis.com/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}',
+            method: 'PATCH'
+          },
+          params: params,
+          requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
+          pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * analytics.management.remarketingAudience.update
+       *
+       * @desc Updates an existing remarketing audiences.
+       *
+       * @alias analytics.management.remarketingAudience.update
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID for the remarketing audience to update.
+       * @param {string} params.remarketingAudienceId Remarketing audience ID of the remarketing audience to update.
+       * @param {string} params.webPropertyId Web property ID for the remarketing audience to update.
+       * @param {analytics(v3).RemarketingAudience} params.resource Request body data
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      update: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://www.googleapis.com/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}',
+            method: 'PUT'
+          },
+          params: params,
+          requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
+          pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      }
+    },
+
     segments: {
 
       /**
@@ -3051,6 +3208,31 @@ function Analytics(options) { // eslint-disable-line
  * @property {string} username Email ID of the authenticated user
  */
 /**
+ * @typedef IncludeConditions
+ * @memberOf! analytics(v3)
+ * @type object
+ * @property {integer} daysToLookBack The look-back window lets you specify a time frame for evaluating the behavior that qualifies users for your audience. For example, if your filters include users from Central Asia, and Transactions Greater than 2, and you set the look-back window to 14 days, then any user from Central Asia whose cumulative transactions exceed 2 during the last 14 days is added to the audience.
+ * @property {boolean} isSmartList Boolean indicating whether this segment is a smart list. https://support.google.com/analytics/answer/4628577
+ * @property {string} kind Resource type for include conditions.
+ * @property {integer} membershipDurationDays Number of days a user remains in the audience. Use any integer from 1-540. In remarketing audiences for search ads, membership duration is truncated to 180 days.
+ * @property {string} segment The segment condition that will cause a user to be added to an audience.
+ */
+/**
+ * @typedef LinkedForeignAccount
+ * @memberOf! analytics(v3)
+ * @type object
+ * @property {string} accountId Account ID to which this linked foreign account belongs.
+ * @property {boolean} eligibleForSearch Boolean indicating whether this is eligible for search.
+ * @property {string} id Entity ad account link ID.
+ * @property {string} internalWebPropertyId Internal ID for the web property to which this linked foreign account belongs.
+ * @property {string} kind Resource type for linked foreign account.
+ * @property {string} linkedAccountId The foreign account ID. For example the an AdWords `linkedAccountId` has the following format XXX-XXX-XXXX.
+ * @property {string} remarketingAudienceId Remarketing audience ID to which this linked foreign account belongs.
+ * @property {string} status The status of this foreign account link.
+ * @property {string} type The type of the foreign account. For example `ADWORDS_LINKS`.
+ * @property {string} webPropertyId Web property ID of the form UA-XXXXX-YY to which this linked foreign account belongs.
+ */
+/**
  * @typedef McfData
  * @memberOf! analytics(v3)
  * @type object
@@ -3176,6 +3358,38 @@ For write (i.e., create, update, or delete) operations, you may specify a value 
  * @property {string} selfLink Link to this page.
  * @property {integer} totalResults The total number of rows for the query, regardless of the number of rows in the response.
  * @property {object} totalsForAllResults Total values for the requested metrics over all the results, not just the results returned in this response. The order of the metric totals is same as the metric order specified in the request.
+ */
+/**
+ * @typedef RemarketingAudience
+ * @memberOf! analytics(v3)
+ * @type object
+ * @property {string} accountId Account ID to which this remarketing audience belongs.
+ * @property {object} audienceDefinition The simple audience definition that will cause a user to be added to an audience.
+ * @property {string} audienceType The type of audience, either SIMPLE or STATE_BASED.
+ * @property {string} created Time this remarketing audience was created.
+ * @property {string} description The description of this remarketing audience.
+ * @property {string} id Remarketing Audience ID.
+ * @property {string} internalWebPropertyId Internal ID for the web property to which this remarketing audience belongs.
+ * @property {string} kind Collection type.
+ * @property {analytics(v3).LinkedForeignAccount[]} linkedAdAccounts The linked ad accounts associated with this remarketing audience. A remarketing audience can have only one linkedAdAccount currently.
+ * @property {string[]} linkedViews The views (profiles) that this remarketing audience is linked to.
+ * @property {string} name The name of this remarketing audience.
+ * @property {object} stateBasedAudienceDefinition A state based audience definition that will cause a user to be added or removed from an audience.
+ * @property {string} updated Time this remarketing audience was last modified.
+ * @property {string} webPropertyId Web property ID of the form UA-XXXXX-YY to which this remarketing audience belongs.
+ */
+/**
+ * @typedef RemarketingAudiences
+ * @memberOf! analytics(v3)
+ * @type object
+ * @property {analytics(v3).RemarketingAudience[]} items A list of remarketing audiences.
+ * @property {integer} itemsPerPage The maximum number of resources the response can contain, regardless of the actual number of resources returned. Its value ranges from 1 to 1000 with a value of 1000 by default, or otherwise specified by the max-results query parameter.
+ * @property {string} kind Collection type.
+ * @property {string} nextLink Link to next page for this remarketing audience collection.
+ * @property {string} previousLink Link to previous page for this view (profile) collection.
+ * @property {integer} startIndex The starting index of the resources, which is 1 by default or otherwise specified by the start-index query parameter.
+ * @property {integer} totalResults The total number of results for the query, regardless of the number of results in the response.
+ * @property {string} username Email ID of the authenticated user
  */
 /**
  * @typedef Segment

--- a/apis/analyticsreporting/v4.js
+++ b/apis/analyticsreporting/v4.js
@@ -422,9 +422,10 @@ combined with `AND` operator.
  * @memberOf! analyticsreporting(v4)
  * @type object
 * @property {analyticsreporting(v4).Dimension[]} dimensions A list of dimensions to show as pivot columns. A Pivot can have a maximum
-of 4 dimensions.
+of 4 dimensions. Pivot dimensions are part of the restriction on the
+total number of dimensions allowed in the request.
 * @property {analyticsreporting(v4).Metric[]} metrics The pivot metrics. Pivot metrics are part of the
-restriction on total number of metrics in the request.
+restriction on total number of metrics allowed in the request.
 * @property {integer} maxGroupCount Specifies the maximum number of groups to return.
 The default value is 10, also the maximum value is 1,000.
 * @property {analyticsreporting(v4).DimensionFilterClause[]} dimensionFilterClauses DimensionFilterClauses are logically combined with an `AND` operator: only

--- a/apis/classroom/v1.js
+++ b/apis/classroom/v1.js
@@ -713,7 +713,7 @@ function Classroom(options) { // eslint-disable-line
          *
          * @param {object} params Parameters for request
          * @param {string} params.courseId Identifier of the course. This identifier can be either the Classroom-assigned identifier or an alias.
-         * @param {string} params.courseWorkId Identifer of the student work to request. If `user_id` is specified, this may be set to the string literal `"-"` to request student work for all course work in the specified course.
+         * @param {string} params.courseWorkId Identifer of the student work to request. This may be set to the string literal `"-"` to request student work for all course work in the specified course.
          * @param {string=} params.userId Optional argument to restrict returned student work to those owned by the student with the specified identifier. The identifier can be one of the following: * the numeric identifier for the user * the email address of the user * the string literal `"me"`, indicating the requesting user
          * @param {string=} params.states Requested submission states. If specified, returned student submissions match one of the specified submission states.
          * @param {string=} params.late Requested lateness value. If specified, returned student submissions are restricted by the requested value. If unspecified, submissions are returned regardless of `late` value.
@@ -864,6 +864,253 @@ function Classroom(options) { // eslint-disable-line
     }
   };
 
+  self.userProfiles = {
+
+    /**
+     * classroom.userProfiles.get
+     *
+     * @desc Returns a user profile. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access this user profile or if no profile exists with the requested ID or for access errors.
+     *
+     * @alias classroom.userProfiles.get
+     * @memberOf! classroom(v1)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.userId Identifier of the profile to return. The identifier can be one of the following: * the numeric identifier for the user * the email address of the user * the string literal `"me"`, indicating the requesting user
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://classroom.googleapis.com/v1/userProfiles/{userId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['userId'],
+        pathParams: ['userId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    guardianInvitations: {
+
+      /**
+       * classroom.userProfiles.guardianInvitations.list
+       *
+       * @desc Returns a list of guardian invitations that the requesting user is permitted to view, filtered by the parameters provided. This method returns the following error codes: * `PERMISSION_DENIED` if a `student_id` is specified, and the requesting user is not permitted to view guardian invitations for that student, if guardians are not enabled for the domain in question, or for other access errors. * `INVALID_ARGUMENT` if a `student_id` is specified, but its format cannot be recognized (it is not an email address, nor a `student_id` from the API, nor the literal string `me`). May also be returned if an invalid `page_token` or `state` is provided. * `NOT_FOUND` if a `student_id` is specified, and its format can be recognized, but Classroom has no record of that student.
+       *
+       * @alias classroom.userProfiles.guardianInvitations.list
+       * @memberOf! classroom(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.studentId The ID of the student whose guardian invitations are to be returned. The identifier can be one of the following: * the numeric identifier for the user * the email address of the user * the string literal `"me"`, indicating the requesting user
+       * @param {string=} params.invitedEmailAddress If specified, only results with the specified `invited_email_address` will be returned.
+       * @param {string=} params.states If specified, only results with the specified `state` values will be returned. Otherwise, results with a `state` of `PENDING` will be returned.
+       * @param {string=} params.pageToken nextPageToken value returned from a previous list call, indicating that the subsequent page of results should be returned. The list request must be otherwise identical to the one that resulted in this token.
+       * @param {integer=} params.pageSize Maximum number of items to return. Zero or unspecified indicates that the server may assign a maximum. The server may return fewer than the specified number of results.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://classroom.googleapis.com/v1/userProfiles/{studentId}/guardianInvitations',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['studentId'],
+          pathParams: ['studentId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * classroom.userProfiles.guardianInvitations.get
+       *
+       * @desc Returns a specific guardian invitation. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view guardian invitations for the student identified by the `student_id`, if guardians are not enabled for the domain in question, or for other access errors. * `INVALID_ARGUMENT` if a `student_id` is specified, but its format cannot be recognized (it is not an email address, nor a `student_id` from the API, nor the literal string `me`). * `NOT_FOUND` if Classroom cannot find any record of the given student or `invitation_id`. May also be returned if the student exists, but the requesting user does not have access to see that student.
+       *
+       * @alias classroom.userProfiles.guardianInvitations.get
+       * @memberOf! classroom(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.studentId The ID of the student whose guardian invitation is being requested.
+       * @param {string} params.invitationId The `id` field of the `GuardianInvitation` being requested.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://classroom.googleapis.com/v1/userProfiles/{studentId}/guardianInvitations/{invitationId}',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['studentId', 'invitationId'],
+          pathParams: ['studentId', 'invitationId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * classroom.userProfiles.guardianInvitations.create
+       *
+       * @desc Creates a guardian invitation, and sends an email to the guardian asking them to confirm that they are the student's guardian. Once the guardian accepts the invitation, their `state` will change to `COMPLETED` and they will start receiving guardian notifications. A `Guardian` resource will also be created to represent the active guardian. The request object must have the `student_id` and `invited_email_address` fields set. Failing to set these fields, or setting any other fields in the request, will result in an error. This method returns the following error codes: * `PERMISSION_DENIED` if the current user does not have permission to manage guardians, if the guardian in question has already rejected too many requests for that student, if guardians are not enabled for the domain in question, or for other access errors. * `RESOURCE_EXHAUSTED` if the student or guardian has exceeded the guardian link limit. * `INVALID_ARGUMENT` if the guardian email address is not valid (for example, if it is too long), or if the format of the student ID provided cannot be recognized (it is not an email address, nor a `user_id` from this API). This error will also be returned if read-only fields are set, or if the `state` field is set to to a value other than `PENDING`. * `NOT_FOUND` if the student ID provided is a valid student ID, but Classroom has no record of that student. * `ALREADY_EXISTS` if there is already a pending guardian invitation for the student and `invited_email_address` provided, or if the provided `invited_email_address` matches the Google account of an existing `Guardian` for this user.
+       *
+       * @alias classroom.userProfiles.guardianInvitations.create
+       * @memberOf! classroom(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.studentId ID of the student (in standard format)
+       * @param {classroom(v1).GuardianInvitation} params.resource Request body data
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      create: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://classroom.googleapis.com/v1/userProfiles/{studentId}/guardianInvitations',
+            method: 'POST'
+          },
+          params: params,
+          requiredParams: ['studentId'],
+          pathParams: ['studentId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * classroom.userProfiles.guardianInvitations.patch
+       *
+       * @desc Modifies a guardian invitation. Currently, the only valid modification is to change the `state` from `PENDING` to `COMPLETE`. This has the effect of withdrawing the invitation. This method returns the following error codes: * `PERMISSION_DENIED` if the current user does not have permission to manage guardians, if guardians are not enabled for the domain in question or for other access errors. * `FAILED_PRECONDITION` if the guardian link is not in the `PENDING` state. * `INVALID_ARGUMENT` if the format of the student ID provided cannot be recognized (it is not an email address, nor a `user_id` from this API), or if the passed `GuardianInvitation` has a `state` other than `COMPLETE`, or if it modifies fields other than `state`. * `NOT_FOUND` if the student ID provided is a valid student ID, but Classroom has no record of that student, or if the `id` field does not refer to a guardian invitation known to Classroom.
+       *
+       * @alias classroom.userProfiles.guardianInvitations.patch
+       * @memberOf! classroom(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.studentId The ID of the student whose guardian invitation is to be modified.
+       * @param {string} params.invitationId The `id` field of the `GuardianInvitation` to be modified.
+       * @param {string=} params.updateMask Mask that identifies which fields on the course to update. This field is required to do an update. The update will fail if invalid fields are specified. The following fields are valid: * `state` When set in a query parameter, this field should be specified as `updateMask=,,...`
+       * @param {classroom(v1).GuardianInvitation} params.resource Request body data
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      patch: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://classroom.googleapis.com/v1/userProfiles/{studentId}/guardianInvitations/{invitationId}',
+            method: 'PATCH'
+          },
+          params: params,
+          requiredParams: ['studentId', 'invitationId'],
+          pathParams: ['studentId', 'invitationId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      }
+    },
+
+    guardians: {
+
+      /**
+       * classroom.userProfiles.guardians.list
+       *
+       * @desc Returns a list of guardians that the requesting user is permitted to view, restricted to those that match the request. This method returns the following error codes: * `PERMISSION_DENIED` if a `student_id` is specified, and the requesting user is not permitted to view guardian information for that student, if guardians are not enabled for the domain in question, if the `invited_email_address` filter is set by a user who is not a domain administrator, or for other access errors. * `INVALID_ARGUMENT` if a `student_id` is specified, but its format cannot be recognized (it is not an email address, nor a `student_id` from the API, nor the literal string `me`). May also be returned if an invalid `page_token` is provided. * `NOT_FOUND` if a `student_id` is specified, and its format can be recognized, but Classroom has no record of that student.
+       *
+       * @alias classroom.userProfiles.guardians.list
+       * @memberOf! classroom(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.studentId Filter results by the student who the guardian is linked to. The identifier can be one of the following: * the numeric identifier for the user * the email address of the user * the string literal `"me"`, indicating the requesting user
+       * @param {string=} params.invitedEmailAddress Filter results by the email address that the original invitation was sent to, resulting in this guardian link. This filter can only be used by domain administrators.
+       * @param {string=} params.pageToken nextPageToken value returned from a previous list call, indicating that the subsequent page of results should be returned. The list request must be otherwise identical to the one that resulted in this token.
+       * @param {integer=} params.pageSize Maximum number of items to return. Zero or unspecified indicates that the server may assign a maximum. The server may return fewer than the specified number of results.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://classroom.googleapis.com/v1/userProfiles/{studentId}/guardians',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['studentId'],
+          pathParams: ['studentId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * classroom.userProfiles.guardians.get
+       *
+       * @desc Returns a specific guardian. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view guardian information for the student identified by the `student_id`, if guardians are not enabled for the domain in question, or for other access errors. * `INVALID_ARGUMENT` if a `student_id` is specified, but its format cannot be recognized (it is not an email address, nor a `student_id` from the API, nor the literal string `me`). * `NOT_FOUND` if Classroom cannot find any record of the given student or `guardian_id`, or if the guardian has been disabled.
+       *
+       * @alias classroom.userProfiles.guardians.get
+       * @memberOf! classroom(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.studentId The student whose guardian is being requested. One of the following: * the numeric identifier for the user * the email address of the user * the string literal `"me"`, indicating the requesting user
+       * @param {string} params.guardianId The `id` field from a `Guardian`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://classroom.googleapis.com/v1/userProfiles/{studentId}/guardians/{guardianId}',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['studentId', 'guardianId'],
+          pathParams: ['studentId', 'guardianId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * classroom.userProfiles.guardians.delete
+       *
+       * @desc Deletes a guardian. The guardian will no longer receive guardian notifications and the guardian will no longer be accessible via the API. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to manage guardians for the student identified by the `student_id`, if guardians are not enabled for the domain in question, or for other access errors. * `INVALID_ARGUMENT` if a `student_id` is specified, but its format cannot be recognized (it is not an email address, nor a `student_id` from the API). * `NOT_FOUND` if Classroom cannot find any record of the given `student_id` or `guardian_id`, or if the guardian has already been disabled.
+       *
+       * @alias classroom.userProfiles.guardians.delete
+       * @memberOf! classroom(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.studentId The student whose guardian is to be deleted. One of the following: * the numeric identifier for the user * the email address of the user * the string literal `"me"`, indicating the requesting user
+       * @param {string} params.guardianId The `id` field from a `Guardian`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://classroom.googleapis.com/v1/userProfiles/{studentId}/guardians/{guardianId}',
+            method: 'DELETE'
+          },
+          params: params,
+          requiredParams: ['studentId', 'guardianId'],
+          pathParams: ['studentId', 'guardianId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      }
+    }
+  };
+
   self.invitations = {
 
     /**
@@ -1010,38 +1257,6 @@ function Classroom(options) { // eslint-disable-line
     }
 
   };
-
-  self.userProfiles = {
-
-    /**
-     * classroom.userProfiles.get
-     *
-     * @desc Returns a user profile. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access this user profile or if no profile exists with the requested ID or for access errors.
-     *
-     * @alias classroom.userProfiles.get
-     * @memberOf! classroom(v1)
-     *
-     * @param {object} params Parameters for request
-     * @param {string} params.userId Identifier of the profile to return. The identifier can be one of the following: * the numeric identifier for the user * the email address of the user * the string literal `"me"`, indicating the requesting user
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    get: function (params, callback) {
-      var parameters = {
-        options: {
-          url: 'https://classroom.googleapis.com/v1/userProfiles/{userId}',
-          method: 'GET'
-        },
-        params: params,
-        requiredParams: ['userId'],
-        pathParams: ['userId'],
-        context: self
-      };
-
-      return createAPIRequest(parameters, callback);
-    }
-
-  };
 }
 
 /**
@@ -1150,20 +1365,37 @@ function Classroom(options) { // eslint-disable-line
  * @property {string} nextPageToken Token identifying the next page of results to return. If empty, no further results are available.
  */
 /**
- * @typedef Invitation
+ * @typedef ListGuardianInvitationsResponse
  * @memberOf! classroom(v1)
  * @type object
- * @property {string} id Identifier assigned by Classroom. Read-only.
- * @property {string} userId Identifier of the invited user. When specified as a parameter of a request, this identifier can be set to one of the following: * the numeric identifier for the user * the email address of the user * the string literal `&quot;me&quot;`, indicating the requesting user
- * @property {string} courseId Identifier of the course to invite the user to.
- * @property {string} role Role to invite the user to have. Must not be `COURSE_ROLE_UNSPECIFIED`.
+ * @property {classroom(v1).GuardianInvitation[]} guardianInvitations Guardian invitations that matched the list request.
+ * @property {string} nextPageToken Token identifying the next page of results to return. If empty, no further results are available.
  */
 /**
- * @typedef ListInvitationsResponse
+ * @typedef GuardianInvitation
  * @memberOf! classroom(v1)
  * @type object
- * @property {classroom(v1).Invitation[]} invitations Invitations that match the list request.
+ * @property {string} studentId ID of the student (in standard format)
+ * @property {string} invitationId Unique identifier for this invitation. Read-only.
+ * @property {string} invitedEmailAddress Email address that the invitation was sent to. This field is only visible to domain administrators.
+ * @property {string} state The state that this invitation is in.
+ * @property {string} creationTime The time that this invitation was created. Read-only.
+ */
+/**
+ * @typedef ListGuardiansResponse
+ * @memberOf! classroom(v1)
+ * @type object
+ * @property {classroom(v1).Guardian[]} guardians Guardians on this page of results that met the criteria specified in the request.
  * @property {string} nextPageToken Token identifying the next page of results to return. If empty, no further results are available.
+ */
+/**
+ * @typedef Guardian
+ * @memberOf! classroom(v1)
+ * @type object
+ * @property {string} studentId Identifier for the student to whom the guardian relationship applies.
+ * @property {string} guardianId Identifier for the guardian.
+ * @property {classroom(v1).UserProfile} guardianProfile User profile for the guardian.
+ * @property {string} invitedEmailAddress The email address to which the initial guardian invitation was sent. This field is only visible to domain administrators.
  */
 /**
  * @typedef UserProfile
@@ -1221,6 +1453,22 @@ function Classroom(options) { // eslint-disable-line
  * @property {string} nextPageToken Token identifying the next page of results to return. If empty, no further results are available.
  */
 /**
+ * @typedef Invitation
+ * @memberOf! classroom(v1)
+ * @type object
+ * @property {string} id Identifier assigned by Classroom. Read-only.
+ * @property {string} userId Identifier of the invited user. When specified as a parameter of a request, this identifier can be set to one of the following: * the numeric identifier for the user * the email address of the user * the string literal `&quot;me&quot;`, indicating the requesting user
+ * @property {string} courseId Identifier of the course to invite the user to.
+ * @property {string} role Role to invite the user to have. Must not be `COURSE_ROLE_UNSPECIFIED`.
+ */
+/**
+ * @typedef ListInvitationsResponse
+ * @memberOf! classroom(v1)
+ * @type object
+ * @property {classroom(v1).Invitation[]} invitations Invitations that match the list request.
+ * @property {string} nextPageToken Token identifying the next page of results to return. If empty, no further results are available.
+ */
+/**
  * @typedef CourseWork
  * @memberOf! classroom(v1)
  * @type object
@@ -1228,14 +1476,14 @@ function Classroom(options) { // eslint-disable-line
  * @property {string} id Classroom-assigned identifier of this course work, unique per course. Read-only.
  * @property {string} title Title of this course work. The title must be a valid UTF-8 string containing between 1 and 3000 characters.
  * @property {string} description Optional description of this course work. If set, the description must be a valid UTF-8 string containing no more than 30,000 characters.
- * @property {classroom(v1).Material[]} materials Additional materials.
- * @property {string} state Status of this course work.. If unspecified, the default state is `DRAFT`.
+ * @property {classroom(v1).Material[]} materials Additional materials. CourseWork must have no more than 20 material items.
+ * @property {string} state Status of this course work. If unspecified, the default state is `DRAFT`.
  * @property {string} alternateLink Absolute link to this course work in the Classroom web UI. This is only populated if `state` is `PUBLISHED`. Read-only.
  * @property {string} creationTime Timestamp when this course work was created. Read-only.
  * @property {string} updateTime Timestamp of the most recent change to this course work. Read-only.
  * @property {classroom(v1).Date} dueDate Optional date, in UTC, that submissions for this this course work are due. This must be specified if `due_time` is specified.
  * @property {classroom(v1).TimeOfDay} dueTime Optional time of day, in UTC, that submissions for this this course work are due. This must be specified if `due_date` is specified.
- * @property {number} maxPoints Maximum grade for this course work. If zero or unspecified, this assignment is considered ungraded. This must be an integer value.
+ * @property {number} maxPoints Maximum grade for this course work. If zero or unspecified, this assignment is considered ungraded. This must be a non-negative integer value.
  * @property {string} workType Type of this course work. The type is set when the course work is created and cannot be changed. When creating course work, this must be `ASSIGNMENT`.
  * @property {boolean} associatedWithDeveloper Whether this course work item is associated with the Developer Console project making the request. See google.classroom.Work.CreateCourseWork for more details. Read-only.
  * @property {string} submissionModificationMode Setting to determine when students are allowed to modify submissions. If unspecified, the default value is `MODIFIABLE_UNTIL_TURNED_IN`.
@@ -1302,18 +1550,18 @@ function Classroom(options) { // eslint-disable-line
  * @property {string} courseWorkId Identifier for the course work this corresponds to. Read-only.
  * @property {string} id Classroom-assigned Identifier for the student submission. This is unique among submissions for the relevant course work. Read-only.
  * @property {string} userId Identifier for the student that owns this submission. Read-only.
- * @property {string} creationTime Creation time of this submission.. This may be unset if the student has not accessed this item. Read-only.
+ * @property {string} creationTime Creation time of this submission. This may be unset if the student has not accessed this item. Read-only.
  * @property {string} updateTime Last update time of this submission. This may be unset if the student has not accessed this item. Read-only.
  * @property {string} state State of this submission. Read-only.
  * @property {boolean} late Whether this submission is late. Read-only.
- * @property {number} draftGrade Optional pending grade. If unset, no grade was set. This must be an integer value. This is only visible to and modifiable by course teachers.
- * @property {number} assignedGrade Optional grade. If unset, no grade was set. This must be an integer value. This may be modified only by course teachers.
+ * @property {number} draftGrade Optional pending grade. If unset, no grade was set. This must be a non-negative integer value. This is only visible to and modifiable by course teachers.
+ * @property {number} assignedGrade Optional grade. If unset, no grade was set. This must be a non-negative integer value. This may be modified only by course teachers.
  * @property {string} alternateLink Absolute link to the submission in the Classroom web UI. Read-only.
  * @property {string} courseWorkType Type of course work this submission is for. Read-only.
  * @property {boolean} associatedWithDeveloper Whether this student submission is associated with the Developer Console project making the request. See google.classroom.Work.CreateCourseWork for more details. Read-only.
  * @property {classroom(v1).AssignmentSubmission} assignmentSubmission Submission content when course_work_type is ASSIGNMENT .
  * @property {classroom(v1).ShortAnswerSubmission} shortAnswerSubmission Submission content when course_work_type is SHORT_ANSWER_QUESTION.
- * @property {classroom(v1).MultipleChoiceSubmission} multipleChoiceSubmission Submission content when course_work_type is MUTIPLE_CHOICE_QUESTION.
+ * @property {classroom(v1).MultipleChoiceSubmission} multipleChoiceSubmission Submission content when course_work_type is MULTIPLE_CHOICE_QUESTION.
  */
 /**
  * @typedef AssignmentSubmission
@@ -1368,6 +1616,6 @@ function Classroom(options) { // eslint-disable-line
  * @typedef ModifyAttachmentsRequest
  * @memberOf! classroom(v1)
  * @type object
- * @property {classroom(v1).Attachment[]} addAttachments Attachments to add. This may only contain link attachments.
+ * @property {classroom(v1).Attachment[]} addAttachments Attachments to add. A student submission may not have more than 20 attachments. This may only contain link attachments.
  */
 module.exports = Classroom;

--- a/apis/cloudbuild/v1.js
+++ b/apis/cloudbuild/v1.js
@@ -41,6 +41,154 @@ function Cloudbuild(options) { // eslint-disable-line
 
   self.projects = {
 
+    triggers: {
+
+      /**
+       * cloudbuild.projects.triggers.create
+       *
+       * @desc Creates a new BuildTrigger.  This API is experimental.
+       *
+       * @alias cloudbuild.projects.triggers.create
+       * @memberOf! cloudbuild(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.projectId ID of the project for which to configure automatic builds.
+       * @param {cloudbuild(v1).BuildTrigger} params.resource Request body data
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      create: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://cloudbuild.googleapis.com/v1/projects/{projectId}/triggers',
+            method: 'POST'
+          },
+          params: params,
+          requiredParams: ['projectId'],
+          pathParams: ['projectId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * cloudbuild.projects.triggers.get
+       *
+       * @desc Gets information about a BuildTrigger.  This API is experimental.
+       *
+       * @alias cloudbuild.projects.triggers.get
+       * @memberOf! cloudbuild(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.projectId ID of the project that owns the trigger.
+       * @param {string} params.triggerId ID of the BuildTrigger to get.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://cloudbuild.googleapis.com/v1/projects/{projectId}/triggers/{triggerId}',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['projectId', 'triggerId'],
+          pathParams: ['projectId', 'triggerId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * cloudbuild.projects.triggers.list
+       *
+       * @desc Lists existing BuildTrigger.  This API is experimental.
+       *
+       * @alias cloudbuild.projects.triggers.list
+       * @memberOf! cloudbuild(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.projectId ID of the project for which to list BuildTriggers.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://cloudbuild.googleapis.com/v1/projects/{projectId}/triggers',
+            method: 'GET'
+          },
+          params: params,
+          requiredParams: ['projectId'],
+          pathParams: ['projectId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * cloudbuild.projects.triggers.delete
+       *
+       * @desc Deletes an BuildTrigger by its project ID and trigger ID.  This API is experimental.
+       *
+       * @alias cloudbuild.projects.triggers.delete
+       * @memberOf! cloudbuild(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.projectId ID of the project that owns the trigger.
+       * @param {string} params.triggerId ID of the BuildTrigger to delete.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://cloudbuild.googleapis.com/v1/projects/{projectId}/triggers/{triggerId}',
+            method: 'DELETE'
+          },
+          params: params,
+          requiredParams: ['projectId', 'triggerId'],
+          pathParams: ['projectId', 'triggerId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      },
+
+      /**
+       * cloudbuild.projects.triggers.patch
+       *
+       * @desc Updates an BuildTrigger by its project ID and trigger ID.  This API is experimental.
+       *
+       * @alias cloudbuild.projects.triggers.patch
+       * @memberOf! cloudbuild(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.projectId ID of the project that owns the trigger.
+       * @param {string} params.triggerId ID of the BuildTrigger to update.
+       * @param {cloudbuild(v1).BuildTrigger} params.resource Request body data
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      patch: function (params, callback) {
+        var parameters = {
+          options: {
+            url: 'https://cloudbuild.googleapis.com/v1/projects/{projectId}/triggers/{triggerId}',
+            method: 'PATCH'
+          },
+          params: params,
+          requiredParams: ['projectId', 'triggerId'],
+          pathParams: ['projectId', 'triggerId'],
+          context: self
+        };
+
+        return createAPIRequest(parameters, callback);
+      }
+    },
+
     builds: {
 
       /**
@@ -296,6 +444,23 @@ originally returns it. If you use the default HTTP mapping, the
 `name` should have the format of `operations/some/unique/name`.
 */
 /**
+ * @typedef BuildTrigger
+ * @memberOf! cloudbuild(v1)
+ * @type object
+* @property {cloudbuild(v1).RepoSource} triggerTemplate Template describing the types of source changes to trigger a build.
+
+Branch and tag names in trigger templates are interpreted as regular
+expressions. Any branch or tag change that matches that regular expression
+will trigger a build.
+* @property {cloudbuild(v1).Build} build Contents of the build template.
+* @property {string} createTime Time when the trigger was created.
+
+@OutputOnly
+* @property {string} id Unique identifier of the trigger.
+
+@OutputOnly
+*/
+/**
  * @typedef BuiltImage
  * @memberOf! cloudbuild(v1)
  * @type object
@@ -373,6 +538,12 @@ Logs file names will be of the format `${logs_bucket}/log-${build_id}.txt`.
 @OutputOnly.
 */
 /**
+ * @typedef ListBuildTriggersResponse
+ * @memberOf! cloudbuild(v1)
+ * @type object
+ * @property {cloudbuild(v1).BuildTrigger[]} triggers BuildTriggers for the project, sorted by create_time descending.
+ */
+/**
  * @typedef CancelBuildRequest
  * @memberOf! cloudbuild(v1)
  * @type object
@@ -419,6 +590,11 @@ pipeline, as presented to `docker pull`.
 * @property {string} dir Working directory (relative to project source root) to use when running
 this operation&#39;s container.
 */
+/**
+ * @typedef Empty
+ * @memberOf! cloudbuild(v1)
+ * @type object
+ */
 /**
  * @typedef BuildOptions
  * @memberOf! cloudbuild(v1)

--- a/apis/clouddebugger/v2.js
+++ b/apis/clouddebugger/v2.js
@@ -21,7 +21,7 @@
 var createAPIRequest = require('../../lib/apirequest');
 
 /**
- * Google Cloud Debugger API
+ * Stackdriver Debugger API
  *
  * Examines the call stack and variables of a running application without stopping or slowing it down.
  *

--- a/apis/compute/alpha.js
+++ b/apis/compute/alpha.js
@@ -756,6 +756,38 @@ function Compute(options) { // eslint-disable-line
   self.backendServices = {
 
     /**
+     * compute.backendServices.aggregatedList
+     *
+     * @desc Retrieves the list of all BackendService resources, regional and global, available to the specified project.
+     *
+     * @alias compute.backendServices.aggregatedList
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string=} params.filter Sets a filter expression for filtering listed resources, in the form filter={expression}. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use filter=name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+     * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests.
+     * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+     * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+     * @param {string} params.project Name of the project scoping this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    aggregatedList: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/aggregated/backendServices',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['project'],
+        pathParams: ['project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
      * compute.backendServices.delete
      *
      * @desc Deletes the specified BackendService resource.
@@ -6642,6 +6674,37 @@ function Compute(options) { // eslint-disable-line
     },
 
     /**
+     * compute.regionInstanceGroupManagers.patch
+     *
+     * @desc Updates a managed instance group using the information that you specify in the request. This operation is marked as DONE when the group is updated even if the instances in the group have not yet been updated. You must separately verify the status of the individual instances with the listmanagedinstances method. This method supports patch semantics.
+     *
+     * @alias compute.regionInstanceGroupManagers.patch
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.instanceGroupManager The name of the instance group manager.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {compute(alpha).InstanceGroupManager} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'region'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
      * compute.regionInstanceGroupManagers.recreateInstances
      *
      * @desc Schedules a group action to recreate the specified instances in the managed instance group. The instances are deleted and recreated using the current instance template for the managed instance group. This operation is marked as DONE when the action is scheduled even if the instances have not yet been recreated. You must separately verify the status of the recreating action with the listmanagedinstances method.
@@ -6821,6 +6884,37 @@ function Compute(options) { // eslint-disable-line
         params: params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.regionInstanceGroupManagers.update
+     *
+     * @desc Updates a managed instance group using the information that you specify in the request. This operation is marked as DONE when the group is updated even if the instances in the group have not yet been updated. You must separately verify the status of the individual instances with the listmanagedinstances method.
+     *
+     * @alias compute.regionInstanceGroupManagers.update
+     * @memberOf! compute(alpha)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.instanceGroupManager The name of the instance group manager.
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {compute(alpha).InstanceGroupManager} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    update: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/alpha/projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}',
+          method: 'PUT'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'instanceGroupManager'],
+        pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
 
@@ -10361,7 +10455,7 @@ Instance templates do not store customer-supplied encryption keys, so you cannot
  * @type object
 * @property {compute(alpha).AutoscalingPolicy} autoscalingPolicy The configuration parameters for the autoscaling algorithm. You can define one or more of the policies for an autoscaler: cpuUtilization, customMetricUtilizations, and loadBalancingUtilization.
 
-If none of these are specified, the default will be to autoscale based on cpuUtilization to 0.8 or 80%.
+If none of these are specified, the default will be to autoscale based on cpuUtilization to 0.6 or 60%.
 * @property {string} creationTimestamp [Output Only] Creation timestamp in RFC3339 text format.
 * @property {string} description An optional description of this resource. Provide this property when you create the resource.
 * @property {string} id [Output Only] The unique identifier for the resource. This identifier is defined by the server.
@@ -10372,7 +10466,7 @@ If none of these are specified, the default will be to autoscale based on cpuUti
 * @property {string} status [Output Only] The status of the autoscaler configuration.
 * @property {compute(alpha).AutoscalerStatusDetails[]} statusDetails [Output Only] Human-readable details about the current state of the autoscaler. Examples: ?Error when fetching replicas: Replica Pool xxx doesn?t exist.? ?Autoscaling capped at min_num_replicas: 2.?
 * @property {string} target URL of the managed instance group that this autoscaler will scale.
-* @property {string} zone [Output Only] URL of the zone where the instance group resides.
+* @property {string} zone [Output Only] URL of the zone where the instance group resides (for autoscalers living in zonal scope).
 */
 /**
  * @typedef AutoscalerAggregatedList
@@ -10426,7 +10520,7 @@ Virtual machine initialization times might vary because of numerous factors. We 
  * @typedef AutoscalingPolicyCpuUtilization
  * @memberOf! compute(alpha)
  * @type object
-* @property {number} utilizationTarget The target CPU utilization that the autoscaler should maintain. Must be a float value in the range (0, 1]. If not specified, the default is 0.8.
+* @property {number} utilizationTarget The target CPU utilization that the autoscaler should maintain. Must be a float value in the range (0, 1]. If not specified, the default is 0.6.
 
 If the CPU level is below the target utilization, the autoscaler scales down the number of instances until it reaches the minimum number of instances you specified or until the average CPU of your instances reaches the target utilization.
 
@@ -10576,6 +10670,16 @@ When the protocol is UDP, this field is not used.
 * @property {integer} timeoutSec How many seconds to wait for the backend before considering it a failed request. Default is 30 seconds.
 */
 /**
+ * @typedef BackendServiceAggregatedList
+ * @memberOf! compute(alpha)
+ * @type object
+ * @property {string} id [Output Only] Unique identifier for the resource; defined by the server.
+ * @property {object} items A map of scoped BackendService lists.
+ * @property {string} kind Type of resource.
+ * @property {string} nextPageToken [Output Only] A token used to continue a truncated list request.
+ * @property {string} selfLink [Output Only] Server-defined URL for this resource.
+ */
+/**
  * @typedef BackendServiceGroupHealth
  * @memberOf! compute(alpha)
  * @type object
@@ -10600,6 +10704,13 @@ When the protocol is UDP, this field is not used.
  * @property {string} kind [Output Only] Type of resource. Always compute#backendServiceList for lists of backend services.
  * @property {string} nextPageToken [Output Only] A token used to continue a truncated list request.
  * @property {string} selfLink [Output Only] Server-defined URL for this resource.
+ */
+/**
+ * @typedef BackendServicesScopedList
+ * @memberOf! compute(alpha)
+ * @type object
+ * @property {compute(alpha).BackendService[]} backendServices List of BackendServices contained in this scope.
+ * @property {object} warning Informational warning which replaces the list of backend services when the list is empty.
  */
 /**
  * @typedef Binding
@@ -11204,11 +11315,11 @@ This allows the system to reference ports by the assigned name instead of a port
 
 Named ports apply to all instances in this instance group.
 * @property {string} network The URL of the network to which all instances in the instance group belong.
-* @property {string} region The URL of the region where the instance group is located.
+* @property {string} region The URL of the region where the instance group is located (for regional resources).
 * @property {string} selfLink [Output Only] The URL for this instance group. The server generates this URL.
 * @property {integer} size [Output Only] The total number of instances in the instance group.
 * @property {string} subnetwork The URL of the subnetwork to which all instances in the instance group belong.
-* @property {string} zone [Output Only] The URL of the zone where the instance group is located.
+* @property {string} zone [Output Only] The URL of the zone where the instance group is located (for zonal resources).
 */
 /**
  * @typedef InstanceGroupAggregatedList
@@ -11248,13 +11359,13 @@ Named ports apply to all instances in this instance group.
  * @property {string} name The name of the managed instance group. The name must be 1-63 characters long, and comply with RFC1035.
  * @property {compute(alpha).NamedPort[]} namedPorts Named ports configured for the Instance Groups complementary to this Instance Group Manager.
  * @property {compute(alpha).InstanceGroupManagerPendingActionsSummary} pendingActions [Output Only] The list of instance actions and the number of instances in this managed instance group that are pending for each of those actions.
- * @property {string} region [Output Only] URL of the region where the managed instance group resides.
+ * @property {string} region [Output Only] The URL of the region where the managed instance group resides (for regional resources).
  * @property {string} selfLink [Output Only] The URL for this managed instance group. The server defines this URL.
  * @property {string[]} targetPools The URLs for all TargetPool resources to which instances in the instanceGroup field are added. The target pools automatically apply to all of the instances in the managed instance group.
  * @property {integer} targetSize The target number of running instances for this managed instance group. Deleting or abandoning instances reduces this number. Resizing the group changes this number.
  * @property {compute(alpha).InstanceGroupManagerUpdatePolicy} updatePolicy The update policy for this managed instance group.
  * @property {compute(alpha).InstanceGroupManagerVersion[]} versions Versions supported by this IGM. User should set this field if they need fine-grained control over how many instances in each version are run by this IGM. Versions are keyed by instanceTemplate. Every instanceTemplate can appear at most once. This field overrides instanceTemplate field. If both instanceTemplate and versions are set, the user receives a warning. &quot;instanceTemplate: X&quot; is semantically equivalent to &quot;versions [ { instanceTemplate: X } ]&quot;. Exactly one version must have targetSize field left unset. Size of such a version will be calculated automatically.
- * @property {string} zone The name of the zone where the managed instance group is located.
+ * @property {string} zone [Output Only] The URL of the zone where the managed instance group is located (for zonal resources).
  */
 /**
  * @typedef InstanceGroupManagerActionsSummary

--- a/apis/compute/beta.js
+++ b/apis/compute/beta.js
@@ -4733,6 +4733,35 @@ function Compute(options) { // eslint-disable-line
     },
 
     /**
+     * compute.networks.switchToCustomMode
+     *
+     * @desc Switches the network mode from auto subnet mode to custom subnet mode.
+     *
+     * @alias compute.networks.switchToCustomMode
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.network Name of the network to be updated.
+     * @param {string} params.project Project ID for this request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    switchToCustomMode: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/global/networks/{network}/switchToCustomMode',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: ['project', 'network'],
+        pathParams: ['network', 'project'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
      * compute.networks.testIamPermissions
      *
      * @desc Returns permissions that a caller has on the specified resource.
@@ -6690,6 +6719,37 @@ function Compute(options) { // eslint-disable-line
         options: {
           url: 'https://www.googleapis.com/compute/beta/projects/{project}/regions/{region}/subnetworks/{subnetwork}',
           method: 'DELETE'
+        },
+        params: params,
+        requiredParams: ['project', 'region', 'subnetwork'],
+        pathParams: ['project', 'region', 'subnetwork'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * compute.subnetworks.expandIpCidrRange
+     *
+     * @desc Expands the IP CIDR range of the subnetwork to a specified value.
+     *
+     * @alias compute.subnetworks.expandIpCidrRange
+     * @memberOf! compute(beta)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.project Project ID for this request.
+     * @param {string} params.region Name of the region scoping this request.
+     * @param {string} params.subnetwork Name of the Subnetwork resource to update.
+     * @param {compute(beta).SubnetworksExpandIpCidrRangeRequest} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    expandIpCidrRange: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/compute/beta/projects/{project}/regions/{region}/subnetworks/{subnetwork}/expandIpCidrRange',
+          method: 'POST'
         },
         params: params,
         requiredParams: ['project', 'region', 'subnetwork'],
@@ -8970,7 +9030,7 @@ Instance templates do not store customer-supplied encryption keys, so you cannot
  * @type object
 * @property {compute(beta).AutoscalingPolicy} autoscalingPolicy The configuration parameters for the autoscaling algorithm. You can define one or more of the policies for an autoscaler: cpuUtilization, customMetricUtilizations, and loadBalancingUtilization.
 
-If none of these are specified, the default will be to autoscale based on cpuUtilization to 0.8 or 80%.
+If none of these are specified, the default will be to autoscale based on cpuUtilization to 0.6 or 60%.
 * @property {string} creationTimestamp [Output Only] Creation timestamp in RFC3339 text format.
 * @property {string} description An optional description of this resource. Provide this property when you create the resource.
 * @property {string} id [Output Only] The unique identifier for the resource. This identifier is defined by the server.
@@ -8978,8 +9038,10 @@ If none of these are specified, the default will be to autoscale based on cpuUti
 * @property {string} name Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
 * @property {string} region [Output Only] URL of the region where the instance group resides (for autoscalers living in regional scope).
 * @property {string} selfLink [Output Only] Server-defined URL for the resource.
+* @property {string} status [Output Only] The status of the autoscaler configuration.
+* @property {compute(beta).AutoscalerStatusDetails[]} statusDetails [Output Only] Human-readable details about the current state of the autoscaler. Examples: ?Error when fetching replicas: Replica Pool xxx doesn?t exist.? ?Autoscaling capped at min_num_replicas: 2.?
 * @property {string} target URL of the managed instance group that this autoscaler will scale.
-* @property {string} zone [Output Only] URL of the zone where the instance group resides.
+* @property {string} zone [Output Only] URL of the zone where the instance group resides (for autoscalers living in zonal scope).
 */
 /**
  * @typedef AutoscalerAggregatedList
@@ -9000,6 +9062,13 @@ If none of these are specified, the default will be to autoscale based on cpuUti
  * @property {string} kind [Output Only] Type of resource. Always compute#autoscalerList for lists of autoscalers.
  * @property {string} nextPageToken [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
  * @property {string} selfLink [Output Only] Server-defined URL for this resource.
+ */
+/**
+ * @typedef AutoscalerStatusDetails
+ * @memberOf! compute(beta)
+ * @type object
+ * @property {string} message 
+ * @property {string} type 
  */
 /**
  * @typedef AutoscalersScopedList
@@ -9025,7 +9094,7 @@ Virtual machine initialization times might vary because of numerous factors. We 
  * @typedef AutoscalingPolicyCpuUtilization
  * @memberOf! compute(beta)
  * @type object
-* @property {number} utilizationTarget The target CPU utilization that the autoscaler should maintain. Must be a float value in the range (0, 1]. If not specified, the default is 0.8.
+* @property {number} utilizationTarget The target CPU utilization that the autoscaler should maintain. Must be a float value in the range (0, 1]. If not specified, the default is 0.6.
 
 If the CPU level is below the target utilization, the autoscaler scales down the number of instances until it reaches the minimum number of instances you specified or until the average CPU of your instances reaches the target utilization.
 
@@ -9673,11 +9742,11 @@ This allows the system to reference ports by the assigned name instead of a port
 
 Named ports apply to all instances in this instance group.
 * @property {string} network The URL of the network to which all instances in the instance group belong.
-* @property {string} region The URL of the region where the instance group is located.
+* @property {string} region The URL of the region where the instance group is located (for regional resources).
 * @property {string} selfLink [Output Only] The URL for this instance group. The server generates this URL.
 * @property {integer} size [Output Only] The total number of instances in the instance group.
 * @property {string} subnetwork The URL of the subnetwork to which all instances in the instance group belong.
-* @property {string} zone [Output Only] The URL of the zone where the instance group is located.
+* @property {string} zone [Output Only] The URL of the zone where the instance group is located (for zonal resources).
 */
 /**
  * @typedef InstanceGroupAggregatedList
@@ -9716,11 +9785,11 @@ Named ports apply to all instances in this instance group.
  * @property {string} kind [Output Only] The resource type, which is always compute#instanceGroupManager for managed instance groups.
  * @property {string} name The name of the managed instance group. The name must be 1-63 characters long, and comply with RFC1035.
  * @property {compute(beta).NamedPort[]} namedPorts Named ports configured for the Instance Groups complementary to this Instance Group Manager.
- * @property {string} region [Output Only] URL of the region where the managed instance group resides.
+ * @property {string} region [Output Only] The URL of the region where the managed instance group resides (for regional resources).
  * @property {string} selfLink [Output Only] The URL for this managed instance group. The server defines this URL.
  * @property {string[]} targetPools The URLs for all TargetPool resources to which instances in the instanceGroup field are added. The target pools automatically apply to all of the instances in the managed instance group.
  * @property {integer} targetSize The target number of running instances for this managed instance group. Deleting or abandoning instances reduces this number. Resizing the group changes this number.
- * @property {string} zone The name of the zone where the managed instance group is located.
+ * @property {string} zone [Output Only] The URL of the zone where the managed instance group is located (for zonal resources).
  */
 /**
  * @typedef InstanceGroupManagerActionsSummary
@@ -10608,6 +10677,12 @@ If you do not provide an encryption key when creating the snapshot, then the sna
  * @property {string} kind [Output Only] Type of resource. Always compute#subnetworkList for lists of subnetworks.
  * @property {string} nextPageToken [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
  * @property {string} selfLink [Output Only] Server-defined URL for this resource.
+ */
+/**
+ * @typedef SubnetworksExpandIpCidrRangeRequest
+ * @memberOf! compute(beta)
+ * @type object
+ * @property {string} ipCidrRange The IP (in CIDR format or netmask) of internal addresses that are legal on this Subnetwork. This range should be disjoint from other subnetworks within this network. This range can only be larger than (i.e. a superset of) the range previously defined before the update.
  */
 /**
  * @typedef SubnetworksScopedList

--- a/apis/compute/v1.js
+++ b/apis/compute/v1.js
@@ -11449,6 +11449,58 @@ function Compute(options) { // eslint-disable-line
      *
      * @desc Preview fields auto-generated during router create and update operations. Calling this method does NOT create or update the router.
      *
+     * @example
+     * // BEFORE RUNNING:
+     * // ---------------
+     * // 1. If not already done, enable the Compute Engine API
+     * //    and check the quota for your project at
+     * //    https://console.developers.google.com/apis/api/compute
+     * // 2. This sample uses Application Default Credentials for authentication.
+     * //    If not already done, install the gcloud CLI from
+     * //    https://cloud.google.com/sdk/ and run
+     * //    'gcloud auth application-default login'
+     * // 3. Install the Node.js client library and Application Default Credentials
+     * //    library by running 'npm install googleapis --save'
+     * var google = require('googleapis');
+     * var compute = google.compute('v1');
+     *
+     * google.auth.getApplicationDefault(function(err, authClient) {
+     *   if (err) {
+     *     console.log('Authentication failed because of ', err);
+     *     return;
+     *   }
+     *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+     *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+     *     authClient = authClient.createScoped(scopes);
+     *   }
+     *
+     *   var request = {
+     *     // TODO: Change placeholders below to appropriate parameter values for the 'preview' method:
+     *
+     *     // * Project ID for this request.
+     *     project: "",
+     *
+     *     // * Name of the region for this request.
+     *     region: "",
+     *
+     *     // * Name of the Router resource to query.
+     *     router: "",
+     *
+     *     resource: {},
+     *
+     *     // Auth client
+     *     auth: authClient
+     *   };
+     *
+     *   compute.routers.preview(request, function(err, result) {
+     *     if (err) {
+     *       console.log(err);
+     *     } else {
+     *       console.log(result);
+     *     }
+     *   });
+     * });
+     *
      * @alias compute.routers.preview
      * @memberOf! compute(v1)
      *
@@ -17004,7 +17056,7 @@ Instance templates do not store customer-supplied encryption keys, so you cannot
  * @type object
 * @property {compute(v1).AutoscalingPolicy} autoscalingPolicy The configuration parameters for the autoscaling algorithm. You can define one or more of the policies for an autoscaler: cpuUtilization, customMetricUtilizations, and loadBalancingUtilization.
 
-If none of these are specified, the default will be to autoscale based on cpuUtilization to 0.8 or 80%.
+If none of these are specified, the default will be to autoscale based on cpuUtilization to 0.6 or 60%.
 * @property {string} creationTimestamp [Output Only] Creation timestamp in RFC3339 text format.
 * @property {string} description An optional description of this resource. Provide this property when you create the resource.
 * @property {string} id [Output Only] The unique identifier for the resource. This identifier is defined by the server.
@@ -17012,7 +17064,7 @@ If none of these are specified, the default will be to autoscale based on cpuUti
 * @property {string} name Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
 * @property {string} selfLink [Output Only] Server-defined URL for the resource.
 * @property {string} target URL of the managed instance group that this autoscaler will scale.
-* @property {string} zone [Output Only] URL of the zone where the instance group resides.
+* @property {string} zone [Output Only] URL of the zone where the instance group resides (for autoscalers living in zonal scope).
 */
 /**
  * @typedef AutoscalerAggregatedList
@@ -17058,7 +17110,7 @@ Virtual machine initialization times might vary because of numerous factors. We 
  * @typedef AutoscalingPolicyCpuUtilization
  * @memberOf! compute(v1)
  * @type object
-* @property {number} utilizationTarget The target CPU utilization that the autoscaler should maintain. Must be a float value in the range (0, 1]. If not specified, the default is 0.8.
+* @property {number} utilizationTarget The target CPU utilization that the autoscaler should maintain. Must be a float value in the range (0, 1]. If not specified, the default is 0.6.
 
 If the CPU level is below the target utilization, the autoscaler scales down the number of instances until it reaches the minimum number of instances you specified or until the average CPU of your instances reaches the target utilization.
 
@@ -17609,7 +17661,7 @@ Named ports apply to all instances in this instance group.
 * @property {string} selfLink [Output Only] The URL for this instance group. The server generates this URL.
 * @property {integer} size [Output Only] The total number of instances in the instance group.
 * @property {string} subnetwork The URL of the subnetwork to which all instances in the instance group belong.
-* @property {string} zone [Output Only] The URL of the zone where the instance group is located.
+* @property {string} zone [Output Only] The URL of the zone where the instance group is located (for zonal resources).
 */
 /**
  * @typedef InstanceGroupAggregatedList
@@ -17649,7 +17701,7 @@ Named ports apply to all instances in this instance group.
  * @property {string} selfLink [Output Only] The URL for this managed instance group. The server defines this URL.
  * @property {string[]} targetPools The URLs for all TargetPool resources to which instances in the instanceGroup field are added. The target pools automatically apply to all of the instances in the managed instance group.
  * @property {integer} targetSize The target number of running instances for this managed instance group. Deleting or abandoning instances reduces this number. Resizing the group changes this number.
- * @property {string} zone The name of the zone where the managed instance group is located.
+ * @property {string} zone [Output Only] The URL of the zone where the managed instance group is located (for zonal resources).
  */
 /**
  * @typedef InstanceGroupManagerActionsSummary
@@ -17659,6 +17711,7 @@ Named ports apply to all instances in this instance group.
 * @property {integer} creating [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully.
 
 If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.
+* @property {integer} creatingWithoutRetries [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group&#39;s target_size value accordingly.
 * @property {integer} deleting [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.
 * @property {integer} none [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.
 * @property {integer} recreating [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.

--- a/apis/container/v1.js
+++ b/apis/container/v1.js
@@ -48,6 +48,55 @@ function Container(options) { // eslint-disable-line
        *
        * @desc Returns configuration info about the Container Engine service.
        *
+       * @example
+       * // BEFORE RUNNING:
+       * // ---------------
+       * // 1. If not already done, enable the Google Container Engine API
+       * //    and check the quota for your project at
+       * //    https://console.developers.google.com/apis/api/container
+       * // 2. This sample uses Application Default Credentials for authentication.
+       * //    If not already done, install the gcloud CLI from
+       * //    https://cloud.google.com/sdk/ and run
+       * //    'gcloud beta auth application-default login'
+       * // 3. Install the Node.js client library and Application Default Credentials
+       * //    library by running 'npm install googleapis --save'
+       * var google = require('googleapis');
+       * var container = google.container('v1');
+       *
+       * google.auth.getApplicationDefault(function(err, authClient) {
+       *   if (err) {
+       *     console.log('Authentication failed because of ', err);
+       *     return;
+       *   }
+       *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+       *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+       *     authClient = authClient.createScoped(scopes);
+       *   }
+       *
+       *   var request = {
+       *     // TODO: Change placeholders below to appropriate parameter values for the 'getServerconfig' method:
+       *
+       *     // * The Google Developers Console [project ID or project
+       *     //   number](https://support.google.com/cloud/answer/6158840).
+       *     projectId: "",
+       *
+       *     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available)
+       *     //   to return operations for.
+       *     zone: "",
+       *
+       *     // Auth client
+       *     auth: authClient
+       *   };
+       *
+       *   container.projects.zones.getServerconfig(request, function(err, result) {
+       *     if (err) {
+       *       console.log(err);
+       *     } else {
+       *       console.log(result);
+       *     }
+       *   });
+       * });
+       *
        * @alias container.projects.zones.getServerconfig
        * @memberOf! container(v1)
        *
@@ -79,6 +128,56 @@ function Container(options) { // eslint-disable-line
          *
          * @desc Lists all clusters owned by a project in either the specified zone or all zones.
          *
+         * @example
+         * // BEFORE RUNNING:
+         * // ---------------
+         * // 1. If not already done, enable the Google Container Engine API
+         * //    and check the quota for your project at
+         * //    https://console.developers.google.com/apis/api/container
+         * // 2. This sample uses Application Default Credentials for authentication.
+         * //    If not already done, install the gcloud CLI from
+         * //    https://cloud.google.com/sdk/ and run
+         * //    'gcloud beta auth application-default login'
+         * // 3. Install the Node.js client library and Application Default Credentials
+         * //    library by running 'npm install googleapis --save'
+         * var google = require('googleapis');
+         * var container = google.container('v1');
+         *
+         * google.auth.getApplicationDefault(function(err, authClient) {
+         *   if (err) {
+         *     console.log('Authentication failed because of ', err);
+         *     return;
+         *   }
+         *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+         *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+         *     authClient = authClient.createScoped(scopes);
+         *   }
+         *
+         *   var request = {
+         *     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
+         *
+         *     // * The Google Developers Console [project ID or project
+         *     //   number](https://support.google.com/cloud/answer/6158840).
+         *     projectId: "",
+         *
+         *     // * The name of the Google Compute Engine
+         *     //   [zone](/compute/docs/zones#available) in which the cluster
+         *     //   resides, or "-" for all zones.
+         *     zone: "",
+         *
+         *     // Auth client
+         *     auth: authClient
+         *   };
+         *
+         *   container.projects.zones.clusters.list(request, function(err, result) {
+         *     if (err) {
+         *       console.log(err);
+         *     } else {
+         *       console.log(result);
+         *     }
+         *   });
+         * });
+         *
          * @alias container.projects.zones.clusters.list
          * @memberOf! container(v1)
          *
@@ -107,6 +206,59 @@ function Container(options) { // eslint-disable-line
          * container.projects.zones.clusters.get
          *
          * @desc Gets the details of a specific cluster.
+         *
+         * @example
+         * // BEFORE RUNNING:
+         * // ---------------
+         * // 1. If not already done, enable the Google Container Engine API
+         * //    and check the quota for your project at
+         * //    https://console.developers.google.com/apis/api/container
+         * // 2. This sample uses Application Default Credentials for authentication.
+         * //    If not already done, install the gcloud CLI from
+         * //    https://cloud.google.com/sdk/ and run
+         * //    'gcloud beta auth application-default login'
+         * // 3. Install the Node.js client library and Application Default Credentials
+         * //    library by running 'npm install googleapis --save'
+         * var google = require('googleapis');
+         * var container = google.container('v1');
+         *
+         * google.auth.getApplicationDefault(function(err, authClient) {
+         *   if (err) {
+         *     console.log('Authentication failed because of ', err);
+         *     return;
+         *   }
+         *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+         *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+         *     authClient = authClient.createScoped(scopes);
+         *   }
+         *
+         *   var request = {
+         *     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
+         *
+         *     // * The Google Developers Console [project ID or project
+         *     //   number](https://support.google.com/cloud/answer/6158840).
+         *     projectId: "",
+         *
+         *     // * The name of the Google Compute Engine
+         *     //   [zone](/compute/docs/zones#available) in which the cluster
+         *     //   resides.
+         *     zone: "",
+         *
+         *     // * The name of the cluster to retrieve.
+         *     clusterId: "",
+         *
+         *     // Auth client
+         *     auth: authClient
+         *   };
+         *
+         *   container.projects.zones.clusters.get(request, function(err, result) {
+         *     if (err) {
+         *       console.log(err);
+         *     } else {
+         *       console.log(result);
+         *     }
+         *   });
+         * });
          *
          * @alias container.projects.zones.clusters.get
          * @memberOf! container(v1)
@@ -138,6 +290,58 @@ function Container(options) { // eslint-disable-line
          *
          * @desc Creates a cluster, consisting of the specified number and type of Google Compute Engine instances. By default, the cluster is created in the project's [default network](/compute/docs/networks-and-firewalls#networks). One firewall is added for the cluster. After cluster creation, the cluster creates routes for each node to allow the containers on that node to communicate with all other instances in the cluster. Finally, an entry is added to the project's global metadata indicating which CIDR range is being used by the cluster.
          *
+         * @example
+         * // BEFORE RUNNING:
+         * // ---------------
+         * // 1. If not already done, enable the Google Container Engine API
+         * //    and check the quota for your project at
+         * //    https://console.developers.google.com/apis/api/container
+         * // 2. This sample uses Application Default Credentials for authentication.
+         * //    If not already done, install the gcloud CLI from
+         * //    https://cloud.google.com/sdk/ and run
+         * //    'gcloud beta auth application-default login'
+         * // 3. Install the Node.js client library and Application Default Credentials
+         * //    library by running 'npm install googleapis --save'
+         * var google = require('googleapis');
+         * var container = google.container('v1');
+         *
+         * google.auth.getApplicationDefault(function(err, authClient) {
+         *   if (err) {
+         *     console.log('Authentication failed because of ', err);
+         *     return;
+         *   }
+         *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+         *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+         *     authClient = authClient.createScoped(scopes);
+         *   }
+         *
+         *   var request = {
+         *     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
+         *
+         *     // * The Google Developers Console [project ID or project
+         *     //   number](https://support.google.com/cloud/answer/6158840).
+         *     projectId: "",
+         *
+         *     // * The name of the Google Compute Engine
+         *     //   [zone](/compute/docs/zones#available) in which the cluster
+         *     //   resides.
+         *     zone: "",
+         *
+         *     resource: {},
+         *
+         *     // Auth client
+         *     auth: authClient
+         *   };
+         *
+         *   container.projects.zones.clusters.create(request, function(err, result) {
+         *     if (err) {
+         *       console.log(err);
+         *     } else {
+         *       console.log(result);
+         *     }
+         *   });
+         * });
+         *
          * @alias container.projects.zones.clusters.create
          * @memberOf! container(v1)
          *
@@ -167,6 +371,61 @@ function Container(options) { // eslint-disable-line
          * container.projects.zones.clusters.update
          *
          * @desc Updates the settings of a specific cluster.
+         *
+         * @example
+         * // BEFORE RUNNING:
+         * // ---------------
+         * // 1. If not already done, enable the Google Container Engine API
+         * //    and check the quota for your project at
+         * //    https://console.developers.google.com/apis/api/container
+         * // 2. This sample uses Application Default Credentials for authentication.
+         * //    If not already done, install the gcloud CLI from
+         * //    https://cloud.google.com/sdk/ and run
+         * //    'gcloud beta auth application-default login'
+         * // 3. Install the Node.js client library and Application Default Credentials
+         * //    library by running 'npm install googleapis --save'
+         * var google = require('googleapis');
+         * var container = google.container('v1');
+         *
+         * google.auth.getApplicationDefault(function(err, authClient) {
+         *   if (err) {
+         *     console.log('Authentication failed because of ', err);
+         *     return;
+         *   }
+         *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+         *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+         *     authClient = authClient.createScoped(scopes);
+         *   }
+         *
+         *   var request = {
+         *     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
+         *
+         *     // * The Google Developers Console [project ID or project
+         *     //   number](https://support.google.com/cloud/answer/6158840).
+         *     projectId: "",
+         *
+         *     // * The name of the Google Compute Engine
+         *     //   [zone](/compute/docs/zones#available) in which the cluster
+         *     //   resides.
+         *     zone: "",
+         *
+         *     // * The name of the cluster to upgrade.
+         *     clusterId: "",
+         *
+         *     resource: {},
+         *
+         *     // Auth client
+         *     auth: authClient
+         *   };
+         *
+         *   container.projects.zones.clusters.update(request, function(err, result) {
+         *     if (err) {
+         *       console.log(err);
+         *     } else {
+         *       console.log(result);
+         *     }
+         *   });
+         * });
          *
          * @alias container.projects.zones.clusters.update
          * @memberOf! container(v1)
@@ -198,6 +457,59 @@ function Container(options) { // eslint-disable-line
          * container.projects.zones.clusters.delete
          *
          * @desc Deletes the cluster, including the Kubernetes endpoint and all worker nodes. Firewalls and routes that were configured during cluster creation are also deleted. Other Google Compute Engine resources that might be in use by the cluster (e.g. load balancer resources) will not be deleted if they weren't present at the initial create time.
+         *
+         * @example
+         * // BEFORE RUNNING:
+         * // ---------------
+         * // 1. If not already done, enable the Google Container Engine API
+         * //    and check the quota for your project at
+         * //    https://console.developers.google.com/apis/api/container
+         * // 2. This sample uses Application Default Credentials for authentication.
+         * //    If not already done, install the gcloud CLI from
+         * //    https://cloud.google.com/sdk/ and run
+         * //    'gcloud beta auth application-default login'
+         * // 3. Install the Node.js client library and Application Default Credentials
+         * //    library by running 'npm install googleapis --save'
+         * var google = require('googleapis');
+         * var container = google.container('v1');
+         *
+         * google.auth.getApplicationDefault(function(err, authClient) {
+         *   if (err) {
+         *     console.log('Authentication failed because of ', err);
+         *     return;
+         *   }
+         *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+         *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+         *     authClient = authClient.createScoped(scopes);
+         *   }
+         *
+         *   var request = {
+         *     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
+         *
+         *     // * The Google Developers Console [project ID or project
+         *     //   number](https://support.google.com/cloud/answer/6158840).
+         *     projectId: "",
+         *
+         *     // * The name of the Google Compute Engine
+         *     //   [zone](/compute/docs/zones#available) in which the cluster
+         *     //   resides.
+         *     zone: "",
+         *
+         *     // * The name of the cluster to delete.
+         *     clusterId: "",
+         *
+         *     // Auth client
+         *     auth: authClient
+         *   };
+         *
+         *   container.projects.zones.clusters.delete(request, function(err, result) {
+         *     if (err) {
+         *       console.log(err);
+         *     } else {
+         *       console.log(result);
+         *     }
+         *   });
+         * });
          *
          * @alias container.projects.zones.clusters.delete
          * @memberOf! container(v1)
@@ -231,6 +543,59 @@ function Container(options) { // eslint-disable-line
            *
            * @desc Lists the node pools for a cluster.
            *
+           * @example
+           * // BEFORE RUNNING:
+           * // ---------------
+           * // 1. If not already done, enable the Google Container Engine API
+           * //    and check the quota for your project at
+           * //    https://console.developers.google.com/apis/api/container
+           * // 2. This sample uses Application Default Credentials for authentication.
+           * //    If not already done, install the gcloud CLI from
+           * //    https://cloud.google.com/sdk/ and run
+           * //    'gcloud beta auth application-default login'
+           * // 3. Install the Node.js client library and Application Default Credentials
+           * //    library by running 'npm install googleapis --save'
+           * var google = require('googleapis');
+           * var container = google.container('v1');
+           *
+           * google.auth.getApplicationDefault(function(err, authClient) {
+           *   if (err) {
+           *     console.log('Authentication failed because of ', err);
+           *     return;
+           *   }
+           *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+           *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+           *     authClient = authClient.createScoped(scopes);
+           *   }
+           *
+           *   var request = {
+           *     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
+           *
+           *     // * The Google Developers Console [project ID or project
+           *     //   number](https://developers.google.com/console/help/new/#projectnumber).
+           *     projectId: "",
+           *
+           *     // * The name of the Google Compute Engine
+           *     //   [zone](/compute/docs/zones#available) in which the cluster
+           *     //   resides.
+           *     zone: "",
+           *
+           *     // * The name of the cluster.
+           *     clusterId: "",
+           *
+           *     // Auth client
+           *     auth: authClient
+           *   };
+           *
+           *   container.projects.zones.clusters.nodePools.list(request, function(err, result) {
+           *     if (err) {
+           *       console.log(err);
+           *     } else {
+           *       console.log(result);
+           *     }
+           *   });
+           * });
+           *
            * @alias container.projects.zones.clusters.nodePools.list
            * @memberOf! container(v1)
            *
@@ -260,6 +625,62 @@ function Container(options) { // eslint-disable-line
            * container.projects.zones.clusters.nodePools.get
            *
            * @desc Retrieves the node pool requested.
+           *
+           * @example
+           * // BEFORE RUNNING:
+           * // ---------------
+           * // 1. If not already done, enable the Google Container Engine API
+           * //    and check the quota for your project at
+           * //    https://console.developers.google.com/apis/api/container
+           * // 2. This sample uses Application Default Credentials for authentication.
+           * //    If not already done, install the gcloud CLI from
+           * //    https://cloud.google.com/sdk/ and run
+           * //    'gcloud beta auth application-default login'
+           * // 3. Install the Node.js client library and Application Default Credentials
+           * //    library by running 'npm install googleapis --save'
+           * var google = require('googleapis');
+           * var container = google.container('v1');
+           *
+           * google.auth.getApplicationDefault(function(err, authClient) {
+           *   if (err) {
+           *     console.log('Authentication failed because of ', err);
+           *     return;
+           *   }
+           *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+           *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+           *     authClient = authClient.createScoped(scopes);
+           *   }
+           *
+           *   var request = {
+           *     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
+           *
+           *     // * The Google Developers Console [project ID or project
+           *     //   number](https://developers.google.com/console/help/new/#projectnumber).
+           *     projectId: "",
+           *
+           *     // * The name of the Google Compute Engine
+           *     //   [zone](/compute/docs/zones#available) in which the cluster
+           *     //   resides.
+           *     zone: "",
+           *
+           *     // * The name of the cluster.
+           *     clusterId: "",
+           *
+           *     // * The name of the node pool.
+           *     nodePoolId: "",
+           *
+           *     // Auth client
+           *     auth: authClient
+           *   };
+           *
+           *   container.projects.zones.clusters.nodePools.get(request, function(err, result) {
+           *     if (err) {
+           *       console.log(err);
+           *     } else {
+           *       console.log(result);
+           *     }
+           *   });
+           * });
            *
            * @alias container.projects.zones.clusters.nodePools.get
            * @memberOf! container(v1)
@@ -292,6 +713,61 @@ function Container(options) { // eslint-disable-line
            *
            * @desc Creates a node pool for a cluster.
            *
+           * @example
+           * // BEFORE RUNNING:
+           * // ---------------
+           * // 1. If not already done, enable the Google Container Engine API
+           * //    and check the quota for your project at
+           * //    https://console.developers.google.com/apis/api/container
+           * // 2. This sample uses Application Default Credentials for authentication.
+           * //    If not already done, install the gcloud CLI from
+           * //    https://cloud.google.com/sdk/ and run
+           * //    'gcloud beta auth application-default login'
+           * // 3. Install the Node.js client library and Application Default Credentials
+           * //    library by running 'npm install googleapis --save'
+           * var google = require('googleapis');
+           * var container = google.container('v1');
+           *
+           * google.auth.getApplicationDefault(function(err, authClient) {
+           *   if (err) {
+           *     console.log('Authentication failed because of ', err);
+           *     return;
+           *   }
+           *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+           *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+           *     authClient = authClient.createScoped(scopes);
+           *   }
+           *
+           *   var request = {
+           *     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
+           *
+           *     // * The Google Developers Console [project ID or project
+           *     //   number](https://developers.google.com/console/help/new/#projectnumber).
+           *     projectId: "",
+           *
+           *     // * The name of the Google Compute Engine
+           *     //   [zone](/compute/docs/zones#available) in which the cluster
+           *     //   resides.
+           *     zone: "",
+           *
+           *     // * The name of the cluster.
+           *     clusterId: "",
+           *
+           *     resource: {},
+           *
+           *     // Auth client
+           *     auth: authClient
+           *   };
+           *
+           *   container.projects.zones.clusters.nodePools.create(request, function(err, result) {
+           *     if (err) {
+           *       console.log(err);
+           *     } else {
+           *       console.log(result);
+           *     }
+           *   });
+           * });
+           *
            * @alias container.projects.zones.clusters.nodePools.create
            * @memberOf! container(v1)
            *
@@ -322,6 +798,62 @@ function Container(options) { // eslint-disable-line
            * container.projects.zones.clusters.nodePools.delete
            *
            * @desc Deletes a node pool from a cluster.
+           *
+           * @example
+           * // BEFORE RUNNING:
+           * // ---------------
+           * // 1. If not already done, enable the Google Container Engine API
+           * //    and check the quota for your project at
+           * //    https://console.developers.google.com/apis/api/container
+           * // 2. This sample uses Application Default Credentials for authentication.
+           * //    If not already done, install the gcloud CLI from
+           * //    https://cloud.google.com/sdk/ and run
+           * //    'gcloud beta auth application-default login'
+           * // 3. Install the Node.js client library and Application Default Credentials
+           * //    library by running 'npm install googleapis --save'
+           * var google = require('googleapis');
+           * var container = google.container('v1');
+           *
+           * google.auth.getApplicationDefault(function(err, authClient) {
+           *   if (err) {
+           *     console.log('Authentication failed because of ', err);
+           *     return;
+           *   }
+           *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+           *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+           *     authClient = authClient.createScoped(scopes);
+           *   }
+           *
+           *   var request = {
+           *     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
+           *
+           *     // * The Google Developers Console [project ID or project
+           *     //   number](https://developers.google.com/console/help/new/#projectnumber).
+           *     projectId: "",
+           *
+           *     // * The name of the Google Compute Engine
+           *     //   [zone](/compute/docs/zones#available) in which the cluster
+           *     //   resides.
+           *     zone: "",
+           *
+           *     // * The name of the cluster.
+           *     clusterId: "",
+           *
+           *     // * The name of the node pool to delete.
+           *     nodePoolId: "",
+           *
+           *     // Auth client
+           *     auth: authClient
+           *   };
+           *
+           *   container.projects.zones.clusters.nodePools.delete(request, function(err, result) {
+           *     if (err) {
+           *       console.log(err);
+           *     } else {
+           *       console.log(result);
+           *     }
+           *   });
+           * });
            *
            * @alias container.projects.zones.clusters.nodePools.delete
            * @memberOf! container(v1)
@@ -358,6 +890,55 @@ function Container(options) { // eslint-disable-line
          *
          * @desc Lists all operations in a project in a specific zone or all zones.
          *
+         * @example
+         * // BEFORE RUNNING:
+         * // ---------------
+         * // 1. If not already done, enable the Google Container Engine API
+         * //    and check the quota for your project at
+         * //    https://console.developers.google.com/apis/api/container
+         * // 2. This sample uses Application Default Credentials for authentication.
+         * //    If not already done, install the gcloud CLI from
+         * //    https://cloud.google.com/sdk/ and run
+         * //    'gcloud beta auth application-default login'
+         * // 3. Install the Node.js client library and Application Default Credentials
+         * //    library by running 'npm install googleapis --save'
+         * var google = require('googleapis');
+         * var container = google.container('v1');
+         *
+         * google.auth.getApplicationDefault(function(err, authClient) {
+         *   if (err) {
+         *     console.log('Authentication failed because of ', err);
+         *     return;
+         *   }
+         *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+         *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+         *     authClient = authClient.createScoped(scopes);
+         *   }
+         *
+         *   var request = {
+         *     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
+         *
+         *     // * The Google Developers Console [project ID or project
+         *     //   number](https://support.google.com/cloud/answer/6158840).
+         *     projectId: "",
+         *
+         *     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available)
+         *     //   to return operations for, or `-` for all zones.
+         *     zone: "",
+         *
+         *     // Auth client
+         *     auth: authClient
+         *   };
+         *
+         *   container.projects.zones.operations.list(request, function(err, result) {
+         *     if (err) {
+         *       console.log(err);
+         *     } else {
+         *       console.log(result);
+         *     }
+         *   });
+         * });
+         *
          * @alias container.projects.zones.operations.list
          * @memberOf! container(v1)
          *
@@ -386,6 +967,59 @@ function Container(options) { // eslint-disable-line
          * container.projects.zones.operations.get
          *
          * @desc Gets the specified operation.
+         *
+         * @example
+         * // BEFORE RUNNING:
+         * // ---------------
+         * // 1. If not already done, enable the Google Container Engine API
+         * //    and check the quota for your project at
+         * //    https://console.developers.google.com/apis/api/container
+         * // 2. This sample uses Application Default Credentials for authentication.
+         * //    If not already done, install the gcloud CLI from
+         * //    https://cloud.google.com/sdk/ and run
+         * //    'gcloud beta auth application-default login'
+         * // 3. Install the Node.js client library and Application Default Credentials
+         * //    library by running 'npm install googleapis --save'
+         * var google = require('googleapis');
+         * var container = google.container('v1');
+         *
+         * google.auth.getApplicationDefault(function(err, authClient) {
+         *   if (err) {
+         *     console.log('Authentication failed because of ', err);
+         *     return;
+         *   }
+         *   if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+         *     var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+         *     authClient = authClient.createScoped(scopes);
+         *   }
+         *
+         *   var request = {
+         *     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
+         *
+         *     // * The Google Developers Console [project ID or project
+         *     //   number](https://support.google.com/cloud/answer/6158840).
+         *     projectId: "",
+         *
+         *     // * The name of the Google Compute Engine
+         *     //   [zone](/compute/docs/zones#available) in which the cluster
+         *     //   resides.
+         *     zone: "",
+         *
+         *     // * The server-assigned `name` of the operation.
+         *     operationId: "",
+         *
+         *     // Auth client
+         *     auth: authClient
+         *   };
+         *
+         *   container.projects.zones.operations.get(request, function(err, result) {
+         *     if (err) {
+         *       console.log(err);
+         *     } else {
+         *       console.log(result);
+         *     }
+         *   });
+         * });
          *
          * @alias container.projects.zones.operations.get
          * @memberOf! container(v1)

--- a/apis/content/v2.js
+++ b/apis/content/v2.js
@@ -1745,6 +1745,188 @@ function Content(options) { // eslint-disable-line
     }
 
   };
+
+  self.shippingsettings = {
+
+    /**
+     * content.shippingsettings.custombatch
+     *
+     * @desc Retrieves and updates the shipping settings of multiple accounts in a single request.
+     *
+     * @alias content.shippingsettings.custombatch
+     * @memberOf! content(v2)
+     *
+     * @param {object} params Parameters for request
+     * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+     * @param {content(v2).ShippingsettingsCustomBatchRequest} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    custombatch: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/content/v2/shippingsettings/batch',
+          method: 'POST'
+        },
+        params: params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * content.shippingsettings.get
+     *
+     * @desc Retrieves the shipping settings of the account.
+     *
+     * @alias content.shippingsettings.get
+     * @memberOf! content(v2)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.accountId The ID of the account for which to get/update shipping settings.
+     * @param {string} params.merchantId The ID of the managing account.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/content/v2/{merchantId}/shippingsettings/{accountId}',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['merchantId', 'accountId'],
+        pathParams: ['accountId', 'merchantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * content.shippingsettings.getsupportedcarriers
+     *
+     * @desc Retrieves supported carriers and carrier services for an account.
+     *
+     * @alias content.shippingsettings.getsupportedcarriers
+     * @memberOf! content(v2)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.merchantId The ID of the account for which to retrieve the supported carriers.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    getsupportedcarriers: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/content/v2/{merchantId}/supportedCarriers',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['merchantId'],
+        pathParams: ['merchantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * content.shippingsettings.list
+     *
+     * @desc Lists the shipping settings of the sub-accounts in your Merchant Center account.
+     *
+     * @alias content.shippingsettings.list
+     * @memberOf! content(v2)
+     *
+     * @param {object} params Parameters for request
+     * @param {integer=} params.maxResults The maximum number of shipping settings to return in the response, used for paging.
+     * @param {string} params.merchantId The ID of the managing account.
+     * @param {string=} params.pageToken The token returned by the previous request.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    list: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/content/v2/{merchantId}/shippingsettings',
+          method: 'GET'
+        },
+        params: params,
+        requiredParams: ['merchantId'],
+        pathParams: ['merchantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * content.shippingsettings.patch
+     *
+     * @desc Updates the shipping settings of the account. This method supports patch semantics.
+     *
+     * @alias content.shippingsettings.patch
+     * @memberOf! content(v2)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.accountId The ID of the account for which to get/update shipping settings.
+     * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+     * @param {string} params.merchantId The ID of the managing account.
+     * @param {content(v2).ShippingSettings} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/content/v2/{merchantId}/shippingsettings/{accountId}',
+          method: 'PATCH'
+        },
+        params: params,
+        requiredParams: ['merchantId', 'accountId'],
+        pathParams: ['accountId', 'merchantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    },
+
+    /**
+     * content.shippingsettings.update
+     *
+     * @desc Updates the shipping settings of the account.
+     *
+     * @alias content.shippingsettings.update
+     * @memberOf! content(v2)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.accountId The ID of the account for which to get/update shipping settings.
+     * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+     * @param {string} params.merchantId The ID of the managing account.
+     * @param {content(v2).ShippingSettings} params.resource Request body data
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    update: function (params, callback) {
+      var parameters = {
+        options: {
+          url: 'https://www.googleapis.com/content/v2/{merchantId}/shippingsettings/{accountId}',
+          method: 'PUT'
+        },
+        params: params,
+        requiredParams: ['merchantId', 'accountId'],
+        pathParams: ['accountId', 'merchantId'],
+        context: self
+      };
+
+      return createAPIRequest(parameters, callback);
+    }
+
+  };
 }
 
 /**
@@ -2099,6 +2281,25 @@ function Content(options) { // eslint-disable-line
  * @property {content(v2).AccountTax[]} resources 
  */
 /**
+ * @typedef CarrierRate
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} carrierName Carrier service, such as &quot;UPS&quot; or &quot;Fedex&quot;. The list of supported carriers can be retrieved via the getSupportedCarriers method. Required.
+ * @property {string} carrierService Carrier service, such as &quot;ground&quot; or &quot;2 days&quot;. The list of supported services for a carrier can be retrieved via the getSupportedCarriers method. Required.
+ * @property {content(v2).Price} flatAdjustment Additive shipping rate modifier. Can be negative. For example { &quot;value&quot;: &quot;1&quot;, &quot;currency&quot; : &quot;USD&quot; } adds $1 to the rate, { &quot;value&quot;: &quot;-3&quot;, &quot;currency&quot; : &quot;USD&quot; } removes $3 from the rate. Optional.
+ * @property {string} name Name of the carrier rate. Must be unique per rate group. Required.
+ * @property {string} originPostalCode Shipping origin for this carrier rate. Required.
+ * @property {string} percentageAdjustment Multiplicative shipping rate modifier as a number in decimal notation. Can be negative. For example &quot;5.4&quot; increases the rate by 5.4%, &quot;-3&quot; decreases the rate by 3%. Optional.
+ */
+/**
+ * @typedef CarriersCarrier
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} country The CLDR country code of the carrier (e.g., &quot;US&quot;). Always present.
+ * @property {string} name The name of the carrier (e.g., &quot;UPS&quot;). Always present.
+ * @property {string[]} services A list of supported services (e.g., &quot;ground&quot;) for that carrier. Contains at least one service.
+ */
+/**
  * @typedef Datafeed
  * @memberOf! content(v2)
  * @type object
@@ -2243,6 +2444,13 @@ function Content(options) { // eslint-disable-line
  * @property {content(v2).DatafeedStatus[]} resources 
  */
 /**
+ * @typedef DeliveryTime
+ * @memberOf! content(v2)
+ * @type object
+ * @property {integer} maxTransitTimeInDays Maximum number of business days that is spent in transit. 0 means same day delivery, 1 means next day delivery. Must be greater than or equal to minTransitTimeInDays. Required.
+ * @property {integer} minTransitTimeInDays Minimum number of business days that is spent in transit. 0 means same day delivery, 1 means next day delivery. Required.
+ */
+/**
  * @typedef Error
  * @memberOf! content(v2)
  * @type object
@@ -2257,6 +2465,16 @@ function Content(options) { // eslint-disable-line
  * @property {integer} code The HTTP status of the first error in errors.
  * @property {content(v2).Error[]} errors A list of errors.
  * @property {string} message The message of the first error in errors.
+ */
+/**
+ * @typedef Headers
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).LocationIdSet[]} locations A list of location ID sets. Must be non-empty. Can only be set if all other fields are not set.
+ * @property {string[]} numberOfItems A list of inclusive number of items upper bounds. The last value can be &quot;infinity&quot;. For example [&quot;10&quot;, &quot;50&quot;, &quot;infinity&quot;] represents the headers &quot;&lt;= 10 items&quot;, &quot; 50 items&quot;. Must be non-empty. Can only be set if all other fields are not set.
+ * @property {string[]} postalCodeGroupNames A list of postal group names. The last value can be &quot;all other locations&quot;. Example: [&quot;zone 1&quot;, &quot;zone 2&quot;, &quot;all other locations&quot;]. The referred postal code groups must match the delivery country of the service. Must be non-empty. Can only be set if all other fields are not set.
+ * @property {content(v2).Price[]} prices be &quot;infinity&quot;. For example [{&quot;value&quot;: &quot;10&quot;, &quot;currency&quot;: &quot;USD&quot;}, {&quot;value&quot;: &quot;500&quot;, &quot;currency&quot;: &quot;USD&quot;}, {&quot;value&quot;: &quot;infinity&quot;, &quot;currency&quot;: &quot;USD&quot;}] represents the headers &quot;&lt;= $10&quot;, &quot; $500&quot;. All prices within a service must have the same currency. Must be non-empty. Can only be set if all other fields are not set.
+ * @property {content(v2).Weight[]} weights be &quot;infinity&quot;. For example [{&quot;value&quot;: &quot;10&quot;, &quot;unit&quot;: &quot;kg&quot;}, {&quot;value&quot;: &quot;50&quot;, &quot;unit&quot;: &quot;kg&quot;}, {&quot;value&quot;: &quot;infinity&quot;, &quot;unit&quot;: &quot;kg&quot;}] represents the headers &quot;&lt;= 10kg&quot;, &quot; 50kg&quot;. All weights within a service must have the same unit. Must be non-empty. Can only be set if all other fields are not set.
  */
 /**
  * @typedef Installment
@@ -2328,6 +2546,12 @@ function Content(options) { // eslint-disable-line
  * @memberOf! content(v2)
  * @type object
  * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#inventorySetResponse&quot;.
+ */
+/**
+ * @typedef LocationIdSet
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string[]} locationIds A non-empty list of location IDs. They must all be of the same location type (e.g., state).
  */
 /**
  * @typedef LoyaltyPoints
@@ -2809,6 +3033,21 @@ Start date and end date are separated by a forward slash (/). The start date is 
  * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#ordersUpdateShipmentResponse&quot;.
  */
 /**
+ * @typedef PostalCodeGroup
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} country The CLDR territory code of the country the postal code group applies to. Required.
+ * @property {string} name The name of the postal code group, referred to in headers. Required.
+ * @property {content(v2).PostalCodeRange[]} postalCodeRanges A range of postal codes. Required.
+ */
+/**
+ * @typedef PostalCodeRange
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} postalCodeRangeBegin A postal code or a pattern of the form prefix* denoting the inclusive lower bound of the range defining the area. Examples values: &quot;94108&quot;, &quot;9410*&quot;, &quot;9*&quot;. Required.
+ * @property {string} postalCodeRangeEnd A postal code or a pattern of the form prefix* denoting the inclusive upper bound of the range defining the area. It must have the same length as postalCodeRangeBegin: if postalCodeRangeBegin is a postal code then postalCodeRangeEnd must be a postal code too; if postalCodeRangeBegin is a pattern then postalCodeRangeEnd must be a pattern with the same prefix length. Optional: if not set, then the area is defined as being all the postal codes matching postalCodeRangeBegin.
+ */
+/**
  * @typedef Price
  * @memberOf! content(v2)
  * @type object
@@ -3093,6 +3332,97 @@ Acceptable values are:
  * @property {content(v2).ProductStatus[]} resources 
  */
 /**
+ * @typedef RateGroup
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string[]} applicableShippingLabels A list of shipping labels defining the products to which this rate group applies to. This is a disjunction: only one of the labels has to match for the rate group to apply. May only be empty for the last rate group of a service. Required.
+ * @property {content(v2).CarrierRate[]} carrierRates A list of carrier rates that can be referred to by mainTable or singleValue.
+ * @property {content(v2).Table} mainTable A table defining the rate group, when singleValue is not expressive enough. Can only be set if singleValue is not set.
+ * @property {content(v2).Value} singleValue The value of the rate group (e.g. flat rate $10). Can only be set if mainTable and subtables are not set.
+ * @property {content(v2).Table[]} subtables A list of subtables referred to by mainTable. Can only be set if mainTable is set.
+ */
+/**
+ * @typedef Row
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).Value[]} cells The list of cells that constitute the row. Must have the same length as columnHeaders for two-dimensional tables, a length of 1 for one-dimensional tables. Required.
+ */
+/**
+ * @typedef Service
+ * @memberOf! content(v2)
+ * @type object
+ * @property {boolean} active A boolean exposing the active status of the shipping service. Required.
+ * @property {string} currency The CLDR code of the currency to which this service applies. Must match that of the prices in rate groups.
+ * @property {string} deliveryCountry The CLDR territory code of the country to which the service applies. Required.
+ * @property {content(v2).DeliveryTime} deliveryTime Time spent in various aspects from order to the delivery of the product. Required.
+ * @property {string} name Free-form name of the service. Must be unique within target account. Required.
+ * @property {content(v2).RateGroup[]} rateGroups Shipping rate group definitions. Only the last one is allowed to have an empty applicableShippingLabels, which means &quot;everything else&quot;. The other applicableShippingLabels must not overlap.
+ */
+/**
+ * @typedef ShippingSettings
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} accountId The ID of the account to which these account shipping settings belong. Ignored upon update, always present in get request responses.
+ * @property {content(v2).PostalCodeGroup[]} postalCodeGroups A list of postal code groups that can be referred to in services. Optional.
+ * @property {content(v2).Service[]} services The target account&#39;s list of services. Optional.
+ */
+/**
+ * @typedef ShippingsettingsCustomBatchRequest
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).ShippingsettingsCustomBatchRequestEntry[]} entries The request entries to be processed in the batch.
+ */
+/**
+ * @typedef ShippingsettingsCustomBatchRequestEntry
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} accountId The ID of the account for which to get/update account shipping settings.
+ * @property {integer} batchId An entry ID, unique within the batch request.
+ * @property {string} merchantId The ID of the managing account.
+ * @property {string} method 
+ * @property {content(v2).ShippingSettings} shippingSettings The account shipping settings to update. Only defined if the method is update.
+ */
+/**
+ * @typedef ShippingsettingsCustomBatchResponse
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).ShippingsettingsCustomBatchResponseEntry[]} entries The result of the execution of the batch requests.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#shippingsettingsCustomBatchResponse&quot;.
+ */
+/**
+ * @typedef ShippingsettingsCustomBatchResponseEntry
+ * @memberOf! content(v2)
+ * @type object
+ * @property {integer} batchId The ID of the request entry to which this entry responds.
+ * @property {content(v2).Errors} errors A list of errors defined if, and only if, the request failed.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#shippingsettingsCustomBatchResponseEntry&quot;.
+ * @property {content(v2).ShippingSettings} shippingSettings The retrieved or updated account shipping settings.
+ */
+/**
+ * @typedef ShippingsettingsGetSupportedCarriersResponse
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).CarriersCarrier[]} carriers A list of supported carriers. May be empty.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#shippingsettingsGetSupportedCarriersResponse&quot;.
+ */
+/**
+ * @typedef ShippingsettingsListResponse
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#shippingsettingsListResponse&quot;.
+ * @property {string} nextPageToken The token for the retrieval of the next page of shipping settings.
+ * @property {content(v2).ShippingSettings[]} resources 
+ */
+/**
+ * @typedef Table
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).Headers} columnHeaders Headers of the table&#39;s columns. Optional: if not set then the table has only one dimension.
+ * @property {string} name Name of the table. Required for subtables, ignored for the main table.
+ * @property {content(v2).Headers} rowHeaders Headers of the table&#39;s rows. Required.
+ * @property {content(v2).Row[]} rows The list of rows that constitute the table. Must have the same length as rowHeaders. Required.
+ */
+/**
  * @typedef TestOrder
  * @memberOf! content(v2)
  * @type object
@@ -3151,6 +3481,16 @@ Acceptable values are:
  * @property {string} lastFourDigits The last four digits of the card number.
  * @property {string} predefinedBillingAddress The billing address.
  * @property {string} type The type of instrument. Note that real orders might have different values than the four values accepted by createTestOrder.
+ */
+/**
+ * @typedef Value
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} carrierRateName The name of a carrier rate referring to a carrier rate defined in the same rate group. Can only be set if all other fields are not set.
+ * @property {content(v2).Price} flatRate A flat rate. Can only be set if all other fields are not set.
+ * @property {boolean} noShipping If true, then the product can&#39;t ship. Must be true when set, can only be set if all other fields are not set.
+ * @property {string} pricePercentage A percentage of the price represented as a number in decimal notation (e.g., &quot;5.4&quot;). Can only be set if all other fields are not set.
+ * @property {string} subtableName The name of a subtable. Can only be set in table cells (i.e., not for single values), and only if all other fields are not set.
  */
 /**
  * @typedef Weight

--- a/apis/datastore/v1.js
+++ b/apis/datastore/v1.js
@@ -28,12 +28,12 @@ var createAPIRequest = require('../../lib/apirequest');
  *
  * @example
  * var google = require('googleapis');
- * var datastore = google.datastore('v1beta3');
+ * var datastore = google.datastore('v1');
  *
  * @namespace datastore
  * @type {Function}
- * @version v1beta3
- * @variation v1beta3
+ * @version v1
+ * @variation v1
  * @param {object=} options Options for Datastore
  */
 function Datastore(options) { // eslint-disable-line
@@ -48,18 +48,18 @@ function Datastore(options) { // eslint-disable-line
      * @desc Queries for entities.
      *
      * @alias datastore.projects.runQuery
-     * @memberOf! datastore(v1beta3)
+     * @memberOf! datastore(v1)
      *
      * @param {object} params Parameters for request
      * @param {string} params.projectId The ID of the project against which to make the request.
-     * @param {datastore(v1beta3).RunQueryRequest} params.resource Request body data
+     * @param {datastore(v1).RunQueryRequest} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     runQuery: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://datastore.googleapis.com/v1beta3/projects/{projectId}:runQuery',
+          url: 'https://datastore.googleapis.com/v1/projects/{projectId}:runQuery',
           method: 'POST'
         },
         params: params,
@@ -77,18 +77,18 @@ function Datastore(options) { // eslint-disable-line
      * @desc Begins a new transaction.
      *
      * @alias datastore.projects.beginTransaction
-     * @memberOf! datastore(v1beta3)
+     * @memberOf! datastore(v1)
      *
      * @param {object} params Parameters for request
      * @param {string} params.projectId The ID of the project against which to make the request.
-     * @param {datastore(v1beta3).BeginTransactionRequest} params.resource Request body data
+     * @param {datastore(v1).BeginTransactionRequest} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     beginTransaction: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://datastore.googleapis.com/v1beta3/projects/{projectId}:beginTransaction',
+          url: 'https://datastore.googleapis.com/v1/projects/{projectId}:beginTransaction',
           method: 'POST'
         },
         params: params,
@@ -106,18 +106,18 @@ function Datastore(options) { // eslint-disable-line
      * @desc Allocates IDs for the given keys, which is useful for referencing an entity before it is inserted.
      *
      * @alias datastore.projects.allocateIds
-     * @memberOf! datastore(v1beta3)
+     * @memberOf! datastore(v1)
      *
      * @param {object} params Parameters for request
      * @param {string} params.projectId The ID of the project against which to make the request.
-     * @param {datastore(v1beta3).AllocateIdsRequest} params.resource Request body data
+     * @param {datastore(v1).AllocateIdsRequest} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     allocateIds: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://datastore.googleapis.com/v1beta3/projects/{projectId}:allocateIds',
+          url: 'https://datastore.googleapis.com/v1/projects/{projectId}:allocateIds',
           method: 'POST'
         },
         params: params,
@@ -135,18 +135,18 @@ function Datastore(options) { // eslint-disable-line
      * @desc Looks up entities by key.
      *
      * @alias datastore.projects.lookup
-     * @memberOf! datastore(v1beta3)
+     * @memberOf! datastore(v1)
      *
      * @param {object} params Parameters for request
      * @param {string} params.projectId The ID of the project against which to make the request.
-     * @param {datastore(v1beta3).LookupRequest} params.resource Request body data
+     * @param {datastore(v1).LookupRequest} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     lookup: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://datastore.googleapis.com/v1beta3/projects/{projectId}:lookup',
+          url: 'https://datastore.googleapis.com/v1/projects/{projectId}:lookup',
           method: 'POST'
         },
         params: params,
@@ -164,18 +164,18 @@ function Datastore(options) { // eslint-disable-line
      * @desc Commits a transaction, optionally creating, deleting or modifying some entities.
      *
      * @alias datastore.projects.commit
-     * @memberOf! datastore(v1beta3)
+     * @memberOf! datastore(v1)
      *
      * @param {object} params Parameters for request
      * @param {string} params.projectId The ID of the project against which to make the request.
-     * @param {datastore(v1beta3).CommitRequest} params.resource Request body data
+     * @param {datastore(v1).CommitRequest} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     commit: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://datastore.googleapis.com/v1beta3/projects/{projectId}:commit',
+          url: 'https://datastore.googleapis.com/v1/projects/{projectId}:commit',
           method: 'POST'
         },
         params: params,
@@ -193,18 +193,18 @@ function Datastore(options) { // eslint-disable-line
      * @desc Rolls back a transaction.
      *
      * @alias datastore.projects.rollback
-     * @memberOf! datastore(v1beta3)
+     * @memberOf! datastore(v1)
      *
      * @param {object} params Parameters for request
      * @param {string} params.projectId The ID of the project against which to make the request.
-     * @param {datastore(v1beta3).RollbackRequest} params.resource Request body data
+     * @param {datastore(v1).RollbackRequest} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
     rollback: function (params, callback) {
       var parameters = {
         options: {
-          url: 'https://datastore.googleapis.com/v1beta3/projects/{projectId}:rollback',
+          url: 'https://datastore.googleapis.com/v1/projects/{projectId}:rollback',
           method: 'POST'
         },
         params: params,
@@ -221,16 +221,16 @@ function Datastore(options) { // eslint-disable-line
 
 /**
  * @typedef Value
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} stringValue A UTF-8 encoded string value.
 When `exclude_from_indexes` is false (it is indexed) , may have at most 1500 bytes.
 Otherwise, may be set to at least 1,000,000 bytes.
-* @property {datastore(v1beta3).ArrayValue} arrayValue An array value.
+* @property {datastore(v1).ArrayValue} arrayValue An array value.
 Cannot contain another array value.
 A `Value` instance that sets field `array_value` must not set fields
 `meaning` or `exclude_from_indexes`.
-* @property {datastore(v1beta3).Entity} entityValue An entity value.
+* @property {datastore(v1).Entity} entityValue An entity value.
 
 - May have no key.
 - May have a key with an incomplete key path.
@@ -242,10 +242,10 @@ A `Value` instance that sets field `array_value` must not set fields
 May have at most 1,000,000 bytes.
 When `exclude_from_indexes` is false, may have at most 1500 bytes.
 In JSON requests, must be base64-encoded.
-* @property {datastore(v1beta3).LatLng} geoPointValue A geo point value representing a point on the surface of Earth.
+* @property {datastore(v1).LatLng} geoPointValue A geo point value representing a point on the surface of Earth.
 * @property {string} nullValue A null value.
 * @property {boolean} booleanValue A boolean value.
-* @property {datastore(v1beta3).Key} keyValue A key value.
+* @property {datastore(v1).Key} keyValue A key value.
 * @property {boolean} excludeFromIndexes If the value should be excluded from all indexes including those defined
 explicitly.
 * @property {string} timestampValue A timestamp value.
@@ -254,7 +254,7 @@ any additional precision is rounded down.
 */
 /**
  * @typedef ReadOptions
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} transaction The identifier of the transaction in which to read. A
 transaction identifier is returned by a call to
@@ -264,20 +264,20 @@ Cannot be set to `STRONG` for global queries.
 */
 /**
  * @typedef PropertyOrder
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
  * @property {string} direction The direction to order by. Defaults to `ASCENDING`.
- * @property {datastore(v1beta3).PropertyReference} property The property to order by.
+ * @property {datastore(v1).PropertyReference} property The property to order by.
  */
 /**
  * @typedef CommitRequest
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} transaction The identifier of the transaction associated with the commit. A
 transaction identifier is returned by a call to
 BeginTransaction.
 * @property {string} mode The type of commit to perform. Defaults to `TRANSACTIONAL`.
-* @property {datastore(v1beta3).Mutation[]} mutations The mutations to perform.
+* @property {datastore(v1).Mutation[]} mutations The mutations to perform.
 
 When mode is `TRANSACTIONAL`, mutations affecting a single entity are
 applied in order. The following sequences of mutations affecting a single
@@ -293,43 +293,43 @@ entity.
 */
 /**
  * @typedef Query
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {integer} limit The maximum number of results to return. Applies after all other
 constraints. Optional.
 Unspecified is interpreted as no limit.
 Must be &gt;= 0 if specified.
-* @property {datastore(v1beta3).Filter} filter The filter to apply.
+* @property {datastore(v1).Filter} filter The filter to apply.
 * @property {string} endCursor An ending point for the query results. Query cursors are
 returned in query result batches and
 [can only be used to limit the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets).
-* @property {datastore(v1beta3).PropertyReference[]} distinctOn The properties to make distinct. The query results will contain the first
+* @property {datastore(v1).PropertyReference[]} distinctOn The properties to make distinct. The query results will contain the first
 result for each distinct combination of values for the given properties
 (if empty, all results are returned).
 * @property {integer} offset The number of results to skip. Applies before limit, but after all other
 constraints. Optional. Must be &gt;= 0 if specified.
-* @property {datastore(v1beta3).Projection[]} projection The projection to return. Defaults to returning all properties.
-* @property {datastore(v1beta3).PropertyOrder[]} order The order to apply to the query results (if empty, order is unspecified).
+* @property {datastore(v1).Projection[]} projection The projection to return. Defaults to returning all properties.
+* @property {datastore(v1).PropertyOrder[]} order The order to apply to the query results (if empty, order is unspecified).
 * @property {string} startCursor A starting point for the query results. Query cursors are
 returned in query result batches and
 [can only be used to continue the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets).
-* @property {datastore(v1beta3).KindExpression[]} kind The kinds to query (if empty, returns entities of all kinds).
+* @property {datastore(v1).KindExpression[]} kind The kinds to query (if empty, returns entities of all kinds).
 Currently at most 1 kind may be specified.
 */
 /**
  * @typedef RollbackRequest
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} transaction The transaction identifier, returned by a call to
-google.datastore.v1beta3.Datastore.BeginTransaction.
+google.datastore.v1.Datastore.BeginTransaction.
 */
 /**
  * @typedef EntityResult
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} cursor A cursor that points to the position after the result entity.
 Set only when the `EntityResult` is part of a `QueryResultBatch` message.
-* @property {datastore(v1beta3).Entity} entity The resulting entity.
+* @property {datastore(v1).Entity} entity The resulting entity.
 * @property {string} version The version of the entity, a strictly positive number that monotonically
 increases with changes to the entity.
 
@@ -340,43 +340,43 @@ up the entity, and it is always set except for eventually consistent reads.
 */
 /**
  * @typedef GqlQueryParameter
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).Value} value A value parameter.
+* @property {datastore(v1).Value} value A value parameter.
 * @property {string} cursor A query cursor. Query cursors are returned in query
 result batches.
 */
 /**
  * @typedef ArrayValue
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).Value[]} values Values in the array.
+* @property {datastore(v1).Value[]} values Values in the array.
 The order of this array may not be preserved if it contains a mix of
 indexed and unindexed values.
 */
 /**
  * @typedef Filter
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
- * @property {datastore(v1beta3).PropertyFilter} propertyFilter A filter on a property.
- * @property {datastore(v1beta3).CompositeFilter} compositeFilter A composite filter.
+ * @property {datastore(v1).PropertyFilter} propertyFilter A filter on a property.
+ * @property {datastore(v1).CompositeFilter} compositeFilter A composite filter.
  */
 /**
  * @typedef BeginTransactionResponse
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
  * @property {string} transaction The transaction identifier (always present).
  */
 /**
  * @typedef PartitionId
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
  * @property {string} namespaceId If not empty, the ID of the namespace to which the entities belong.
  * @property {string} projectId The ID of the project to which the entities belong.
  */
 /**
  * @typedef QueryResultBatch
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} snapshotVersion The version number of the snapshot this batch was returned from.
 This applies to the range of results from the query&#39;s `start_cursor` (or
@@ -391,33 +391,33 @@ is valid for all preceding batches.
 Will be set when `skipped_results` != 0.
 * @property {string} entityResultType The result type for every entity in `entity_results`.
 * @property {string} moreResults The state of the query after the current batch.
-* @property {datastore(v1beta3).EntityResult[]} entityResults The results for this batch.
+* @property {datastore(v1).EntityResult[]} entityResults The results for this batch.
 * @property {integer} skippedResults The number of results skipped, typically because of an offset.
 */
 /**
  * @typedef AllocateIdsRequest
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).Key[]} keys A list of keys with incomplete key paths for which to allocate IDs.
+* @property {datastore(v1).Key[]} keys A list of keys with incomplete key paths for which to allocate IDs.
 No key may be reserved/read-only.
 */
 /**
  * @typedef KindExpression
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
  * @property {string} name The name of the kind.
  */
 /**
  * @typedef PropertyFilter
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
- * @property {datastore(v1beta3).Value} value The value to compare the property to.
+ * @property {datastore(v1).Value} value The value to compare the property to.
  * @property {string} op The operator to filter by.
- * @property {datastore(v1beta3).PropertyReference} property The property to filter by.
+ * @property {datastore(v1).PropertyReference} property The property to filter by.
  */
 /**
  * @typedef PathElement
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} kind The kind of the entity.
 A kind matching regex `__.*__` is reserved/read-only.
@@ -433,29 +433,29 @@ Cannot be `&quot;&quot;`.
 */
 /**
  * @typedef RollbackResponse
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
  */
 /**
  * @typedef PropertyReference
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} name The name of the property.
 If name includes &quot;.&quot;s, it may be interpreted as a property name path.
 */
 /**
  * @typedef Projection
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
- * @property {datastore(v1beta3).PropertyReference} property The property to project.
+ * @property {datastore(v1).PropertyReference} property The property to project.
  */
 /**
  * @typedef MutationResult
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {boolean} conflictDetected Whether a conflict was detected for this mutation. Always false when a
 conflict detection strategy field is not set in the mutation.
-* @property {datastore(v1beta3).Key} key The automatically allocated key.
+* @property {datastore(v1).Key} key The automatically allocated key.
 Set only when the mutation allocated a key.
 * @property {string} version The version of the entity on the server after processing the mutation. If
 the mutation doesn&#39;t change anything on the server, then the version will
@@ -465,38 +465,38 @@ than the version of any possible future entity.
 */
 /**
  * @typedef AllocateIdsResponse
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).Key[]} keys The keys specified in the request (in the same order), each with
+* @property {datastore(v1).Key[]} keys The keys specified in the request (in the same order), each with
 its key path completed with a newly allocated ID.
 */
 /**
  * @typedef LookupResponse
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).EntityResult[]} found Entities found as `ResultType.FULL` entities. The order of results in this
+* @property {datastore(v1).EntityResult[]} found Entities found as `ResultType.FULL` entities. The order of results in this
 field is undefined and has no relation to the order of the keys in the
 input.
-* @property {datastore(v1beta3).EntityResult[]} missing Entities not found as `ResultType.KEY_ONLY` entities. The order of results
+* @property {datastore(v1).EntityResult[]} missing Entities not found as `ResultType.KEY_ONLY` entities. The order of results
 in this field is undefined and has no relation to the order of the keys
 in the input.
-* @property {datastore(v1beta3).Key[]} deferred A list of keys that were not looked up due to resource constraints. The
+* @property {datastore(v1).Key[]} deferred A list of keys that were not looked up due to resource constraints. The
 order of results in this field is undefined and has no relation to the
 order of the keys in the input.
 */
 /**
  * @typedef BeginTransactionRequest
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
  */
 /**
  * @typedef Key
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).PartitionId} partitionId Entities are partitioned into subsets, currently identified by a project
+* @property {datastore(v1).PartitionId} partitionId Entities are partitioned into subsets, currently identified by a project
 ID and namespace ID.
 Queries are scoped to a single partition.
-* @property {datastore(v1beta3).PathElement[]} path The entity path.
+* @property {datastore(v1).PathElement[]} path The entity path.
 An entity path consists of one or more elements composed of a kind and a
 string or numerical identifier, which identify entities. The first
 element identifies a _root entity_, the second element identifies
@@ -515,14 +515,14 @@ A path can never be empty, and a path can have at most 100 elements.
 */
 /**
  * @typedef RunQueryResponse
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
- * @property {datastore(v1beta3).QueryResultBatch} batch A batch of query results (always present).
- * @property {datastore(v1beta3).Query} query The parsed form of the `GqlQuery` from the request, if it was set.
+ * @property {datastore(v1).QueryResultBatch} batch A batch of query results (always present).
+ * @property {datastore(v1).Query} query The parsed form of the `GqlQuery` from the request, if it was set.
  */
 /**
  * @typedef Entity
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {object} properties The entity&#39;s properties.
 The map&#39;s keys are property names.
@@ -530,7 +530,7 @@ A property name matching regex `__.*__` is reserved.
 A reserved property name is forbidden in certain documented contexts.
 The name must not contain more than 500 characters.
 The name cannot be `&quot;&quot;`.
-* @property {datastore(v1beta3).Key} key The entity&#39;s key.
+* @property {datastore(v1).Key} key The entity&#39;s key.
 
 An entity must have a key, unless otherwise documented (for example,
 an entity in `Value.entity_value` may have no key).
@@ -539,7 +539,7 @@ or null if it has no key.
 */
 /**
  * @typedef GqlQuery
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} queryString A string of the format described
 [here](https://cloud.google.com/datastore/docs/apis/gql/gql_reference).
@@ -552,7 +552,7 @@ Key must match regex `A-Za-z_$*`, must not match regex
 must bind all values. For example,
 `SELECT * FROM Kind WHERE a = &#39;string literal&#39;` is not allowed, while
 `SELECT * FROM Kind WHERE a = @value` is.
-* @property {datastore(v1beta3).GqlQueryParameter[]} positionalBindings Numbered binding site @1 references the first numbered parameter,
+* @property {datastore(v1).GqlQueryParameter[]} positionalBindings Numbered binding site @1 references the first numbered parameter,
 effectively using 1-based indexing, rather than the usual 0.
 For each binding site numbered i in `query_string`,
 there must be an i-th numbered parameter.
@@ -560,60 +560,60 @@ The inverse must also be true.
 */
 /**
  * @typedef Mutation
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).Entity} insert The entity to insert. The entity must not already exist.
+* @property {datastore(v1).Entity} insert The entity to insert. The entity must not already exist.
 The entity key&#39;s final path element may be incomplete.
-* @property {datastore(v1beta3).Entity} update The entity to update. The entity must already exist.
+* @property {datastore(v1).Entity} update The entity to update. The entity must already exist.
 Must have a complete key path.
 * @property {string} baseVersion The version of the entity that this mutation is being applied to. If this
 does not match the current version on the server, the mutation conflicts.
-* @property {datastore(v1beta3).Entity} upsert The entity to upsert. The entity may or may not already exist.
+* @property {datastore(v1).Entity} upsert The entity to upsert. The entity may or may not already exist.
 The entity key&#39;s final path element may be incomplete.
-* @property {datastore(v1beta3).Key} delete The key of the entity to delete. The entity may or may not already exist.
+* @property {datastore(v1).Key} delete The key of the entity to delete. The entity may or may not already exist.
 Must have a complete key path and must not be reserved/read-only.
 */
 /**
  * @typedef CommitResponse
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).MutationResult[]} mutationResults The result of performing the mutations.
+* @property {datastore(v1).MutationResult[]} mutationResults The result of performing the mutations.
 The i-th mutation result corresponds to the i-th mutation in the request.
 * @property {integer} indexUpdates The number of index entries updated during the commit, or zero if none were
 updated.
 */
 /**
  * @typedef RunQueryRequest
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
-* @property {datastore(v1beta3).PartitionId} partitionId Entities are partitioned into subsets, identified by a partition ID.
+* @property {datastore(v1).PartitionId} partitionId Entities are partitioned into subsets, identified by a partition ID.
 Queries are scoped to a single partition.
 This partition ID is normalized with the standard default context
 partition ID.
-* @property {datastore(v1beta3).GqlQuery} gqlQuery The GQL query to run.
-* @property {datastore(v1beta3).ReadOptions} readOptions The options for this query.
-* @property {datastore(v1beta3).Query} query The query to run.
+* @property {datastore(v1).GqlQuery} gqlQuery The GQL query to run.
+* @property {datastore(v1).ReadOptions} readOptions The options for this query.
+* @property {datastore(v1).Query} query The query to run.
 */
 /**
  * @typedef LookupRequest
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
- * @property {datastore(v1beta3).ReadOptions} readOptions The options for this lookup request.
- * @property {datastore(v1beta3).Key[]} keys Keys of entities to look up.
+ * @property {datastore(v1).ReadOptions} readOptions The options for this lookup request.
+ * @property {datastore(v1).Key[]} keys Keys of entities to look up.
  */
 /**
  * @typedef LatLng
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
  * @property {number} latitude The latitude in degrees. It must be in the range [-90.0, +90.0].
  * @property {number} longitude The longitude in degrees. It must be in the range [-180.0, +180.0].
  */
 /**
  * @typedef CompositeFilter
- * @memberOf! datastore(v1beta3)
+ * @memberOf! datastore(v1)
  * @type object
 * @property {string} op The operator for combining multiple filters.
-* @property {datastore(v1beta3).Filter[]} filters The list of filters to combine.
+* @property {datastore(v1).Filter[]} filters The list of filters to combine.
 Must contain at least one filter.
 */
 module.exports = Datastore;

--- a/apis/genomics/v1.js
+++ b/apis/genomics/v1.js
@@ -1800,6 +1800,7 @@ function Genomics(options) { // eslint-disable-line
  * @memberOf! genomics(v1)
  * @type object
  * @property {genomics(v1).Annotation[]} annotations The annotations to be created. At most 4096 can be specified in a single request.
+ * @property {string} requestId A unique request ID which enables the server to detect duplicated requests. If provided, duplicated requests will result in the same response; if not provided, duplicated requests may result in duplicated data. For a given annotation set, callers should not reuse `request_id`s when writing different batches of annotations - behavior in this case is undefined. A common approach is to use a UUID. For batch jobs where worker crashes are a possibility, consider using some unique variant of a worker or run ID.
  */
 /**
  * @typedef BatchCreateAnnotationsResponse

--- a/apis/genomics/v1alpha2.js
+++ b/apis/genomics/v1alpha2.js
@@ -308,7 +308,7 @@ function Genomics(options) { // eslint-disable-line
     /**
      * genomics.pipelines.setOperationStatus
      *
-     * @desc Sets status of a given operation. All timestamps are sent on each call, and the whole series of events is replaced, in case intermediate calls are lost. Should only be called by VMs created by the Pipelines Service and not by end users.
+     * @desc Sets status of a given operation. Any new timestamps (as determined by description) are appended to TimestampEvents. Should only be called by VMs created by the Pipelines Service and not by end users.
      *
      * @alias genomics.pipelines.setOperationStatus
      * @memberOf! genomics(v1alpha2)

--- a/apis/identitytoolkit/v3.js
+++ b/apis/identitytoolkit/v3.js
@@ -585,6 +585,7 @@ function Identitytoolkit(options) { // eslint-disable-line
  * @memberOf! identitytoolkit(v3)
  * @type object
  * @property {string} appId The app ID of the mobile app, base64(CERT_SHA1):PACKAGE_NAME for Android, BUNDLE_ID for iOS.
+ * @property {string} authFlowType Explicitly specify the auth flow type. Currently only support &quot;CODE_FLOW&quot; type. The field is only used for Google provider.
  * @property {string} clientId The relying party OAuth client ID.
  * @property {string} context The opaque value used by the client to maintain context info between the authentication request and the IDP callback.
  * @property {string} continueUri The URI to which the IDP redirects the user after the federated login flow.
@@ -595,6 +596,7 @@ function Identitytoolkit(options) { // eslint-disable-line
  * @property {string} openidRealm Optional realm for OpenID protocol. The sub string &quot;scheme://domain:port&quot; of the param &quot;continueUri&quot; is used if this is not set.
  * @property {string} otaApp The native app package for OTA installation.
  * @property {string} providerId The IdP ID. For white listed IdPs it&#39;s a short domain name e.g. google.com, aol.com, live.net and yahoo.com. For other OpenID IdPs it&#39;s the OP identifier.
+ * @property {string} sessionId The session_id passed by client.
  */
 /**
  * @typedef IdentitytoolkitRelyingpartyDeleteAccountRequest
@@ -855,6 +857,7 @@ function Identitytoolkit(options) { // eslint-disable-line
  * @property {string} photoUrl The URL of the user profile photo.
  * @property {object[]} providerUserInfo The IDP of the user.
  * @property {string} salt The user&#39;s password salt.
+ * @property {string} screenName User&#39;s screen name at Twitter.
  * @property {string} validSince Timestamp in seconds for valid login token.
  * @property {integer} version Version of the user&#39;s password.
  */

--- a/apis/logging/v2beta1.js
+++ b/apis/logging/v2beta1.js
@@ -152,7 +152,7 @@ function Logging(options) { // eslint-disable-line
        *   var request = {
        *     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
        *
-       *     // * Required. The resource name containing the sinks.
+       *     // * Required. The cloud resource containing the sinks.
        *     //   Example: `"projects/my-logging-project"`.
        *     parent: "projects/{MY-PROJECT}",
        *
@@ -234,7 +234,7 @@ function Logging(options) { // eslint-disable-line
        *   var request = {
        *     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
        *
-       *     // * The resource name of the sink to return.
+       *     // * Required. The resource name of the sink to return.
        *     //   Example: `"projects/my-project-id/sinks/my-sink-id"`.
        *     sinkName: "projects/{MY-PROJECT}/sinks/{MY-SINK}",
        *
@@ -307,7 +307,7 @@ function Logging(options) { // eslint-disable-line
        *   var request = {
        *     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
        *
-       *     // * The resource in which to create the sink.
+       *     // * Required. The resource in which to create the sink.
        *     //   Example: `"projects/my-project-id"`.
        *     //   The new sink must be provided in the request.
        *     parent: "projects/{MY-PROJECT}",
@@ -384,11 +384,9 @@ function Logging(options) { // eslint-disable-line
        *   var request = {
        *     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
        *
-       *     // * The resource name of the sink to update.
-       *     //   Example: `"projects/my-project-id/sinks/my-sink-id"`.
-       *     //   The updated sink must be provided in the request and have the
-       *     //   same name that is specified in `sinkName`.  If the sink does not
-       *     //   exist, it is created.
+       *     // * Required. The resource name of the sink to update, including the parent
+       *     //   resource and the sink identifier.  If the sink does not exist, this method
+       *     //   creates the sink.  Example: `"projects/my-project-id/sinks/my-sink-id"`.
        *     sinkName: "projects/{MY-PROJECT}/sinks/{MY-SINK}",
        *
        *     resource: {},
@@ -463,8 +461,10 @@ function Logging(options) { // eslint-disable-line
        *   var request = {
        *     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
        *
-       *     // * The resource name of the sink to delete.
-       *     //   Example: `"projects/my-project-id/sinks/my-sink-id"`.
+       *     // * Required. The resource name of the sink to delete, including the parent
+       *     //   resource and the sink identifier.  Example:
+       *     //   `"projects/my-project-id/sinks/my-sink-id"`.  It is an error if the sink
+       *     //   does not exist.
        *     sinkName: "projects/{MY-PROJECT}/sinks/{MY-SINK}",
        *
        *     // Auth client

--- a/apis/servicemanagement/v1.js
+++ b/apis/servicemanagement/v1.js
@@ -137,7 +137,7 @@ function Servicemanagement(options) { // eslint-disable-line
      *
      * @param {object} params Parameters for request
      * @param {string=} params.configId 
-     * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+     * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
@@ -165,7 +165,7 @@ function Servicemanagement(options) { // eslint-disable-line
      * @memberOf! servicemanagement(v1)
      *
      * @param {object} params Parameters for request
-     * @param {string} params.serviceName The name of the service. See the `ServiceManager` overview for naming requirements. For example: `example.googleapis.com`.
+     * @param {string} params.serviceName The name of the service. See the [overview](/service-management/overview) for naming requirements. For example: `example.googleapis.com`.
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
@@ -337,7 +337,7 @@ function Servicemanagement(options) { // eslint-disable-line
      * @memberOf! servicemanagement(v1)
      *
      * @param {object} params Parameters for request
-     * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+     * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
@@ -397,7 +397,7 @@ function Servicemanagement(options) { // eslint-disable-line
        *
        * @param {object} params Parameters for request
        * @param {string} params.rolloutId The id of the rollout resource.
-       * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+       * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
@@ -425,7 +425,7 @@ function Servicemanagement(options) { // eslint-disable-line
        * @memberOf! servicemanagement(v1)
        *
        * @param {object} params Parameters for request
-       * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+       * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
        * @param {servicemanagement(v1).Rollout} params.resource Request body data
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
@@ -455,7 +455,7 @@ function Servicemanagement(options) { // eslint-disable-line
        *
        * @param {object} params Parameters for request
        * @param {integer=} params.pageSize The max number of items to include in the response list.
-       * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+       * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
        * @param {string=} params.pageToken The token of the page to retrieve.
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
@@ -487,7 +487,7 @@ function Servicemanagement(options) { // eslint-disable-line
        * @memberOf! servicemanagement(v1)
        *
        * @param {object} params Parameters for request
-       * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+       * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
        * @param {servicemanagement(v1).SubmitConfigSourceRequest} params.resource Request body data
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
@@ -517,7 +517,7 @@ function Servicemanagement(options) { // eslint-disable-line
        *
        * @param {object} params Parameters for request
        * @param {string} params.configId 
-       * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+       * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
@@ -545,7 +545,7 @@ function Servicemanagement(options) { // eslint-disable-line
        * @memberOf! servicemanagement(v1)
        *
        * @param {object} params Parameters for request
-       * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+       * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
        * @param {servicemanagement(v1).Service} params.resource Request body data
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
@@ -575,7 +575,7 @@ function Servicemanagement(options) { // eslint-disable-line
        *
        * @param {object} params Parameters for request
        * @param {integer=} params.pageSize The max number of items to include in the response list.
-       * @param {string} params.serviceName The name of the service.  See the `ServiceManager` overview for naming requirements.  For example: `example.googleapis.com`.
+       * @param {string} params.serviceName The name of the service.  See the [overview](/service-management/overview) for naming requirements.  For example: `example.googleapis.com`.
        * @param {string=} params.pageToken The token of the page to retrieve.
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
@@ -678,11 +678,6 @@ methods in all APIs.
 
 Refer to selector for syntax details.
 */
-/**
- * @typedef ConfigOptions
- * @memberOf! servicemanagement(v1)
- * @type object
- */
 /**
  * @typedef Diagnostic
  * @memberOf! servicemanagement(v1)
@@ -917,8 +912,6 @@ one consumer destination.
 * @property {string} producerProjectId ID of the project that produces and owns this service.
 * @property {string} serviceName The name of the service. See the [overview](/service-management/overview)
 for naming requirements.
-This name must match `google.api.Service.name` in the
-`service_config` field.
 */
 /**
  * @typedef ConfigFile
@@ -1048,8 +1041,6 @@ An example of the generated rollout_id is &#39;2016-02-16r1&#39;
  * @type object
 * @property {servicemanagement(v1).ConfigFile[]} files Set of source configuration files that are used to generate a service
 configuration (`google.api.Service`).
-* @property {servicemanagement(v1).ConfigOptions} options Options to cover use of source configuration within ServiceManager and
-tools
 * @property {string} id A unique ID for a specific instance of this message, typically assigned
 by the client for tracking purpose. If empty, the server may choose to
 generate one instead.
@@ -1409,6 +1400,16 @@ different monitored resource type. A log can be used in at most
 one consumer destination.
 */
 /**
+ * @typedef Enum
+ * @memberOf! servicemanagement(v1)
+ * @type object
+ * @property {string} syntax The source syntax.
+ * @property {servicemanagement(v1).EnumValue[]} enumvalue Enum value definitions.
+ * @property {servicemanagement(v1).Option[]} options Protocol buffer options.
+ * @property {servicemanagement(v1).SourceContext} sourceContext The source context.
+ * @property {string} name Enum type name.
+ */
+/**
  * @typedef SystemParameter
  * @memberOf! servicemanagement(v1)
  * @type object
@@ -1419,16 +1420,6 @@ and etc. It is case sensitive.
 * @property {string} httpHeader Define the HTTP header name to use for the parameter. It is case
 insensitive.
 */
-/**
- * @typedef Enum
- * @memberOf! servicemanagement(v1)
- * @type object
- * @property {string} syntax The source syntax.
- * @property {servicemanagement(v1).EnumValue[]} enumvalue Enum value definitions.
- * @property {servicemanagement(v1).Option[]} options Protocol buffer options.
- * @property {servicemanagement(v1).SourceContext} sourceContext The source context.
- * @property {string} name Enum type name.
- */
 /**
  * @typedef GenerateConfigReportResponse
  * @memberOf! servicemanagement(v1)

--- a/apis/speech/v1beta1.js
+++ b/apis/speech/v1beta1.js
@@ -243,7 +243,7 @@ pure binary representation, whereas JSON representations use base64.
 supported, which must be specified in the following format:
 `gs://bucket_name/object_name` (other URI formats return
 google.rpc.Code.INVALID_ARGUMENT). For more information, see
-[Request URIs](/storage/docs/reference-uris).
+[Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 */
 /**
  * @typedef Operation
@@ -298,8 +298,8 @@ Valid values are `0`-`30`. A value of `0` or `1` will return a maximum of
 * @property {string} languageCode [Optional] The language of the supplied audio as a BCP-47 language tag.
 Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
 If omitted, defaults to &quot;en-US&quot;. See
-[Language Support](/speech/docs/best-practices#language_support) for
-a list of the currently supported language codes.
+[Language Support](https://cloud.google.com/speech/docs/best-practices#language_support)
+for a list of the currently supported language codes.
 * @property {speech(v1beta1).SpeechContext} speechContext [Optional] A means to provide context to assist the speech recognition.
 * @property {string} encoding [Required] Encoding of audio data sent in all `RecognitionAudio` messages.
 * @property {boolean} profanityFilter [Optional] If set to `true`, the server will attempt to filter out
@@ -350,9 +350,12 @@ sequential portions of audio.
  * @typedef SpeechContext
  * @memberOf! speech(v1beta1)
  * @type object
-* @property {string[]} phrases [Optional] A list of up to 50 phrases of up to 100 characters each to
-provide words and phrases &quot;hints&quot; to the speech recognition so that it is
-more likely to recognize them.
+* @property {string[]} phrases [Optional] A list of strings containing words and phrases &quot;hints&quot; so that
+the speech recognition is more likely to recognize them. This can be used
+to improve the accuracy for specific words and phrases, for example, if
+specific commands are typically spoken by the user. This can also be used
+to add additional words to the vocabulary of the recognizer. See
+[usage limits](https://cloud.google.com/speech/limits#content).
 */
 /**
  * @typedef AsyncRecognizeRequest

--- a/apis/storage/v1.js
+++ b/apis/storage/v1.js
@@ -2087,6 +2087,7 @@ function Storage(options) { // eslint-disable-line
      * @param {string=} params.destinationPredefinedAcl Apply a predefined set of access controls to the destination object.
      * @param {string=} params.ifGenerationMatch Makes the operation conditional on whether the object's current generation matches the given value.
      * @param {string=} params.ifMetagenerationMatch Makes the operation conditional on whether the object's current metageneration matches the given value.
+     * @param {string=} params.kmsKeyName Resource name of the Cloud KMS key, of the form projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key, that will be used to encrypt the object. Overrides the object metadata's kms_key_name value, if any.
      * @param {storage(v1).ComposeRequest} params.resource Request body data
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
@@ -2440,6 +2441,7 @@ function Storage(options) { // eslint-disable-line
      * @param {string=} params.ifGenerationNotMatch Makes the operation conditional on whether the object's current generation does not match the given value.
      * @param {string=} params.ifMetagenerationMatch Makes the operation conditional on whether the object's current metageneration matches the given value.
      * @param {string=} params.ifMetagenerationNotMatch Makes the operation conditional on whether the object's current metageneration does not match the given value.
+     * @param {string=} params.kmsKeyName Resource name of the Cloud KMS key, of the form projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key, that will be used to encrypt the object. Overrides the object metadata's kms_key_name value, if any.
      * @param {string=} params.name Name of the object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any. For information about how to URL encode object names to be path safe, see Encoding URI Path Parts.
      * @param {string=} params.predefinedAcl Apply a predefined set of access controls to this object.
      * @param {string=} params.projection Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.
@@ -2707,6 +2709,7 @@ function Storage(options) { // eslint-disable-line
      *
      * @param {object} params Parameters for request
      * @param {string} params.destinationBucket Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.
+     * @param {string=} params.destinationKmsKeyName Resource name of the Cloud KMS key, of the form projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key, that will be used to encrypt the object. Overrides the object metadata's kms_key_name value, if any.
      * @param {string} params.destinationObject Name of the new object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any. For information about how to URL encode object names to be path safe, see Encoding URI Path Parts.
      * @param {string=} params.destinationPredefinedAcl Apply a predefined set of access controls to the destination object.
      * @param {string=} params.ifGenerationMatch Makes the operation conditional on whether the destination object's current generation matches the given value.
@@ -2920,6 +2923,7 @@ function Storage(options) { // eslint-disable-line
  * @property {storage(v1).BucketAccessControl[]} acl Access controls on the bucket.
  * @property {object[]} cors The bucket&#39;s Cross-Origin Resource Sharing (CORS) configuration.
  * @property {storage(v1).ObjectAccessControl[]} defaultObjectAcl Default access controls to apply to new objects when no ACL is provided.
+ * @property {object} encryption Encryption configuration used by default for newly inserted objects, when no encryption config is specified.
  * @property {string} etag HTTP 1.1 Entity tag for the bucket.
  * @property {string} id The ID of the bucket.
  * @property {string} kind The kind of item this is. For buckets, this is always storage#bucket.
@@ -3020,6 +3024,7 @@ function Storage(options) { // eslint-disable-line
  * @property {string} generation The content generation of this object. Used for object versioning.
  * @property {string} id The ID of the object.
  * @property {string} kind The kind of item this is. For objects, this is always storage#object.
+ * @property {string} kmsKeyName Cloud KMS Key used to encrypt this object, if the object is encrypted by such a key.
  * @property {string} md5Hash MD5 hash of the data; encoded using base64. For more information about using the MD5 hash, see Hashes and ETags: Best Practices.
  * @property {string} mediaLink Media download link.
  * @property {object} metadata User-provided metadata, in key/value pairs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis",
-  "version": "12.2.0",
+  "version": "12.3.0",
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "description": "Google APIs Client Library for Node.js",


### PR DESCRIPTION
##### 12.3.0 - 17 August 2016

###### Backwards compatible changes
- Added `management.remarketingAudience.get` to `analytics` `v3` API
- Added `management.remarketingAudience.insert` to `analytics` `v3` API
- Added `management.remarketingAudience.list` to `analytics` `v3` API
- Added `management.remarketingAudience.patch` to `analytics` `v3` API
- Added `management.remarketingAudience.update` to `analytics` `v3` API
- Added `userProfiles.guardianInvitations.list` to `classroom` `v1` API
- Added `userProfiles.guardianInvitations.get` to `classroom` `v1` API
- Added `userProfiles.guardianInvitations.create` to `classroom` `v1` API
- Added `userProfiles.guardianInvitations.patch` to `classroom` `v1` API
- Added `userProfiles.guardians.list` to `classroom` `v1` API
- Added `userProfiles.guardians.get` to `classroom` `v1` API
- Added `userProfiles.guardians.delete` to `classroom` `v1` API
- Added `projects.triggers.create` to `cloudbuild` `v1` API
- Added `projects.triggers.get` to `cloudbuild` `v1` API
- Added `projects.triggers.list` to `cloudbuild` `v1` API
- Added `projects.triggers.delete` to `cloudbuild` `v1` API
- Added `projects.triggers.patch` to `cloudbuild` `v1` API
- Added `backendServices.aggregatedList` to `compute` `alpha` API
- Added `regionInstanceGroupManagers.patch` to `compute` `alpha` API
- Added `regionInstanceGroupManagers.update` to `compute` `alpha` API
- Added `networks.switchToCustomMode` to `compute` `beta` API
- Added `subnetworks.expandIpCidrRange` to `compute` `beta` API
- Added `shippingsettings.custombatch` to `content` `v2` API
- Added `shippingsettings.get` to `content` `v2` API
- Added `shippingsettings.getsupportedcarriers` to `content` `v2` API
- Added `shippingsettings.list` to `content` `v2` API
- Added `shippingsettings.patch` to `content` `v2` API
- Added `shippingsettings.update` to `content` `v2` API
- Added `datastore` `v1` API