### PR TITLE
Upgrade google-auth-library to v0.11.0 and fix regressions / bugs

### DIFF
--- a/lib/apirequest.ts
+++ b/lib/apirequest.ts
@@ -13,9 +13,7 @@
 
 import * as stream from 'stream';
 import * as parseString from 'string-template';
-
-const DefaultTransporter = require('google-auth-library/lib/transporters.js');
-
+import { DefaultTransporter } from 'google-auth-library/lib/transporters';
 
 function isReadableStream (obj) {
   return obj instanceof stream.Stream &&

--- a/lib/discovery.ts
+++ b/lib/discovery.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs';
 import * as url from 'url';
 import * as util from 'util';
 import createAPIRequest from './apirequest';
-import * as DefaultTransporter from 'google-auth-library/lib/transporters';
+import { DefaultTransporter } from 'google-auth-library/lib/transporters';
 
 const handleError = generatorUtils.handleError;
 const transporter = new DefaultTransporter();

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "google-auth-library": "~0.10.0",
     "async": "~2.3.0",
+    "google-auth-library": "~0.11.0",
     "string-template": "~1.0.0"
   },
   "semistandard": {

--- a/scripts/generator.ts
+++ b/scripts/generator.ts
@@ -20,7 +20,7 @@ import * as fs from 'fs';
 import * as url from 'url';
 import * as util from 'util';
 import { js_beautify } from 'js-beautify';
-import * as DefaultTransporter from 'google-auth-library/lib/transporters';
+import { DefaultTransporter } from 'google-auth-library/lib/transporters';
 import * as minimist from 'minimist';
 
 const handleError = generatorUtils.handleError;

--- a/scripts/generator_utils.ts
+++ b/scripts/generator_utils.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DefaultTransporter } from 'google-auth-library';
+import { DefaultTransporter } from 'google-auth-library/lib/transporters';
 
 /**
  * Build a string used to create a URL from the discovery doc provided URL.

--- a/test/test.apikey.ts
+++ b/test/test.apikey.ts
@@ -15,7 +15,7 @@ import * as assert from 'power-assert';
 import * as async from 'async';
 import * as nock from 'nock';
 import utils from './utils';
-let googleapis = require('../');
+const googleapis = require('../lib/googleapis');
 
 function testGet (drive) {
   const req = drive.files.get({
@@ -82,7 +82,7 @@ describe('API key', () => {
     const google = new googleapis.GoogleApis();
     const OAuth2 = google.auth.OAuth2;
     authClient = new OAuth2('CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_URL');
-    authClient.setCredentials({ access_token: 'abc123' });
+    authClient.credentials = { access_token: 'abc123' };
     localDrive = google.drive('v2');
     localUrlshortener = google.urlshortener('v1');
   });

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -62,7 +62,7 @@ function testNoTokens (urlshortener, oauth2client, cb) {
     shortUrl: '123',
     auth: oauth2client
   }, (err, result) => {
-    assert.equal(err.message, 'No access or refresh token is set.');
+    assert.equal(err.message, 'No access, refresh token or API key is set.');
     assert.equal(result, null);
     cb();
   });

--- a/test/test.options.ts
+++ b/test/test.options.ts
@@ -14,7 +14,7 @@
 import * as assert from 'power-assert';
 import * as nock from 'nock';
 import utils from './utils';
-let googleapis = require('../');
+const googleapis = require('../lib/googleapis');
 
 describe('Options', () => {
   let authClient;
@@ -111,7 +111,7 @@ describe('Options', () => {
     const google = new googleapis.GoogleApis();
     const OAuth2 = google.auth.OAuth2;
     authClient = new OAuth2('CLIENTID', 'CLIENTSECRET', 'REDIRECTURI');
-    authClient.setCredentials({ access_token: 'abc' });
+    authClient.credentials = { access_token: 'abc' };
     const drive = google.drive({ version: 'v2', auth: 'apikey2', proxy: 'http://proxy.example.com' });
     const req = drive.files.get({ auth: authClient, fileId: 'woot' }, utils.noop);
     assert.equal(req.proxy.host, 'proxy.example.com');

--- a/test/test.query.ts
+++ b/test/test.query.ts
@@ -15,7 +15,7 @@ import * as assert from 'power-assert';
 import * as async from 'async';
 import * as nock from 'nock';
 import utils from './utils';
-let googleapis = require('../');
+const googleapis = require('../lib/googleapis');
 
 describe('Query params', () => {
   let localCompute, remoteCompute;
@@ -132,7 +132,7 @@ describe('Query params', () => {
       'CLIENT_SECRET',
       'REDIRECT_URI'
     );
-    oauth2client.setCredentials({ access_token: 'abc123' });
+    oauth2client.credentials = { access_token: 'abc123' };
     let req = localDrive.files.get({
       fileId: '123',
       auth: oauth2client


### PR DESCRIPTION
Fixes #816 

Upgraded google-auth-library to v0.11.0 and fixed some bugs that were related to the switch to typescript, eg. no setCredentials anymore in favor of getters/setters

- [ x ] `npm test` succeeds
- [ x ] Pull request has been squashed into 1 commit
- [ x ] I did NOT manually make changes to anything in `apis/`
- [ x ] Code coverage does not decrease (if any source code was changed)
- [ x ] Appropriate JSDoc comments were updated in source code (if applicable)
- [ x ] Approprate changes to readme/docs are included in PR
