### PR TITLE
Fix wrong documentation for generateAuthUrl()

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ var url = oauth2Client.generateAuthUrl({
   scope: scopes,
 
   // Optional property that passes state parameters to redirect URI
-  // state: { foo: 'bar' }
+  // state: 'foo'
 });
 ```
 ##### IMPORTANT NOTE


### PR DESCRIPTION
Hi everyone!
The `state` parameter in the auth URL should be a string, as documented here https://developers.google.com/identity/protocols/OAuth2WebServer .

In this README was stated that is possible to pass the `state` as an object literal, but this doesn't work. Changing the parameter to a string works like expected.

Fixes #794 #716