### PR TITLE
chore: upgrade to the latest google-auth-library and fix the build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis",
-  "version": "24.0.0",
+  "version": "25.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3003,14 +3003,15 @@
       }
     },
     "google-auth-library": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.0.0.tgz",
-      "integrity": "sha512-QYZSpVUG6ATNvVrbqXvLSbbhnx6UzbFg0afrdDikJMQktj4zLgyRzNcac5x1SNp5e+7RNdeTSkhOSqFEFn8jaw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.1.0.tgz",
+      "integrity": "sha512-WgWLwplY8ftublrySvrJYsoJR0eL1TBqG3cxCPInYZmpo2h0aEpCYJBP0Lz43OO0ceMc7BreLghZXXVfrbF/PA==",
       "requires": {
         "axios": "0.17.1",
-        "gtoken": "2.0.2",
+        "gtoken": "2.1.0",
         "jws": "3.1.4",
-        "lodash.isstring": "4.0.1"
+        "lodash.isstring": "4.0.1",
+        "lru-cache": "4.1.1"
       }
     },
     "google-p12-pem": {
@@ -3054,9 +3055,9 @@
       "dev": true
     },
     "gtoken": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.0.2.tgz",
-      "integrity": "sha512-wyK3Px5YIZJOGBTZP1JGWQ6lRa+mgU73ucgvNqn6adHcQYSB1hXXXGPRznofZNh3UkVTF5HdShsi8RLeCu9kTA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.1.0.tgz",
+      "integrity": "sha512-r/dh/cVgPBWHcskq03KOSDl+L+0Ac0B8VEhpIbnrcsvHSJHdkEtwbC0lOZNxBIqWbM1+HNig8jpuCwKJzCcilg==",
       "requires": {
         "axios": "0.17.1",
         "google-p12-pem": "1.0.0",
@@ -3895,7 +3896,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -6350,8 +6350,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "punycode": {
       "version": "1.4.1",
@@ -7431,8 +7430,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "async": "2.6.0",
-    "google-auth-library": "^1.0.0",
+    "google-auth-library": "^1.1.0",
     "qs": "^6.5.1",
     "string-template": "1.0.0",
     "uuid": "^3.1.0"

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -195,26 +195,27 @@ describe('OAuth2 client', () => {
   });
 
   it('should make request if access token not expired', async () => {
-    const scope = nock('https://accounts.google.com')
-                      .post('/o/oauth2/token')
+    const scope = nock('https://www.googleapis.com')
+                      .post('/oauth2/v4/token')
                       .times(2)
                       .reply(200, {access_token: 'abc123', expires_in: 10000});
     let oauth2client =
         new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     let now = (new Date()).getTime();
-    let tenSecondsFromNow = now + 10000;
+    let tenMinutesFromNow = now + 1000 * 60 * 10;
     oauth2client.credentials = {
       access_token: 'abc123',
       refresh_token: 'abc',
-      expiry_date: tenSecondsFromNow
+      expiry_date: tenMinutesFromNow
     };
 
     nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
     await pify(localDrive.files.get)({fileId: 'wat', auth: oauth2client});
+    console.log(`Creds: ${JSON.stringify(oauth2client.credentials)}`);
     assert.equal(JSON.stringify(oauth2client.credentials), JSON.stringify({
       access_token: 'abc123',
       refresh_token: 'abc',
-      expiry_date: tenSecondsFromNow,
+      expiry_date: tenMinutesFromNow,
       token_type: 'Bearer'
     }));
 
@@ -224,11 +225,11 @@ describe('OAuth2 client', () => {
     oauth2client =
         new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
     now = (new Date()).getTime();
-    tenSecondsFromNow = now + 10000;
+    tenMinutesFromNow = now + 1000 * 60 * 10;
     oauth2client.credentials = {
       access_token: 'abc123',
       refresh_token: 'abc',
-      expiry_date: tenSecondsFromNow
+      expiry_date: tenMinutesFromNow
     };
 
     nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
@@ -236,7 +237,7 @@ describe('OAuth2 client', () => {
     assert.equal(JSON.stringify(oauth2client.credentials), JSON.stringify({
       access_token: 'abc123',
       refresh_token: 'abc',
-      expiry_date: tenSecondsFromNow,
+      expiry_date: tenMinutesFromNow,
       token_type: 'Bearer'
     }));
 


### PR DESCRIPTION
This upgrades us to the 1.1.0 release of the google-auth-library.  There were multiple changes in that release that were breaking our CI (even though they were probably not semver major changes). 