### PR TITLE
Adds 'types' property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   ],
   "description": "Google APIs Client Library for Node.js",
   "main": "./lib/googleapis.js",
+  "types": "./lib/googleapis.d.ts",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Without this property typescript compiler fails to locate type definitions. Need of "types" parameter in package.js file was mentioned [https://github.com/google/google-api-nodejs-client/pull/785](here), but in some reason this never been done.

- [x] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [x] Appropriate changes to readme/docs are included in PR
