### PR TITLE
Add support for overriding request options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ google.auth.getApplicationDefault(function (err, authClient) {
   var request = {
     projectId: '<your-project-id>',
     datasetId: '<your-dataset-id>',
-    
+
     // This is a "request-level" option
     auth: authClient
   };
@@ -512,6 +512,22 @@ google.auth.getApplicationDefault(function (err, authClient) {
       console.log(result);
     }
   });
+});
+```
+
+You can also override *request* options per request, such as `url`, `method`,
+and `encoding`.
+
+For example:
+
+```js
+drive.files.export({
+  fileId: 'asxKJod9s79', // A Google Doc
+  mimeType: 'application/pdf'
+}, {
+  encoding: null // Make sure we get the binary data
+}, function (err, buffer) {
+  // ...
 });
 ```
 

--- a/templates/api-endpoint.js
+++ b/templates/api-endpoint.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var createAPIRequest = require('../../lib/apirequest');
+var utils = require('../../lib/utils');
 
 {% set Name = name|capitalize %}
 {% set Version = version|replace('\.', '_')|capitalize %}

--- a/templates/method-partial.js
+++ b/templates/method-partial.js
@@ -32,15 +32,22 @@
  * @param {object} params.resource Request body data
 {% endif -%}
 {% endif -%}
+ * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
  * @param {callback} callback The callback that handles the response.
  * @return {object} Request object
  */
-{% if globalmethods %}this.{{ mname }} ={% else %}{{ mname }}:{% endif %} function (params, callback) {
+{% if globalmethods %}this.{{ mname }} ={% else %}{{ mname }}:{% endif %} function (params, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  options || (options = {});
+
   var parameters = {
-    options: {
+    options: utils.extend({
       url: {{ (rootUrl + servicePath + m.path)|buildurl }},
       method: '{{ m.httpMethod }}'
-    },
+    }, options),
     params: params,
     {%- if m.mediaUpload.protocols.simple.path -%}mediaUrl: {{ [rootUrl, m.mediaUpload.protocols.simple.path]|join('')|buildurl }},{%- endif -%}
     requiredParams: [{%- if m.parameterOrder.length -%}'{{ m.parameterOrder|join("', '")|safe }}'{%- endif -%}],

--- a/test/test.options.js
+++ b/test/test.options.js
@@ -101,6 +101,14 @@ describe('Options', function () {
     assert.equal(req.uri.query, 'key=apikey3');
   });
 
+  it('should allow overriding endpoint options', function () {
+    var google = new googleapis.GoogleApis();
+    var drive = google.drive('v3');
+    var req = drive.files.get({ fileId: 'woot' }, { url: 'https://myproxy.com/drive/v3/files/{fileId}', encoding: null }, utils.noop);
+    assert.equal(req.url, 'https://myproxy.com/drive/v3/files/woot', 'Request used overridden url.');
+    assert.equal(req.encoding, null, 'Request used overridden encoding.');
+  });
+
   it('should apply endpoint options like proxy to oauth transporter', function () {
     var google = new googleapis.GoogleApis();
     var OAuth2 = google.auth.OAuth2;


### PR DESCRIPTION
- [x] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [x] Appropriate changes to readme/docs are included in PR

Fixes #501
Fixes #618
Fixes #621 

## Before

```js
drive.files.export({
  fileId: 'asxKJod9s79', // A Google Doc
  mimeType: 'application/pdf',
  encoding: null // This is ignored
}, , function (err, buffer) {
  // Oh no! buffer got incorrectly interpreted as a string!
});
```

## After

```js
drive.files.export({
  fileId: 'asxKJod9s79', // A Google Doc
  mimeType: 'application/pdf'
}, {
  encoding: null // Make sure we get the binary data
}, function (err, buffer) {
  // Nice, the buffer is actually a Buffer!
});
```