### PR TITLE
Implemented formDataParams parameter for createAPIRequest()

### DIFF
--- a/lib/apirequest.ts
+++ b/lib/apirequest.ts
@@ -124,6 +124,12 @@ function createAPIRequest (parameters, callback) {
     delete params[param];
   });
 
+  const formData = {};
+  (parameters.formDataParams || []).forEach(function (param) {
+    formData[param] = params[param];
+    delete params[param];
+  });
+
   // if authClient is actually a string, use it as an API KEY
   if (typeof authClient === 'string') {
     params.key = params.key || authClient;
@@ -156,6 +162,10 @@ function createAPIRequest (parameters, callback) {
         options.body = media.body;
       }
     }
+  // only add form data to options if form data is given
+  } else if(Object.getOwnPropertyNames(formData).length > 0) {
+    options.formData = formData;
+    options.json = true;
   } else {
     options.json = resource || (
       (options.method === 'GET' || options.method === 'DELETE') ? true : {}

--- a/scripts/generator.ts
+++ b/scripts/generator.ts
@@ -114,6 +114,19 @@ export default class Generator {
     return pathParams;
   }
 
+  private getFormDataParams (params) {
+    const formDataParams = [];
+    if (typeof params !== 'object') {
+      params = {};
+    }
+    Object.keys(params).forEach(function (key) {
+      if (params[key].location === 'formdata') {
+        formDataParams.push(key);
+      }
+    });
+    return formDataParams;
+  }
+
   private getSafeParamName (param) {
     if (RESERVED_PARAMS.indexOf(param) !== -1) {
       return param + '_';
@@ -152,6 +165,7 @@ export default class Generator {
     swig.setFilter('oneLine', this.oneLine);
     swig.setFilter('cleanComments', this.cleanComments);
     swig.setFilter('getPathParams', this.getPathParams);
+    swig.setFilter('getFormDataParams', this.getFormDataParams);
     swig.setFilter('getSafeParamName', this.getSafeParamName);
     swig.setFilter('cleanPaths', (str) => {
       return str.replace(/\/\*\//gi, '/x/').replace(/\/\*`/gi, '/x');

--- a/templates/method-partial.ts
+++ b/templates/method-partial.ts
@@ -1,6 +1,7 @@
 {% set lb = "{" %}
 {% set rb = "}" %}
 {%- set pathParams = m.parameters|getPathParams -%}
+{%- set formDataParams = m.parameters|getFormDataParams -%}
 /**
  * {{ m.id }}
  *
@@ -52,6 +53,7 @@
     {%- if m.mediaUpload.protocols.simple.path -%}mediaUrl: {{ [rootUrl, m.mediaUpload.protocols.simple.path]|join('')|buildurl }},{%- endif -%}
     requiredParams: [{%- if m.parameterOrder.length -%}'{{ m.parameterOrder|join("', '")|safe }}'{%- endif -%}],
     pathParams: [{%- if pathParams.length -%}'{{ pathParams|join("', '")|safe }}'{%- endif -%}],
+    formDataParams: [{%- if formDataParams.length -%}'{{ formDataParams|join("', '")|safe }}'{%- endif -%}],
     context: self
   };
 


### PR DESCRIPTION
This allows certain parameters to be sent as multipart form data instead of query string analogous to pathParams.
I am using this code to implement the Cloud Print API, where file contents need to be sent as multipart form data (e.g. binary blobs). Unfortunately the Cloud Print service is not included in API discovery yet.

- [ X ] `npm test` succeeds
- [ X ] Pull request has been squashed into 1 commit
- [ X ] I did NOT manually make changes to anything in `apis/`
- [ ] Code coverage does not decrease (if any source code was changed)
       I can't call any API with form data officially yet, thus no test
- [ X ] Appropriate JSDoc comments were updated in source code (if applicable)
- [ X ] Approprate changes to readme/docs are included in PR
