### PR TITLE
try some appveyor magic

### DIFF
--- a/test/test.kitchen.ts
+++ b/test/test.kitchen.ts
@@ -30,7 +30,9 @@ const pkg = require('../../package.json');
 const spawnp = (command: string, args: string[], options: cp.SpawnOptions = {}):
     Promise<void> => {
       return new Promise((resolve, reject) => {
-        cp.spawn(command, args, Object.assign(options, {stdio: 'inherit', shell: true}))
+        cp.spawn(
+              command, args,
+              Object.assign(options, {stdio: 'inherit', shell: true}))
             .on('close',
                 (code, signal) => {
                   if (code === 0) {

--- a/test/test.kitchen.ts
+++ b/test/test.kitchen.ts
@@ -30,7 +30,7 @@ const pkg = require('../../package.json');
 const spawnp = (command: string, args: string[], options: cp.SpawnOptions = {}):
     Promise<void> => {
       return new Promise((resolve, reject) => {
-        cp.spawn(command, args, Object.assign(options, {stdio: 'inherit'}))
+        cp.spawn(command, args, Object.assign(options, {stdio: 'inherit', shell: true}))
             .on('close',
                 (code, signal) => {
                   if (code === 0) {


### PR DESCRIPTION
Windows builds fail being unable to run `npm` using `childprocess.spawn`. Details [here](https://github.com/nodejs/node/issues/3675). As a quick solution, passing `{ shell: true }` to `spawn` helps (I guess it's OK for the test code).