### PR TITLE
Make it clearer what a JWT auth scope looks like.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ var jwtClient = new google.auth.JWT(
   key.client_email,
   null,
   key.private_key,
-  [scope1, scope2],
+  ['https://www.googleapis.com/auth/plus.me', 'https://www.googleapis.com/auth/calendar'], // an array of auth scopes
   null
 );
 


### PR DESCRIPTION
Currently the documentation does not indicate what a what an auth scope looks like for JWT authentication. It currently uses the non-descriptive `[scope1, scope2]`.

Instead, I propose to be more explicit, and write out the auth scope URLS:
`['https://www.googleapis.com/auth/plus.me', 'https://www.googleapis.com/auth/calendar']`

Lastly, to give readers more context on what these urls are, I added a descriptive comment afterwards:
`['https://www.googleapis.com/auth/plus.me', 'https://www.googleapis.com/auth/calendar'] // an array of auth scopes`



This also follows the other documentation, for example [Generating an Authentication URL](https://github.com/google/google-api-nodejs-client#generating-an-authentication-url), where auth scopes are explicitly stated.