### PR TITLE
Fix broken link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll add you
 to the official list of contributors and be able to accept your patches.
 
-[js-guide]: https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
+[js-guide]: https://google.github.io/styleguide/jsguide.html
 [c-linter]: https://code.google.com/p/closure-linter/
 [indv-cla]: https://developers.google.com/open-source/cla/individual
 [corp-cla]: https://developers.google.com/open-source/cla/corporate


### PR DESCRIPTION
Replaces an outdated link to the Google JavaScript Style Guide

- [&#10003; ] `npm test` succeeds
- [&#10003; ] Pull request has been squashed into 1 commit
- [&#10003; ] I did NOT manually make changes to anything in `apis/`
- [&#10003; ] Code coverage does not decrease (if any source code was changed)
- [&#10003; ] Appropriate JSDoc comments were updated in source code (if applicable)
- [&#10003; ] Appropriate changes to readme/docs are included in PR
