### PR TITLE
feat: distribute functional d.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis",
-  "version": "24.0.0",
+  "version": "25.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "client library"
   ],
   "description": "Google APIs Client Library for Node.js",
-  "main": "./build/src/lib/googleapis.js",
+  "main": "./build/src/index.js",
+  "types": "./build/src/index.d.ts",
   "engines": {
     "node": ">=4.0"
   },

--- a/samples/analytics/analytics.js
+++ b/samples/analytics/analytics.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const analytics = google.analytics('v3');
 const sampleClient = require('../sampleclient');
 

--- a/samples/blogger/blogger.js
+++ b/samples/blogger/blogger.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const blogger = google.blogger('v3');
 const nconf = require('nconf');
 const path = require('path');

--- a/samples/compute/compute.js
+++ b/samples/compute/compute.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const request = require('request');
-const google = require('googleapis');
+const {google} = require('googleapis');
 const compute = google.compute('v1');
 const uri = 'http://metadata/computeMetadata/v1/project/project-id';
 const headers = { 'Metadata-Flavor': 'Google' };

--- a/samples/customsearch/customsearch.js
+++ b/samples/customsearch/customsearch.js
@@ -15,7 +15,7 @@
 
 // Example:  node customsearch.js example_term
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const customsearch = google.customsearch('v1');
 const nconf = require('nconf');
 const path = require('path');

--- a/samples/defaultauth.js
+++ b/samples/defaultauth.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const compute = google.compute('v1');
 
 /**

--- a/samples/directory_v1/group-delete.js
+++ b/samples/directory_v1/group-delete.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
-const googleapis = require('googleapis');
+const {google} = require('googleapis');
 const nconf = require('nconf');
 const path = require('path');
 
 nconf.argv().env().file(path.join(__dirname, '../jwt.keys.json'));
 
 // Create JWT auth object
-const jwt = new googleapis.auth.JWT(
+const jwt = new google.auth.JWT(
   nconf.get('client_email'),
   null,
   nconf.get('private_key'),
@@ -38,7 +38,7 @@ jwt.authorize((err, data) => {
   console.log('You have been successfully authenticated: ', data);
 
   // Get Google Admin API
-  const admin = googleapis.admin('directory_v1');
+  const admin = google.admin('directory_v1');
 
   // Delete group
   admin.groups.insert({

--- a/samples/directory_v1/group-email-delete.js
+++ b/samples/directory_v1/group-email-delete.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
-const googleapis = require('googleapis');
+const {google} = require('googleapis');
 const path = require('path');
 const nconf = require('nconf');
 
 nconf.argv().env().file(path.join(__dirname, '../jwt.keys.json'));
 
 // Create JWT auth object
-const jwt = new googleapis.auth.JWT(
+const jwt = new google.auth.JWT(
   nconf.get('client_email'),
   null,
   nconf.get('private_key'),
@@ -38,7 +38,7 @@ jwt.authorize((err, data) => {
   console.log('You have been successfully authenticated: ', data);
 
   // Get Google Admin API
-  const admin = googleapis.admin('directory_v1');
+  const admin = google.admin('directory_v1');
 
   // Delete member from Google group
   admin.members.delete({

--- a/samples/directory_v1/group-email-insert.js
+++ b/samples/directory_v1/group-email-insert.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
-const googleapis = require('googleapis');
+const {google} = require('googleapis');
 const path = require('path');
 const nconf = require('nconf');
 
 nconf.argv().env().file(path.join(__dirname, '../jwt.keys.json'));
 
 // Create JWT auth object
-const jwt = new googleapis.auth.JWT(
+const jwt = new google.auth.JWT(
   nconf.get('client_email'),
   null,
   nconf.get('private_key'),
@@ -38,7 +38,7 @@ jwt.authorize((err, data) => {
   console.log('You have been successfully authenticated: ', data);
 
   // Get Google Admin API
-  const admin = googleapis.admin('directory_v1');
+  const admin = google.admin('directory_v1');
 
   // Insert member in Google group
   admin.members.insert({

--- a/samples/directory_v1/group-insert.js
+++ b/samples/directory_v1/group-insert.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
-const googleapis = require('googleapis');
+const {google} = require('googleapis');
 const path = require('path');
 const nconf = require('nconf');
 
 nconf.argv().env().file(path.join(__dirname, '../jwt.keys.json'));
 
 // Create JWT auth object
-const jwt = new googleapis.auth.JWT(
+const jwt = new google.auth.JWT(
   nconf.get('client_email'),
   null,
   nconf.get('private_key'),
@@ -38,7 +38,7 @@ jwt.authorize((err, data) => {
   console.log('You have been successfully authenticated: ', data);
 
   // Get Google Admin API
-  const admin = googleapis.admin('directory_v1');
+  const admin = google.admin('directory_v1');
 
   // Insert group
   admin.groups.insert({

--- a/samples/drive/download.js
+++ b/samples/drive/download.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 const fs = require('fs');
 

--- a/samples/drive/export.js
+++ b/samples/drive/export.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 const fs = require('fs');
 

--- a/samples/drive/list.js
+++ b/samples/drive/list.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 
 const drive = google.drive({

--- a/samples/jwt.js
+++ b/samples/jwt.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const drive = google.drive('v2');
 const nconf = require('nconf');
 const path = require('path');

--- a/samples/mediaupload.js
+++ b/samples/mediaupload.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const drive = google.drive('v2');
 const sampleClient = require('./sampleclient');
 

--- a/samples/mirror/mirror.js
+++ b/samples/mirror/mirror.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 
 // initialize the Google Mirror API library

--- a/samples/multiple.js
+++ b/samples/multiple.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const urlshortener = google.urlshortener('v1');
 const plus = google.plus('v1');
 const nconf = require('nconf');

--- a/samples/oauth2.js
+++ b/samples/oauth2.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const nconf = require('nconf');
 const readline = require('readline');
 const plus = google.plus('v1');

--- a/samples/people/me.js
+++ b/samples/people/me.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 
 const plus = google.plus({

--- a/samples/sampleclient.js
+++ b/samples/sampleclient.js
@@ -18,7 +18,7 @@
  * an oauth2 workflow.
  */
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const OAuth2Client = google.auth.OAuth2;
 const http = require('http');
 const url = require('url');

--- a/samples/urlshortener/urlshortener.js
+++ b/samples/urlshortener/urlshortener.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const path = require('path');
 const nconf = require('nconf');
 

--- a/samples/youtube/playlist.js
+++ b/samples/youtube/playlist.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 
 // initialize the Youtube API library

--- a/samples/youtube/search.js
+++ b/samples/youtube/search.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 
 // initialize the Youtube API library

--- a/samples/youtube/upload.js
+++ b/samples/youtube/upload.js
@@ -17,7 +17,7 @@
  * Usage: node upload.js PATH_TO_VIDEO_FILE
  */
 
-const google = require('googleapis');
+const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 const fs = require('fs');
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -492,390 +492,392 @@ function getAPI(api, options) {
   }
 }
 
