### PR TITLE
Adding ability to override the endpoint URL

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -112,6 +112,11 @@ function createAPIRequest (parameters, callback) {
     return null;
   }
 
+  // Allow for proxied endpoints
+  if (params.url) {
+    options.url = params.url;
+  }
+
   // Parse urls
   if (options.url) {
     options.url = parseString(options.url, params);


### PR DESCRIPTION
Fixes #621 (it's a good idea to open an issue first for discussion)
- [x] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [x] Approprate changes to readme/docs are included in PR

With preventExtensions turned on, it is not possible to duck-punch the ability to override API endpoint URLs. We need this because we are proxying GA requests so they can be properly rate limited and accounted for. This small change makes that possible while maintaining backwards compatibility.
