### PR TITLE
Allow specifying rootUrl at runtime

### DIFF
--- a/templates/method-partial.ts
+++ b/templates/method-partial.ts
@@ -43,13 +43,15 @@
   }
   options || (options = {});
 
+  const rootUrl = options.rootUrl || {{ rootUrl|buildurl }};
+
   const parameters = {
     options: Object.assign({
-      url: {{ (rootUrl + servicePath + m.path)|buildurl }},
+      url: (rootUrl + {{ ('/' + servicePath + m.path)|buildurl }}).replace(/([^:]\/)\/+/g, '$1'),
       method: '{{ m.httpMethod }}'
     }, options),
     params: params,
-    {%- if m.mediaUpload.protocols.simple.path -%}mediaUrl: {{ [rootUrl, m.mediaUpload.protocols.simple.path]|join('')|buildurl }},{%- endif -%}
+    {%- if m.mediaUpload.protocols.simple.path -%}mediaUrl: (rootUrl + {{ ('/' + m.mediaUpload.protocols.simple.path)|buildurl }}).replace(/([^:]\/)\/+/g, '$1'),{%- endif -%}
     requiredParams: [{%- if m.parameterOrder.length -%}'{{ m.parameterOrder|join("', '")|safe }}'{%- endif -%}],
     pathParams: [{%- if pathParams.length -%}'{{ pathParams|join("', '")|safe }}'{%- endif -%}],
     context: self

--- a/test/test.options.ts
+++ b/test/test.options.ts
@@ -119,6 +119,15 @@ describe('Options', () => {
     assert.equal(req.headers.Authorization, 'Bearer abc');
   });
 
+  it('should allow overriding rootUrl via options', () => {
+    const google = new googleapis.GoogleApis();
+    const drive = google.drive('v3');
+    const reqWithSlash = drive.files.get({ fileId: 'woot' }, { rootUrl: 'https://myrooturl.com/' }, utils.noop);
+    assert.equal(reqWithSlash.url, 'https://myrooturl.com/drive/v3/files/woot', 'Request used overridden rootUrl with trailing slash.');
+    const reqWithoutSlash = drive.files.get({ fileId: 'woot' }, { rootUrl: 'https://myrooturl.com' }, utils.noop);
+    assert.equal(reqWithoutSlash.url, 'https://myrooturl.com/drive/v3/files/woot', 'Request used overridden rootUrl.');
+  });
+
   after(() => {
     nock.cleanAll();
     nock.enableNetConnect();


### PR DESCRIPTION
This can be useful for testing (pointing clients at `localhost`) or proxying (if for some reason the `proxy` option is insufficient).

Note that I am still using `buildurl`, though I am only building url fragments. Perhaps it should be renamed to `escapeurl`, as it doesn't even really build a url...

I did not squash so you could see the template changes vs the generated api code changes. Let me know if you want me to do so.


- [x] `npm test` succeeds
- [ ] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [x] Approprate changes to readme/docs are included in PR
