### PR TITLE
chore: remove .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-test
-samples
-doc
-node_modules
-coverage
-jsdoc-conf.json
-.travis.yml
-# Empty API
-apis/iam/v1alpha1.js


### PR DESCRIPTION
Now that we define `files` in package.json, we don't need to have an explicit npmignore. 