### PR TITLE
Highlights the `resource` Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ npm install googleapis --save
 
 ## Usage
 
-Example: Creates a URL Shortener client and retrieves the long url of the
+**Example** Creates a URL Shortener client and retrieves the long url of the
 given short url:
 
 ``` js
@@ -112,6 +112,23 @@ urlshortener.url.get(params, function (err, response) {
   }
 });
 ```
+
+**Example** Updates an email message's labels, using the `resource`
+parameter to specify the request body.
+
+```
+gmail.users.messages.modify({
+  id: Number,
+  resource: {
+    addLabelIds: Array,
+    removeLabelIds: Array
+  },
+  userId: 'me',
+}, (err, response) => {
+  // ...
+});
+```
+
 
 ### Create a service client
 


### PR DESCRIPTION
Because the `resource` parameter is only briefly mentioned in the README.md, it's
an immensely useful feature that's difficult to track down outside of the code base.
Until better messaging can be provided---the current "Error: No label add or removes
specified" could use some DX love---this example highlights the `resource` parameter
as a feature of this API.

Addresses Issue #808

- [x] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [x] Approprate changes to readme/docs are included in PR
