### PR TITLE
File encoding on download

### DIFF
--- a/apis/drive/v3.js
+++ b/apis/drive/v3.js
@@ -546,6 +546,7 @@ function Drive(options) { // eslint-disable-line
      * @param {object} params Parameters for request
      * @param {boolean=} params.acknowledgeAbuse Whether the user is acknowledging the risk of downloading known malware or other abusive files. This is only applicable when alt=media.
      * @param {string} params.fileId The ID of the file.
+     * @param {string} params.encoding The encoding of the file to be downloaded (default: utf-8)
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
@@ -560,6 +561,10 @@ function Drive(options) { // eslint-disable-line
         pathParams: ['fileId'],
         context: self
       };
+      
+      if(typeof params.encoding !== 'undefined') {
+        parameters.options.encoding = params.encoding;
+      }
 
       return createAPIRequest(parameters, callback);
     },


### PR DESCRIPTION
Fixes #501 

- [ ] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [ ] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [ ] Approprate changes to readme/docs are included in PR

Added ability to specify file enconding when downloading files from Google Drive.

This also fixes #501 by applying the following:
```javascript
drive.files.get({
  fileId: myFileId,
  alt: "media",
  encoding: null
}, function(err, buffer) {
  // Stuff
  dest.write(buffer);
  dest.close();
});
```