-export function abusiveexperiencereport(options) {
-  return getAPI.call(this, 'abusiveexperiencereport', options);
-}
-export function acceleratedmobilepageurl(options) {
-  return getAPI.call(this, 'acceleratedmobilepageurl', options);
-}
-export function adexchangebuyer(options) {
-  return getAPI.call(this, 'adexchangebuyer', options);
-}
-export function adexchangebuyer2(options) {
-  return getAPI.call(this, 'adexchangebuyer2', options);
-}
-export function adexchangeseller(options) {
-  return getAPI.call(this, 'adexchangeseller', options);
-}
-export function adexperiencereport(options) {
-  return getAPI.call(this, 'adexperiencereport', options);
-}
-export function admin(options) {
-  return getAPI.call(this, 'admin', options);
-}
-export function adsense(options) {
-  return getAPI.call(this, 'adsense', options);
-}
-export function adsensehost(options) {
-  return getAPI.call(this, 'adsensehost', options);
-}
-export function analytics(options) {
-  return getAPI.call(this, 'analytics', options);
-}
-export function analyticsreporting(options) {
-  return getAPI.call(this, 'analyticsreporting', options);
-}
-export function androiddeviceprovisioning(options) {
-  return getAPI.call(this, 'androiddeviceprovisioning', options);
-}
-export function androidenterprise(options) {
-  return getAPI.call(this, 'androidenterprise', options);
-}
-export function androidmanagement(options) {
-  return getAPI.call(this, 'androidmanagement', options);
-}
-export function androidpublisher(options) {
-  return getAPI.call(this, 'androidpublisher', options);
-}
-export function appengine(options) {
-  return getAPI.call(this, 'appengine', options);
-}
-export function appsactivity(options) {
-  return getAPI.call(this, 'appsactivity', options);
-}
-export function appstate(options) {
-  return getAPI.call(this, 'appstate', options);
-}
-export function bigquery(options) {
-  return getAPI.call(this, 'bigquery', options);
-}
-export function bigquerydatatransfer(options) {
-  return getAPI.call(this, 'bigquerydatatransfer', options);
-}
-export function blogger(options) {
-  return getAPI.call(this, 'blogger', options);
-}
-export function books(options) {
-  return getAPI.call(this, 'books', options);
-}
-export function calendar(options) {
-  return getAPI.call(this, 'calendar', options);
-}
-export function civicinfo(options) {
-  return getAPI.call(this, 'civicinfo', options);
-}
-export function classroom(options) {
-  return getAPI.call(this, 'classroom', options);
-}
-export function cloudbilling(options) {
-  return getAPI.call(this, 'cloudbilling', options);
-}
-export function cloudbuild(options) {
-  return getAPI.call(this, 'cloudbuild', options);
-}
-export function clouddebugger(options) {
-  return getAPI.call(this, 'clouddebugger', options);
-}
-export function clouderrorreporting(options) {
-  return getAPI.call(this, 'clouderrorreporting', options);
-}
-export function cloudfunctions(options) {
-  return getAPI.call(this, 'cloudfunctions', options);
-}
-export function cloudiot(options) {
-  return getAPI.call(this, 'cloudiot', options);
-}
-export function cloudkms(options) {
-  return getAPI.call(this, 'cloudkms', options);
-}
-export function cloudresourcemanager(options) {
-  return getAPI.call(this, 'cloudresourcemanager', options);
-}
-export function cloudshell(options) {
-  return getAPI.call(this, 'cloudshell', options);
-}
-export function cloudtasks(options) {
-  return getAPI.call(this, 'cloudtasks', options);
-}
-export function cloudtrace(options) {
-  return getAPI.call(this, 'cloudtrace', options);
-}
-export function clouduseraccounts(options) {
-  return getAPI.call(this, 'clouduseraccounts', options);
-}
-export function compute(options) {
-  return getAPI.call(this, 'compute', options);
-}
-export function container(options) {
-  return getAPI.call(this, 'container', options);
-}
-export function content(options) {
-  return getAPI.call(this, 'content', options);
-}
-export function customsearch(options) {
-  return getAPI.call(this, 'customsearch', options);
-}
-export function dataflow(options) {
-  return getAPI.call(this, 'dataflow', options);
-}
-export function dataproc(options) {
-  return getAPI.call(this, 'dataproc', options);
-}
-export function datastore(options) {
-  return getAPI.call(this, 'datastore', options);
-}
-export function deploymentmanager(options) {
-  return getAPI.call(this, 'deploymentmanager', options);
-}
-export function dfareporting(options) {
-  return getAPI.call(this, 'dfareporting', options);
-}
-export function dialogflow(options) {
-  return getAPI.call(this, 'dialogflow', options);
-}
-export function digitalassetlinks(options) {
-  return getAPI.call(this, 'digitalassetlinks', options);
-}
-export function discovery(options) {
-  return getAPI.call(this, 'discovery', options);
-}
-export function dlp(options) {
-  return getAPI.call(this, 'dlp', options);
-}
-export function dns(options) {
-  return getAPI.call(this, 'dns', options);
-}
-export function doubleclickbidmanager(options) {
-  return getAPI.call(this, 'doubleclickbidmanager', options);
-}
-export function doubleclicksearch(options) {
-  return getAPI.call(this, 'doubleclicksearch', options);
-}
-export function drive(options) {
-  return getAPI.call(this, 'drive', options);
-}
-export function firebasedynamiclinks(options) {
-  return getAPI.call(this, 'firebasedynamiclinks', options);
-}
-export function firebaseremoteconfig(options) {
-  return getAPI.call(this, 'firebaseremoteconfig', options);
-}
-export function firebaserules(options) {
-  return getAPI.call(this, 'firebaserules', options);
-}
-export function firestore(options) {
-  return getAPI.call(this, 'firestore', options);
-}
-export function fitness(options) {
-  return getAPI.call(this, 'fitness', options);
-}
-export function fusiontables(options) {
-  return getAPI.call(this, 'fusiontables', options);
-}
-export function games(options) {
-  return getAPI.call(this, 'games', options);
-}
-export function gamesConfiguration(options) {
-  return getAPI.call(this, 'gamesConfiguration', options);
-}
-export function gamesManagement(options) {
-  return getAPI.call(this, 'gamesManagement', options);
-}
-export function genomics(options) {
-  return getAPI.call(this, 'genomics', options);
-}
-export function gmail(options) {
-  return getAPI.call(this, 'gmail', options);
-}
-export function groupsmigration(options) {
-  return getAPI.call(this, 'groupsmigration', options);
-}
-export function groupssettings(options) {
-  return getAPI.call(this, 'groupssettings', options);
-}
-export function iam(options) {
-  return getAPI.call(this, 'iam', options);
-}
-export function identitytoolkit(options) {
-  return getAPI.call(this, 'identitytoolkit', options);
-}
-export function kgsearch(options) {
-  return getAPI.call(this, 'kgsearch', options);
-}
-export function language(options) {
-  return getAPI.call(this, 'language', options);
-}
-export function licensing(options) {
-  return getAPI.call(this, 'licensing', options);
-}
-export function logging(options) {
-  return getAPI.call(this, 'logging', options);
-}
-export function manufacturers(options) {
-  return getAPI.call(this, 'manufacturers', options);
-}
-export function mirror(options) {
-  return getAPI.call(this, 'mirror', options);
-}
-export function ml(options) {
-  return getAPI.call(this, 'ml', options);
-}
-export function monitoring(options) {
-  return getAPI.call(this, 'monitoring', options);
-}
-export function oauth2(options) {
-  return getAPI.call(this, 'oauth2', options);
-}
-export function oslogin(options) {
-  return getAPI.call(this, 'oslogin', options);
-}
-export function pagespeedonline(options) {
-  return getAPI.call(this, 'pagespeedonline', options);
-}
-export function partners(options) {
-  return getAPI.call(this, 'partners', options);
-}
-export function people(options) {
-  return getAPI.call(this, 'people', options);
-}
-export function playcustomapp(options) {
-  return getAPI.call(this, 'playcustomapp', options);
-}
-export function plus(options) {
-  return getAPI.call(this, 'plus', options);
-}
-export function plusDomains(options) {
-  return getAPI.call(this, 'plusDomains', options);
-}
-export function poly(options) {
-  return getAPI.call(this, 'poly', options);
-}
-export function prediction(options) {
-  return getAPI.call(this, 'prediction', options);
-}
-export function proximitybeacon(options) {
-  return getAPI.call(this, 'proximitybeacon', options);
-}
-export function pubsub(options) {
-  return getAPI.call(this, 'pubsub', options);
-}
-export function replicapool(options) {
-  return getAPI.call(this, 'replicapool', options);
-}
-export function replicapoolupdater(options) {
-  return getAPI.call(this, 'replicapoolupdater', options);
-}
-export function reseller(options) {
-  return getAPI.call(this, 'reseller', options);
-}
-export function resourceviews(options) {
-  return getAPI.call(this, 'resourceviews', options);
-}
-export function runtimeconfig(options) {
-  return getAPI.call(this, 'runtimeconfig', options);
-}
-export function safebrowsing(options) {
-  return getAPI.call(this, 'safebrowsing', options);
-}
-export function script(options) {
-  return getAPI.call(this, 'script', options);
-}
-export function searchconsole(options) {
-  return getAPI.call(this, 'searchconsole', options);
-}
-export function serviceconsumermanagement(options) {
-  return getAPI.call(this, 'serviceconsumermanagement', options);
-}
-export function servicecontrol(options) {
-  return getAPI.call(this, 'servicecontrol', options);
-}
-export function servicemanagement(options) {
-  return getAPI.call(this, 'servicemanagement', options);
-}
-export function serviceuser(options) {
-  return getAPI.call(this, 'serviceuser', options);
-}
-export function sheets(options) {
-  return getAPI.call(this, 'sheets', options);
-}
-export function siteVerification(options) {
-  return getAPI.call(this, 'siteVerification', options);
-}
-export function slides(options) {
-  return getAPI.call(this, 'slides', options);
-}
-export function sourcerepo(options) {
-  return getAPI.call(this, 'sourcerepo', options);
-}
-export function spanner(options) {
-  return getAPI.call(this, 'spanner', options);
-}
-export function spectrum(options) {
-  return getAPI.call(this, 'spectrum', options);
-}
-export function speech(options) {
-  return getAPI.call(this, 'speech', options);
-}
-export function sqladmin(options) {
-  return getAPI.call(this, 'sqladmin', options);
-}
-export function storage(options) {
-  return getAPI.call(this, 'storage', options);
-}
-export function storagetransfer(options) {
-  return getAPI.call(this, 'storagetransfer', options);
-}
-export function streetviewpublish(options) {
-  return getAPI.call(this, 'streetviewpublish', options);
-}
-export function surveys(options) {
-  return getAPI.call(this, 'surveys', options);
-}
-export function tagmanager(options) {
-  return getAPI.call(this, 'tagmanager', options);
-}
-export function taskqueue(options) {
-  return getAPI.call(this, 'taskqueue', options);
-}
-export function tasks(options) {
-  return getAPI.call(this, 'tasks', options);
-}
-export function testing(options) {
-  return getAPI.call(this, 'testing', options);
-}
-export function toolresults(options) {
-  return getAPI.call(this, 'toolresults', options);
-}
-export function tpu(options) {
-  return getAPI.call(this, 'tpu', options);
-}
-export function translate(options) {
-  return getAPI.call(this, 'translate', options);
-}
-export function urlshortener(options) {
-  return getAPI.call(this, 'urlshortener', options);
-}
-export function vault(options) {
-  return getAPI.call(this, 'vault', options);
-}
-export function videointelligence(options) {
-  return getAPI.call(this, 'videointelligence', options);
-}
-export function vision(options) {
-  return getAPI.call(this, 'vision', options);
-}
-export function webfonts(options) {
-  return getAPI.call(this, 'webfonts', options);
-}
-export function webmasters(options) {
-  return getAPI.call(this, 'webmasters', options);
-}
-export function youtube(options) {
-  return getAPI.call(this, 'youtube', options);
-}
-export function youtubeAnalytics(options) {
-  return getAPI.call(this, 'youtubeAnalytics', options);
-}
-export function youtubereporting(options) {
-  return getAPI.call(this, 'youtubereporting', options);
+export class GeneratedAPIs {
+  abusiveexperiencereport(options) {
+    return getAPI.call(this, 'abusiveexperiencereport', options);
+  }
+  acceleratedmobilepageurl(options) {
+    return getAPI.call(this, 'acceleratedmobilepageurl', options);
+  }
+  adexchangebuyer(options) {
+    return getAPI.call(this, 'adexchangebuyer', options);
+  }
+  adexchangebuyer2(options) {
+    return getAPI.call(this, 'adexchangebuyer2', options);
+  }
+  adexchangeseller(options) {
+    return getAPI.call(this, 'adexchangeseller', options);
+  }
+  adexperiencereport(options) {
+    return getAPI.call(this, 'adexperiencereport', options);
+  }
+  admin(options) {
+    return getAPI.call(this, 'admin', options);
+  }
+  adsense(options) {
+    return getAPI.call(this, 'adsense', options);
+  }
+  adsensehost(options) {
+    return getAPI.call(this, 'adsensehost', options);
+  }
+  analytics(options) {
+    return getAPI.call(this, 'analytics', options);
+  }
+  analyticsreporting(options) {
+    return getAPI.call(this, 'analyticsreporting', options);
+  }
+  androiddeviceprovisioning(options) {
+    return getAPI.call(this, 'androiddeviceprovisioning', options);
+  }
+  androidenterprise(options) {
+    return getAPI.call(this, 'androidenterprise', options);
+  }
+  androidmanagement(options) {
+    return getAPI.call(this, 'androidmanagement', options);
+  }
+  androidpublisher(options) {
+    return getAPI.call(this, 'androidpublisher', options);
+  }
+  appengine(options) {
+    return getAPI.call(this, 'appengine', options);
+  }
+  appsactivity(options) {
+    return getAPI.call(this, 'appsactivity', options);
+  }
+  appstate(options) {
+    return getAPI.call(this, 'appstate', options);
+  }
+  bigquery(options) {
+    return getAPI.call(this, 'bigquery', options);
+  }
+  bigquerydatatransfer(options) {
+    return getAPI.call(this, 'bigquerydatatransfer', options);
+  }
+  blogger(options) {
+    return getAPI.call(this, 'blogger', options);
+  }
+  books(options) {
+    return getAPI.call(this, 'books', options);
+  }
+  calendar(options) {
+    return getAPI.call(this, 'calendar', options);
+  }
+  civicinfo(options) {
+    return getAPI.call(this, 'civicinfo', options);
+  }
+  classroom(options) {
+    return getAPI.call(this, 'classroom', options);
+  }
+  cloudbilling(options) {
+    return getAPI.call(this, 'cloudbilling', options);
+  }
+  cloudbuild(options) {
+    return getAPI.call(this, 'cloudbuild', options);
+  }
+  clouddebugger(options) {
+    return getAPI.call(this, 'clouddebugger', options);
+  }
+  clouderrorreporting(options) {
+    return getAPI.call(this, 'clouderrorreporting', options);
+  }
+  cloudfunctions(options) {
+    return getAPI.call(this, 'cloudfunctions', options);
+  }
+  cloudiot(options) {
+    return getAPI.call(this, 'cloudiot', options);
+  }
+  cloudkms(options) {
+    return getAPI.call(this, 'cloudkms', options);
+  }
+  cloudresourcemanager(options) {
+    return getAPI.call(this, 'cloudresourcemanager', options);
+  }
+  cloudshell(options) {
+    return getAPI.call(this, 'cloudshell', options);
+  }
+  cloudtasks(options) {
+    return getAPI.call(this, 'cloudtasks', options);
+  }
+  cloudtrace(options) {
+    return getAPI.call(this, 'cloudtrace', options);
+  }
+  clouduseraccounts(options) {
+    return getAPI.call(this, 'clouduseraccounts', options);
+  }
+  compute(options) {
+    return getAPI.call(this, 'compute', options);
+  }
+  container(options) {
+    return getAPI.call(this, 'container', options);
+  }
+  content(options) {
+    return getAPI.call(this, 'content', options);
+  }
+  customsearch(options) {
+    return getAPI.call(this, 'customsearch', options);
+  }
+  dataflow(options) {
+    return getAPI.call(this, 'dataflow', options);
+  }
+  dataproc(options) {
+    return getAPI.call(this, 'dataproc', options);
+  }
+  datastore(options) {
+    return getAPI.call(this, 'datastore', options);
+  }
+  deploymentmanager(options) {
+    return getAPI.call(this, 'deploymentmanager', options);
+  }
+  dfareporting(options) {
+    return getAPI.call(this, 'dfareporting', options);
+  }
+  dialogflow(options) {
+    return getAPI.call(this, 'dialogflow', options);
+  }
+  digitalassetlinks(options) {
+    return getAPI.call(this, 'digitalassetlinks', options);
+  }
+  discovery(options) {
+    return getAPI.call(this, 'discovery', options);
+  }
+  dlp(options) {
+    return getAPI.call(this, 'dlp', options);
+  }
+  dns(options) {
+    return getAPI.call(this, 'dns', options);
+  }
+  doubleclickbidmanager(options) {
+    return getAPI.call(this, 'doubleclickbidmanager', options);
+  }
+  doubleclicksearch(options) {
+    return getAPI.call(this, 'doubleclicksearch', options);
+  }
+  drive(options) {
+    return getAPI.call(this, 'drive', options);
+  }
+  firebasedynamiclinks(options) {
+    return getAPI.call(this, 'firebasedynamiclinks', options);
+  }
+  firebaseremoteconfig(options) {
+    return getAPI.call(this, 'firebaseremoteconfig', options);
+  }
+  firebaserules(options) {
+    return getAPI.call(this, 'firebaserules', options);
+  }
+  firestore(options) {
+    return getAPI.call(this, 'firestore', options);
+  }
+  fitness(options) {
+    return getAPI.call(this, 'fitness', options);
+  }
+  fusiontables(options) {
+    return getAPI.call(this, 'fusiontables', options);
+  }
+  games(options) {
+    return getAPI.call(this, 'games', options);
+  }
+  gamesConfiguration(options) {
+    return getAPI.call(this, 'gamesConfiguration', options);
+  }
+  gamesManagement(options) {
+    return getAPI.call(this, 'gamesManagement', options);
+  }
+  genomics(options) {
+    return getAPI.call(this, 'genomics', options);
+  }
+  gmail(options) {
+    return getAPI.call(this, 'gmail', options);
+  }
+  groupsmigration(options) {
+    return getAPI.call(this, 'groupsmigration', options);
+  }
+  groupssettings(options) {
+    return getAPI.call(this, 'groupssettings', options);
+  }
+  iam(options) {
+    return getAPI.call(this, 'iam', options);
+  }
+  identitytoolkit(options) {
+    return getAPI.call(this, 'identitytoolkit', options);
+  }
+  kgsearch(options) {
+    return getAPI.call(this, 'kgsearch', options);
+  }
+  language(options) {
+    return getAPI.call(this, 'language', options);
+  }
+  licensing(options) {
+    return getAPI.call(this, 'licensing', options);
+  }
+  logging(options) {
+    return getAPI.call(this, 'logging', options);
+  }
+  manufacturers(options) {
+    return getAPI.call(this, 'manufacturers', options);
+  }
+  mirror(options) {
+    return getAPI.call(this, 'mirror', options);
+  }
+  ml(options) {
+    return getAPI.call(this, 'ml', options);
+  }
+  monitoring(options) {
+    return getAPI.call(this, 'monitoring', options);
+  }
+  oauth2(options) {
+    return getAPI.call(this, 'oauth2', options);
+  }
+  oslogin(options) {
+    return getAPI.call(this, 'oslogin', options);
+  }
+  pagespeedonline(options) {
+    return getAPI.call(this, 'pagespeedonline', options);
+  }
+  partners(options) {
+    return getAPI.call(this, 'partners', options);
+  }
+  people(options) {
+    return getAPI.call(this, 'people', options);
+  }
+  playcustomapp(options) {
+    return getAPI.call(this, 'playcustomapp', options);
+  }
+  plus(options) {
+    return getAPI.call(this, 'plus', options);
+  }
+  plusDomains(options) {
+    return getAPI.call(this, 'plusDomains', options);
+  }
+  poly(options) {
+    return getAPI.call(this, 'poly', options);
+  }
+  prediction(options) {
+    return getAPI.call(this, 'prediction', options);
+  }
+  proximitybeacon(options) {
+    return getAPI.call(this, 'proximitybeacon', options);
+  }
+  pubsub(options) {
+    return getAPI.call(this, 'pubsub', options);
+  }
+  replicapool(options) {
+    return getAPI.call(this, 'replicapool', options);
+  }
+  replicapoolupdater(options) {
+    return getAPI.call(this, 'replicapoolupdater', options);
+  }
+  reseller(options) {
+    return getAPI.call(this, 'reseller', options);
+  }
+  resourceviews(options) {
+    return getAPI.call(this, 'resourceviews', options);
+  }
+  runtimeconfig(options) {
+    return getAPI.call(this, 'runtimeconfig', options);
+  }
+  safebrowsing(options) {
+    return getAPI.call(this, 'safebrowsing', options);
+  }
+  script(options) {
+    return getAPI.call(this, 'script', options);
+  }
+  searchconsole(options) {
+    return getAPI.call(this, 'searchconsole', options);
+  }
+  serviceconsumermanagement(options) {
+    return getAPI.call(this, 'serviceconsumermanagement', options);
+  }
+  servicecontrol(options) {
+    return getAPI.call(this, 'servicecontrol', options);
+  }
+  servicemanagement(options) {
+    return getAPI.call(this, 'servicemanagement', options);
+  }
+  serviceuser(options) {
+    return getAPI.call(this, 'serviceuser', options);
+  }
+  sheets(options) {
+    return getAPI.call(this, 'sheets', options);
+  }
+  siteVerification(options) {
+    return getAPI.call(this, 'siteVerification', options);
+  }
+  slides(options) {
+    return getAPI.call(this, 'slides', options);
+  }
+  sourcerepo(options) {
+    return getAPI.call(this, 'sourcerepo', options);
+  }
+  spanner(options) {
+    return getAPI.call(this, 'spanner', options);
+  }
+  spectrum(options) {
+    return getAPI.call(this, 'spectrum', options);
+  }
+  speech(options) {
+    return getAPI.call(this, 'speech', options);
+  }
+  sqladmin(options) {
+    return getAPI.call(this, 'sqladmin', options);
+  }
+  storage(options) {
+    return getAPI.call(this, 'storage', options);
+  }
+  storagetransfer(options) {
+    return getAPI.call(this, 'storagetransfer', options);
+  }
+  streetviewpublish(options) {
+    return getAPI.call(this, 'streetviewpublish', options);
+  }
+  surveys(options) {
+    return getAPI.call(this, 'surveys', options);
+  }
+  tagmanager(options) {
+    return getAPI.call(this, 'tagmanager', options);
+  }
+  taskqueue(options) {
+    return getAPI.call(this, 'taskqueue', options);
+  }
+  tasks(options) {
+    return getAPI.call(this, 'tasks', options);
+  }
+  testing(options) {
+    return getAPI.call(this, 'testing', options);
+  }
+  toolresults(options) {
+    return getAPI.call(this, 'toolresults', options);
+  }
+  tpu(options) {
+    return getAPI.call(this, 'tpu', options);
+  }
+  translate(options) {
+    return getAPI.call(this, 'translate', options);
+  }
+  urlshortener(options) {
+    return getAPI.call(this, 'urlshortener', options);
+  }
+  vault(options) {
+    return getAPI.call(this, 'vault', options);
+  }
+  videointelligence(options) {
+    return getAPI.call(this, 'videointelligence', options);
+  }
+  vision(options) {
+    return getAPI.call(this, 'vision', options);
+  }
+  webfonts(options) {
+    return getAPI.call(this, 'webfonts', options);
+  }
+  webmasters(options) {
+    return getAPI.call(this, 'webmasters', options);
+  }
+  youtube(options) {
+    return getAPI.call(this, 'youtube', options);
+  }
+  youtubeAnalytics(options) {
+    return getAPI.call(this, 'youtubeAnalytics', options);
+  }
+  youtubereporting(options) {
+    return getAPI.call(this, 'youtubereporting', options);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {GoogleApis} from './lib/googleapis';
+const google = new GoogleApis();
+export {google, GoogleApis};

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -16,25 +16,8 @@ import * as fs from 'fs';
 import {DefaultTransporter} from 'google-auth-library';
 import * as url from 'url';
 import * as util from 'util';
-
 import {buildurl, handleError} from '../scripts/generator_utils';
-
 import {createAPIRequest} from './apirequest';
-
-const transporter = new DefaultTransporter();
-
-function getPathParams(params) {
-  const pathParams = [];
-  if (typeof params !== 'object') {
-    params = {};
-  }
-  Object.keys(params).forEach(key => {
-    if (params[key].location === 'path') {
-      pathParams.push(key);
-    }
-  });
-  return pathParams;
-}
 
 interface DiscoverAPIsResponse {
   items: API[];
@@ -45,248 +28,259 @@ interface API {
   api;
 }
 
-/**
- * Given a method schema, add a method to a target.
- *
- * @private
- * @param {object} target The target to which to add the method.
- * @param {object} schema The top-level schema that contains the rootUrl, etc.
- * @param {object} method The method schema from which to generate the method.
- * @param {object} context The context to add to the method.
- */
-function makeMethod(schema, method, context) {
-  return (params, callback) => {
-    const schemaUrl =
-        buildurl(schema.rootUrl + schema.servicePath + method.path);
+export class Discovery {
 
-    const parameters = {
-      options: {
-        url: schemaUrl.substring(1, schemaUrl.length - 1),
-        method: method.httpMethod
-      },
-      params,
-      requiredParams: method.parameterOrder || [],
-      pathParams: getPathParams(method.parameters),
-      context,
-      mediaUrl: null
+  private transporter = new DefaultTransporter();
+  private options: any;
+
+  private getPathParams(params) {
+    const pathParams = [];
+    if (typeof params !== 'object') {
+      params = {};
+    }
+    Object.keys(params).forEach(key => {
+      if (params[key].location === 'path') {
+        pathParams.push(key);
+      }
+    });
+    return pathParams;
+  }
+
+  /**
+   * Given a method schema, add a method to a target.
+   *
+   * @param {object} target The target to which to add the method.
+   * @param {object} schema The top-level schema that contains the rootUrl, etc.
+   * @param {object} method The method schema from which to generate the method.
+   * @param {object} context The context to add to the method.
+   */
+  private makeMethod(schema, method, context) {
+    return (params, callback) => {
+      const schemaUrl =
+          buildurl(schema.rootUrl + schema.servicePath + method.path);
+
+      const parameters = {
+        options: {
+          url: schemaUrl.substring(1, schemaUrl.length - 1),
+          method: method.httpMethod
+        },
+        params,
+        requiredParams: method.parameterOrder || [],
+        pathParams: this.getPathParams(method.parameters),
+        context,
+        mediaUrl: null
+      };
+
+      if (method.mediaUpload && method.mediaUpload.protocols &&
+          method.mediaUpload.protocols.simple &&
+          method.mediaUpload.protocols.simple.path) {
+        const mediaUrl =
+            buildurl(schema.rootUrl + method.mediaUpload.protocols.simple.path);
+        parameters.mediaUrl = mediaUrl.substring(1, mediaUrl.length - 1);
+      }
+
+      return createAPIRequest(parameters, callback);
     };
-
-    if (method.mediaUpload && method.mediaUpload.protocols &&
-        method.mediaUpload.protocols.simple &&
-        method.mediaUpload.protocols.simple.path) {
-      const mediaUrl =
-          buildurl(schema.rootUrl + method.mediaUpload.protocols.simple.path);
-      parameters.mediaUrl = mediaUrl.substring(1, mediaUrl.length - 1);
-    }
-
-    return createAPIRequest(parameters, callback);
-  };
-}
-
-/**
- * Given a schema, add methods to a target.
- *
- * @private
- * @param {object} target The target to which to apply the methods.
- * @param {object} rootSchema The top-level schema, so we don't lose track of it
- * during recursion.
- * @param {object} schema The current schema from which to extract methods.
- * @param {object} context The context to add to each method.
- */
-function applyMethodsFromSchema(target, rootSchema, schema, context) {
-  if (schema.methods) {
-    for (const name in schema.methods) {
-      if (schema.methods.hasOwnProperty(name)) {
-        const method = schema.methods[name];
-        target[name] = makeMethod(rootSchema, method, context);
-      }
-    }
   }
-}
 
-/**
- * Given a schema, add methods and resources to a target.
- *
- * @private
- * @param {object} target The target to which to apply the schema.
- * @param {object} rootSchema The top-level schema, so we don't lose track of it
- * during recursion.
- * @param {object} schema The current schema from which to extract methods and
- * resources.
- * @param {object} context The context to add to each method.
- */
-function applySchema(target, rootSchema, schema, context) {
-  applyMethodsFromSchema(target, rootSchema, schema, context);
-
-  if (schema.resources) {
-    for (const resourceName in schema.resources) {
-      if (schema.resources.hasOwnProperty(resourceName)) {
-        const resource = schema.resources[resourceName];
-        if (!target[resourceName]) {
-          target[resourceName] = {};
+  /**
+   * Given a schema, add methods to a target.
+   *
+   * @param {object} target The target to which to apply the methods.
+   * @param {object} rootSchema The top-level schema, so we don't lose track of it
+   * during recursion.
+   * @param {object} schema The current schema from which to extract methods.
+   * @param {object} context The context to add to each method.
+   */
+  private applyMethodsFromSchema(target, rootSchema, schema, context) {
+    if (schema.methods) {
+      for (const name in schema.methods) {
+        if (schema.methods.hasOwnProperty(name)) {
+          const method = schema.methods[name];
+          target[name] = this.makeMethod(rootSchema, method, context);
         }
-        applySchema(target[resourceName], rootSchema, resource, context);
       }
     }
   }
-}
 
-/**
- * Generate and Endpoint from an endpoint schema object.
- *
- * @private
- * @param {object} schema The schema from which to generate the Endpoint.
- * @return Function The Endpoint.
- */
-function makeEndpoint(schema) {
-  // Creating an object, so Pascal case is appropriate.
-  // tslint:disable-next-line
-  const Endpoint = function(options) {
-    const self = this;
-    self._options = options || {};
+  /**
+   * Given a schema, add methods and resources to a target.
+   *
+   * @param {object} target The target to which to apply the schema.
+   * @param {object} rootSchema The top-level schema, so we don't lose track of it
+   * during recursion.
+   * @param {object} schema The current schema from which to extract methods and
+   * resources.
+   * @param {object} context The context to add to each method.
+   */
+  private applySchema(target, rootSchema, schema, context) {
+    this.applyMethodsFromSchema(target, rootSchema, schema, context);
 
-    applySchema(self, schema.data, schema.data, self);
-  };
-  return Endpoint;
-}
-
-/**
- * Discovery for discovering API endpoints
- *
- * @private
- * @param {object} options Options for discovery
- * @this {Discovery}
- */
-export function Discovery(options) {
-  this.options = options || {};
-}
-
-/**
- * Log output of generator
- * Works just like console.log
- */
-Discovery.prototype.log = function() {
-  if (this.options && this.options.debug) {
-    console.log.apply(this, arguments);
-  }
-};
-
-/**
- * Generate all APIs and return as in-memory object.
- *
- * @param {function} callback Callback when all APIs have been generated
- * @throws {Error} If there is an error generating any of the APIs
- */
-Discovery.prototype.discoverAllAPIs = function(discoveryUrl, callback) {
-  const self = this;
-  const headers = this.options.includePrivate ? {} : {'X-User-Ip': '0.0.0.0'};
-  transporter.request<DiscoverAPIsResponse>({url: discoveryUrl, headers})
-      .then(res => {
-        const items = res.data.items;
-        async.parallel(
-            items.map(api => {
-              return (cb) => {
-                self.discoverAPI(api.discoveryRestUrl, (e, newApi) => {
-                  if (e) {
-                    return cb(e);
-                  }
-                  api.api = newApi;
-                  cb(null, api);
-                });
-              };
-            }),
-            (e, apis) => {
-              if (e) {
-                return callback(e);
-              }
-
-              const versionIndex = {};
-              const apisIndex = {};
-
-              apis.forEach(api => {
-                if (!apisIndex[api.name]) {
-                  versionIndex[api.name] = {};
-                  apisIndex[api.name] = (options) => {
-                    const type = typeof options;
-                    let version;
-                    if (type === 'string') {
-                      version = options;
-                      options = {};
-                    } else if (type === 'object') {
-                      version = options.version;
-                      delete options.version;
-                    } else {
-                      throw new Error(
-                          'Argument error: Accepts only string or object');
-                    }
-                    try {
-                      // Creating an object, so Pascal case is appropriate.
-                      // tslint:disable-next-line
-                      const Endpoint = versionIndex[api.name][version];
-                      const ep = new Endpoint(options);
-                      ep.google = this;          // for drive.google.transporter
-                      return Object.freeze(ep);  // create new & freeze
-                    } catch (e) {
-                      throw new Error(util.format(
-                          'Unable to load endpoint %s("%s"): %s', api.name,
-                          version, e.message));
-                    }
-                  };
-                }
-                versionIndex[api.name][api.version] = api.api;
-              });
-
-              return callback(null, apisIndex);
-            });
-      })
-      .catch(e => {
-        return handleError(e, callback);
-      });
-};
-
-/**
- * Generate API file given discovery URL
- *
- * @param  {String} apiDiscoveryUrl URL or filename of discovery doc for API
- * @param {function} callback Callback when successful write of API
- * @throws {Error} If there is an error generating the API.
- */
-Discovery.prototype.discoverAPI = function(apiDiscoveryUrl, callback) {
-  function _generate(err, resp) {
-    if (err) {
-      return handleError(err, callback);
+    if (schema.resources) {
+      for (const resourceName in schema.resources) {
+        if (schema.resources.hasOwnProperty(resourceName)) {
+          const resource = schema.resources[resourceName];
+          if (!target[resourceName]) {
+            target[resourceName] = {};
+          }
+          this.applySchema(target[resourceName], rootSchema, resource, context);
+        }
+      }
     }
-    return callback(null, makeEndpoint(resp));
   }
 
-  if (typeof apiDiscoveryUrl === 'string') {
-    const parts = url.parse(apiDiscoveryUrl);
+  /**
+   * Generate and Endpoint from an endpoint schema object.
+   *
+   * @param {object} schema The schema from which to generate the Endpoint.
+   * @return Function The Endpoint.
+   */
+  private makeEndpoint(schema) {
+    // Creating an object, so Pascal case is appropriate.
+    const that = this;
+    // tslint:disable-next-line
+    const Endpoint = function(options) {
+      const self = this;
+      self._options = options || {};
+      that.applySchema(self, schema.data, schema.data, self);
+    };
+    return Endpoint;
+  }
 
-    if (apiDiscoveryUrl && !parts.protocol) {
-      this.log('Reading from file ' + apiDiscoveryUrl);
-      try {
-        return fs.readFile(apiDiscoveryUrl, {encoding: 'utf8'}, (err, file) => {
-          _generate(err, JSON.parse(file));
+  /**
+   * Discovery for discovering API endpoints
+   *
+   * @param {object} options Options for discovery
+   */
+  constructor(options) {
+    this.options = options || {};
+  }
+
+  /**
+   * Log output of generator. Works just like console.log
+   */
+  private log(...args: string[]) {
+    if (this.options && this.options.debug) {
+      console.log.apply(this, arguments);
+    }
+  }
+
+  /**
+   * Generate all APIs and return as in-memory object.
+   *
+   * @param {function} callback Callback when all APIs have been generated
+   * @throws {Error} If there is an error generating any of the APIs
+   */
+  discoverAllAPIs(discoveryUrl, callback) {
+    const headers = this.options.includePrivate ? {} : {'X-User-Ip': '0.0.0.0'};
+    this.transporter.request<DiscoverAPIsResponse>({url: discoveryUrl, headers})
+        .then(res => {
+          const items = res.data.items;
+          async.parallel(
+              items.map(api => {
+                return (cb) => {
+                  this.discoverAPI(api.discoveryRestUrl, (e, newApi) => {
+                    if (e) {
+                      return cb(e);
+                    }
+                    api.api = newApi;
+                    cb(null, api);
+                  });
+                };
+              }),
+              (e, apis) => {
+                if (e) {
+                  return callback(e);
+                }
+
+                const versionIndex = {};
+                const apisIndex = {};
+
+                apis.forEach(api => {
+                  if (!apisIndex[api.name]) {
+                    versionIndex[api.name] = {};
+                    apisIndex[api.name] = (options) => {
+                      const type = typeof options;
+                      let version;
+                      if (type === 'string') {
+                        version = options;
+                        options = {};
+                      } else if (type === 'object') {
+                        version = options.version;
+                        delete options.version;
+                      } else {
+                        throw new Error(
+                            'Argument error: Accepts only string or object');
+                      }
+                      try {
+                        // Creating an object, so Pascal case is appropriate.
+                        // tslint:disable-next-line
+                        const Endpoint = versionIndex[api.name][version];
+                        const ep = new Endpoint(options);
+                        ep.google = this;          // for drive.google.transporter
+                        return Object.freeze(ep);  // create new & freeze
+                      } catch (e) {
+                        throw new Error(util.format(
+                            'Unable to load endpoint %s("%s"): %s', api.name,
+                            version, e.message));
+                      }
+                    };
+                  }
+                  versionIndex[api.name][api.version] = api.api;
+                });
+
+                return callback(null, apisIndex);
+              });
+        })
+        .catch(e => {
+          return handleError(e, callback);
         });
-      } catch (err) {
+  };
+
+  /**
+   * Generate API file given discovery URL
+   *
+   * @param  {String} apiDiscoveryUrl URL or filename of discovery doc for API
+   * @param {function} callback Callback when successful write of API
+   * @throws {Error} If there is an error generating the API.
+   */
+  discoverAPI(apiDiscoveryUrl, callback) {
+    const _generate = (err, resp) => {
+      if (err) {
         return handleError(err, callback);
       }
-    } else {
-      this.log('Requesting ' + apiDiscoveryUrl);
-      transporter.request({url: apiDiscoveryUrl}, _generate);
+      return callback(null, this.makeEndpoint(resp));
     }
-  } else {
-    const options = apiDiscoveryUrl;
-    this.log('Requesting ' + options.url);
-    const parameters = {
-      options: {url: options.url, method: 'GET'},
-      requiredParams: [],
-      pathParams: [],
-      params: null,
-      context: {google: {_options: {}}, _options: {}}
-    };
-    delete options.url;
-    parameters.params = options;
-    createAPIRequest(parameters, _generate);
-  }
-};
+
+    if (typeof apiDiscoveryUrl === 'string') {
+      const parts = url.parse(apiDiscoveryUrl);
+
+      if (apiDiscoveryUrl && !parts.protocol) {
+        this.log('Reading from file ' + apiDiscoveryUrl);
+        try {
+          return fs.readFile(apiDiscoveryUrl, {encoding: 'utf8'}, (err, file) => {
+            _generate(err, JSON.parse(file));
+          });
+        } catch (err) {
+          return handleError(err, callback);
+        }
+      } else {
+        this.log('Requesting ' + apiDiscoveryUrl);
+        this.transporter.request({url: apiDiscoveryUrl}, _generate);
+      }
+    } else {
+      const options = apiDiscoveryUrl;
+      this.log('Requesting ' + options.url);
+      const parameters = {
+        options: {url: options.url, method: 'GET'},
+        requiredParams: [],
+        pathParams: [],
+        params: null,
+        context: {google: {_options: {}}, _options: {}}
+      };
+      delete options.url;
+      parameters.params = options;
+      createAPIRequest(parameters, _generate);
+    }
+  };
+}

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -14,15 +14,10 @@
 import * as async from 'async';
 import * as fs from 'fs';
 import {DefaultTransporter} from 'google-auth-library';
-import * as pify from 'pify';
 import * as url from 'url';
 import * as util from 'util';
-
 import {buildurl, handleError} from '../scripts/generator_utils';
-
 import {createAPIRequest} from './apirequest';
-
-const fsp = pify(fs);
 
 interface DiscoverAPIsResponse {
   items: API[];

--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -47,8 +47,10 @@ function getAPI (api, options) {
   }
 }
 
+export class GeneratedAPIs {
 {% for apiName, api in apis %}
-export function {{ apiName }}(options) {
+{{ apiName }}(options) {
   return getAPI.call(this, '{{ apiName }}', options);
 }
 {% endfor %}
+}

--- a/test/test.apikey.ts
+++ b/test/test.apikey.ts
@@ -15,9 +15,10 @@ import * as async from 'async';
 import * as nock from 'nock';
 import * as pify from 'pify';
 import * as assert from 'power-assert';
-import {Utils} from './utils';
 
-const googleapis = require('../src/lib/googleapis');
+import {GoogleApis} from '../src';
+
+import {Utils} from './utils';
 
 async function testGet(drive) {
   nock(Utils.baseUrl).get('/drive/v2/files/123?key=APIKEY').reply(200);
@@ -53,7 +54,7 @@ describe('API key', () => {
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     async.parallel(
         [
@@ -78,7 +79,7 @@ describe('API key', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     const OAuth2 = google.auth.OAuth2;
     authClient = new OAuth2('CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_URL');
     authClient.credentials = {access_token: 'abc123'};

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -17,10 +17,11 @@ import * as nock from 'nock';
 import * as pify from 'pify';
 import * as assert from 'power-assert';
 
+import {GoogleApis} from '../src';
+
 import {Utils} from './utils';
 
-const googleapis = require('../src/lib/googleapis');
-
+const googleapis = new GoogleApis();
 
 describe('JWT client', () => {
   it('should expose the default auth module', () => {
@@ -104,7 +105,7 @@ describe('OAuth2 client', () => {
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     async.parallel(
         [
@@ -129,7 +130,7 @@ describe('OAuth2 client', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localDrive = google.drive('v2');
     localUrlshortener = google.urlshortener('v1');
   });

--- a/test/test.clients.ts
+++ b/test/test.clients.ts
@@ -19,9 +19,9 @@ import * as pify from 'pify';
 import * as assert from 'power-assert';
 import * as url from 'url';
 
-import {Utils} from './utils';
+import {GoogleApis} from '../src';
 
-const googleapis = require('../src/lib/googleapis');
+import {Utils} from './utils';
 
 function createNock(qs?: string) {
   const query = qs ? `?${qs}` : '';
@@ -36,7 +36,7 @@ describe('Clients', () => {
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     async.parallel(
         [
@@ -61,7 +61,7 @@ describe('Clients', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localPlus = google.plus('v1');
     localOauth2 = google.oauth2('v2');
   });
@@ -145,7 +145,7 @@ describe('Clients', () => {
   });
 
   it('should support default params', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     const datastore =
         google.datastore({version: 'v1beta3', params: {myParam: '123'}});
     createNock('myParam=123');
@@ -169,7 +169,7 @@ describe('Clients', () => {
   });
 
   it('should allow default params to be overriden per-request', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     const datastore =
         google.datastore({version: 'v1beta3', params: {myParam: '123'}});
     // Override the default datasetId param for this particular API call
@@ -200,7 +200,7 @@ describe('Clients', () => {
 
   it('should include default params when only callback is provided to API call',
      async () => {
-       const google = new googleapis.GoogleApis();
+       const google = new GoogleApis();
        const datastore = google.datastore({
          version: 'v1beta3',
          params: {

--- a/test/test.discover.ts
+++ b/test/test.discover.ts
@@ -14,13 +14,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as assert from 'power-assert';
-
-const googleapis = require('../src/lib/googleapis');
+import {GoogleApis} from '../src';
 
 describe('GoogleApis#discover', () => {
   it('should generate all apis', (done) => {
     const localApis = fs.readdirSync(path.join(__dirname, '../src/apis'));
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     const localDrive = google.drive('v2');
 
     assert.equal(typeof google.drive, 'function');

--- a/test/test.drive.v2.ts
+++ b/test/test.drive.v2.ts
@@ -15,16 +15,18 @@ import * as nock from 'nock';
 import * as pify from 'pify';
 import * as assert from 'power-assert';
 
+import {GoogleApis} from '../src';
+
 import {Utils} from './utils';
 
-const googleapis = require('../src/lib/googleapis');
+const googleapis = new GoogleApis();
 
 describe('drive:v2', () => {
   let localDrive, remoteDrive;
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     Utils.loadApi(google, 'drive', 'v2', {}, (err, drive) => {
       nock.disableNetConnect();
@@ -39,7 +41,7 @@ describe('drive:v2', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localDrive = google.drive('v2');
   });
 

--- a/test/test.media.ts
+++ b/test/test.media.ts
@@ -17,9 +17,10 @@ import * as nock from 'nock';
 import * as path from 'path';
 import * as pify from 'pify';
 import * as assert from 'power-assert';
-import {Utils} from './utils';
 
-const googleapis = require('../src/lib/googleapis');
+import {GoogleApis} from '../src';
+
+import {Utils} from './utils';
 
 const boundaryPrefix = 'multipart/related; boundary=';
 
@@ -73,7 +74,7 @@ describe('Media', () => {
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     async.parallel(
         [
@@ -98,7 +99,7 @@ describe('Media', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localDrive = google.drive('v2');
     localGmail = google.gmail('v1');
   });

--- a/test/test.options.ts
+++ b/test/test.options.ts
@@ -15,9 +15,10 @@ import * as nock from 'nock';
 import * as pify from 'pify';
 import * as assert from 'power-assert';
 import * as url from 'url';
-import {Utils} from './utils';
 
-const googleapis = require('../src/lib/googleapis');
+import {GoogleApis} from '../src';
+
+import {Utils} from './utils';
 
 function createNock(path?: string) {
   const p = path ? path : '/drive/v2/files/woot';
@@ -33,25 +34,25 @@ describe('Options', () => {
   });
 
   it('should be a function', () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     assert.equal(typeof google.options, 'function');
   });
 
   it('should expose _options', () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     google.options({hello: 'world'});
     assert.equal(
         JSON.stringify(google._options), JSON.stringify({hello: 'world'}));
   });
 
   it('should expose _options values', () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     google.options({hello: 'world'});
     assert.equal(google._options.hello, 'world');
   });
 
   it('should promote endpoint options over global options', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     google.options({hello: 'world'});
     const drive = google.drive({version: 'v2', hello: 'changed'});
     createNock('/drive/v2/files/123');
@@ -60,7 +61,7 @@ describe('Options', () => {
   });
 
   it('should support global request params', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     google.options({params: {myParam: '123'}});
     const drive = google.drive('v2');
     nock(Utils.baseUrl).get('/drive/v2/files/123?myParam=123').reply(200);
@@ -88,7 +89,7 @@ describe('Options', () => {
   });
 
   it('should promote auth apikey options on request basis', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     google.options({auth: 'apikey1'});
     const drive = google.drive({version: 'v2', auth: 'apikey2'});
     createNock('/drive/v2/files/woot?key=apikey3');
@@ -97,7 +98,7 @@ describe('Options', () => {
   });
 
   it('should apply google options to request object like timeout', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     google.options({timeout: 12345});
     const drive = google.drive({version: 'v2', auth: 'apikey2'});
     createNock('/drive/v2/files/woot?key=apikey3');
@@ -107,7 +108,7 @@ describe('Options', () => {
 
   it('should apply endpoint options to request object like timeout',
      async () => {
-       const google = new googleapis.GoogleApis();
+       const google = new GoogleApis();
        const drive =
            google.drive({version: 'v2', auth: 'apikey2', timeout: 23456});
        createNock('/drive/v2/files/woot?key=apikey3');
@@ -118,7 +119,7 @@ describe('Options', () => {
      });
 
   it('should allow overriding endpoint options', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     const drive = google.drive('v3');
     const host = 'https://myproxy.com';
     nock(host).get('/drive/v3/files/woot').reply(200);
@@ -136,7 +137,7 @@ describe('Options', () => {
 
   it('should apply endpoint options like timeout to oauth transporter',
      async () => {
-       const google = new googleapis.GoogleApis();
+       const google = new GoogleApis();
        const OAuth2 = google.auth.OAuth2;
        authClient = new OAuth2('CLIENTID', 'CLIENTSECRET', 'REDIRECTURI');
        authClient.credentials = {access_token: 'abc'};
@@ -150,7 +151,7 @@ describe('Options', () => {
      });
 
   it('should allow overriding rootUrl via options', async () => {
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     const drive = google.drive('v3');
     const fileId = 'woot';
     const rootUrl = 'https://myrooturl.com';

--- a/test/test.path.ts
+++ b/test/test.path.ts
@@ -15,16 +15,17 @@ import * as nock from 'nock';
 import * as pify from 'pify';
 import * as assert from 'power-assert';
 import * as url from 'url';
-import {Utils} from './utils';
 
-const googleapis = require('../src/lib/googleapis');
+import {GoogleApis} from '../src';
+
+import {Utils} from './utils';
 
 describe('Path params', () => {
   let localDrive, remoteDrive;
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     Utils.loadApi(google, 'drive', 'v2', {}, (err, drive) => {
       nock.disableNetConnect();
@@ -39,7 +40,7 @@ describe('Path params', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localDrive = google.drive('v2');
   });
 

--- a/test/test.query.ts
+++ b/test/test.query.ts
@@ -18,9 +18,9 @@ import * as pify from 'pify';
 import * as assert from 'power-assert';
 import * as url from 'url';
 
-import {Utils} from './utils';
+import {google, GoogleApis} from '../src';
 
-const googleapis = require('../src/lib/googleapis');
+import {Utils} from './utils';
 
 describe('Query params', () => {
   let localCompute, remoteCompute;
@@ -29,7 +29,7 @@ describe('Query params', () => {
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     async.parallel(
         [
@@ -58,7 +58,7 @@ describe('Query params', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localCompute = google.compute('v1');
     localDrive = google.drive('v2');
     localGmail = google.gmail('v1');
@@ -188,8 +188,8 @@ describe('Query params', () => {
   });
 
   it('should not include auth if auth is an OAuth2Client object', async () => {
-    const oauth2client = new googleapis.auth.OAuth2(
-        'CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_URI');
+    const oauth2client =
+        new google.auth.OAuth2('CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_URI');
     oauth2client.credentials = {access_token: 'abc123'};
 
     nock(Utils.baseUrl).get('/drive/v2/files/123').reply(200);

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -15,9 +15,10 @@ import * as async from 'async';
 import * as nock from 'nock';
 import * as pify from 'pify';
 import * as assert from 'power-assert';
-import {Utils} from './utils';
 
-const googleapis = require('../src/lib/googleapis');
+import {GoogleApis} from '../src';
+
+import {Utils} from './utils';
 
 async function testHeaders(drive) {
   nock(Utils.baseUrl).post('/drive/v2/files/a/comments').reply(200);
@@ -83,7 +84,7 @@ describe('Transporters', () => {
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     async.parallel(
         [
@@ -112,7 +113,7 @@ describe('Transporters', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localDrive = google.drive('v2');
     localOauth2 = google.oauth2('v2');
     localUrlshortener = google.urlshortener('v1');

--- a/test/test.urlshortener.v1.ts
+++ b/test/test.urlshortener.v1.ts
@@ -17,9 +17,9 @@ import * as pify from 'pify';
 import * as assert from 'power-assert';
 import * as url from 'url';
 
-import {Utils} from './utils';
+import {GoogleApis} from '../src';
 
-const googleapis = require('../src/lib/googleapis');
+import {Utils} from './utils';
 
 async function testSingleRequest(urlshortener) {
   const obj = {longUrl: 'http://someurl...'};
@@ -54,7 +54,7 @@ describe('Urlshortener', () => {
 
   before((done) => {
     nock.cleanAll();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     nock.enableNetConnect();
     Utils.loadApi(google, 'urlshortener', 'v1', {}, (err, urlshortener) => {
       nock.disableNetConnect();
@@ -69,7 +69,7 @@ describe('Urlshortener', () => {
   beforeEach(() => {
     nock.cleanAll();
     nock.disableNetConnect();
-    const google = new googleapis.GoogleApis();
+    const google = new GoogleApis();
     localUrlshortener = google.urlshortener('v1');
   });
 


### PR DESCRIPTION
This change makes it possible for TypeScript users to actually use the d.ts we create at build time.  This addresses the very popular #503, but at a cost.  

BREAKING CHANGE: This library is now optimized for es6 modules.  In previous
versions you would import the library like this:

```js
const google = require('googleapis');
```

In this and future versions, you must use a named import:

```js
const {google} = require('googleapis');
```

You may also reference the type to instantiate a new instance:

```js
const {GoogleApis} = require('googleapis');
const google = new GoogleApis();
```