### PR TITLE
chore: make a few APIs async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -260,12 +260,6 @@
       "dev": true,
       "optional": true
     },
-    "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-      "dev": true
-    },
     "array-find": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
@@ -339,14 +333,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -555,12 +541,6 @@
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       }
-    },
-    "call-signature": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -1065,12 +1045,6 @@
       "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
-    "diff-match-patch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
-      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
-      "dev": true
-    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1138,12 +1112,6 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
-    "eastasianwidth": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
-      "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
-      "dev": true
-    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -1163,16 +1131,6 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "empower": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
-      "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "empower-core": "0.6.2"
-      }
-    },
     "empower-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/empower-assert/-/empower-assert-1.0.1.tgz",
@@ -1180,16 +1138,6 @@
       "dev": true,
       "requires": {
         "estraverse": "4.2.0"
-      }
-    },
-    "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-      "dev": true,
-      "requires": {
-        "call-signature": "0.0.2",
-        "core-js": "2.5.3"
       }
     },
     "encoding": {
@@ -3403,12 +3351,6 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4004,7 +3946,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -6543,134 +6486,6 @@
         }
       }
     },
-    "power-assert": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.4.tgz",
-      "integrity": "sha1-kpXqdDcZb1pgH95CDwQmMRhtdRc=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "empower": "1.2.3",
-        "power-assert-formatter": "1.4.1",
-        "universal-deep-strict-equal": "1.2.2",
-        "xtend": "4.0.1"
-      }
-    },
-    "power-assert-context-formatter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
-      "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "power-assert-context-traversal": "1.1.1"
-      }
-    },
-    "power-assert-context-reducer-ast": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.2.tgz",
-      "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13",
-        "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.3",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
-    "power-assert-context-traversal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
-      "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "estraverse": "4.2.0"
-      }
-    },
-    "power-assert-formatter": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
-      "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "power-assert-context-formatter": "1.1.1",
-        "power-assert-context-reducer-ast": "1.1.2",
-        "power-assert-renderer-assertion": "1.1.1",
-        "power-assert-renderer-comparison": "1.1.1",
-        "power-assert-renderer-diagram": "1.1.2",
-        "power-assert-renderer-file": "1.1.1"
-      }
-    },
-    "power-assert-renderer-assertion": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
-      "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
-      "dev": true,
-      "requires": {
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1"
-      }
-    },
-    "power-assert-renderer-base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.1.1.tgz",
-      "integrity": "sha1-lqZQxv0F7hvB9mtUrWFELIs/Y+s=",
-      "dev": true
-    },
-    "power-assert-renderer-comparison": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
-      "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "diff-match-patch": "1.0.0",
-        "power-assert-renderer-base": "1.1.1",
-        "stringifier": "1.3.0",
-        "type-name": "2.0.2"
-      }
-    },
-    "power-assert-renderer-diagram": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
-      "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1",
-        "stringifier": "1.3.0"
-      }
-    },
-    "power-assert-renderer-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.1.tgz",
-      "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
-      "dev": true,
-      "requires": {
-        "power-assert-renderer-base": "1.1.1"
-      }
-    },
-    "power-assert-util-string-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
-      "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
-      "dev": true,
-      "requires": {
-        "eastasianwidth": "0.1.1"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7162,9 +6977,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.2.tgz",
-      "integrity": "sha512-9zHceZbQwERaMK1MiFguvx1dL9GQPLXInr2D/wUxAsuV6ZKc9F0DHYWeloMcalkYRbtanwqUakoDjvj55cL/4A==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+      "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
       "dev": true,
       "requires": {
         "source-map": "0.6.1"
@@ -7299,17 +7114,6 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "stringifier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
-      "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "traverse": "0.6.6",
-        "type-name": "2.0.2"
-      }
-    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -7436,12 +7240,6 @@
       "requires": {
         "punycode": "1.4.1"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
     },
     "trim-newlines": {
       "version": "2.0.0",
@@ -7575,17 +7373,6 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "1.0.0"
-      }
-    },
-    "universal-deep-strict-equal": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
-      "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
-      "dev": true,
-      "requires": {
-        "array-filter": "1.0.0",
-        "indexof": "0.0.1",
-        "object-keys": "1.0.11"
       }
     },
     "unzip-response": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "async": "2.6.0",
     "google-auth-library": "^1.1.0",
     "qs": "^6.5.1",
     "string-template": "1.0.0",
@@ -130,7 +129,6 @@
     "opn": "5.2.0",
     "p-queue": "^2.3.0",
     "pify": "^3.0.0",
-    "power-assert": "1.4.4",
     "rimraf": "2.6.2",
     "semistandard": "12.0.0",
     "source-map-support": "0.5.3",

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -11,18 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as async from 'async';
-import {AxiosRequestConfig, AxiosResponse} from 'axios';
 import * as fs from 'fs';
 import {DefaultTransporter} from 'google-auth-library';
-import {Schema} from 'inspector';
+import * as pify from 'pify';
 import * as url from 'url';
 import * as util from 'util';
 
-import {buildurl, handleError} from '../scripts/generator_utils';
-
-import {APIRequestMethodParams, APIRequestParams, createAPIRequest} from './apirequest';
+import {APIRequestMethodParams, createAPIRequest} from './apirequest';
 import {Endpoint} from './endpoint';
+
+const fsp = pify(fs);
 
 export type EndpointCreator = (options: {}) => Endpoint;
 
@@ -33,9 +31,11 @@ interface DiscoverAPIsResponse {
 export interface API {
   discoveryRestUrl: string;
   api: EndpointCreator;
+  name: string;
+  version: string;
 }
 
-interface DiscoveryOptions {
+export interface DiscoveryOptions {
   includePrivate?: boolean;
   debug?: boolean;
 }
@@ -70,13 +70,12 @@ export class Discovery {
   private transporter = new DefaultTransporter();
   private options: DiscoveryOptions;
 
-
   /**
    * Discovery for discovering API endpoints
    *
-   * @param {object} options Options for discovery
+   * @param options Options for discovery
    */
-  constructor(options) {
+  constructor(options: DiscoveryOptions) {
     this.options = options || {};
   }
 
@@ -87,15 +86,6 @@ export class Discovery {
    * @return A function that creates an endpoint.
    */
   private makeEndpoint(schema: APIRequest): EndpointCreator {
-    // // Creating an object, so Pascal case is appropriate.
-    // const that = this;
-    // // tslint:disable-next-line
-    // const Endpoint = function(options) {
-    //   const self = this;
-    //   self._options = options || {};
-    //   that.applySchema(self, schema.data, schema.data, self);
-    // };
-    // return Endpoint;
     return (options: {}) => {
       const ep = new Endpoint(options);
       ep.applySchema(ep, schema, schema, ep);
@@ -115,112 +105,72 @@ export class Discovery {
   /**
    * Generate all APIs and return as in-memory object.
    * @param discoveryUrl
-   * @param callback Callback when all APIs have been generated
    */
-  discoverAllAPIs(
-      discoveryUrl: string, callback: (err: Error|null, api?: {}) => void) {
+  async discoverAllAPIs(discoveryUrl: string) {
     const headers = this.options.includePrivate ? {} : {'X-User-Ip': '0.0.0.0'};
-    this.transporter.request<DiscoverAPIsResponse>({url: discoveryUrl, headers})
-        .then(res => {
-          const items = res.data.items;
-          async.parallel(
-              items.map(api => {
-                return (cb: (err: Error|null, api?: API) => void) => {
-                  this.discoverAPI(api.discoveryRestUrl, (e, newApi) => {
-                    if (e) {
-                      return cb(e);
-                    }
-                    api.api = newApi;
-                    cb(null, api);
-                  });
-                };
-              }),
-              (e: Error|null, apis) => {
-                if (e) {
-                  return callback(e);
-                }
+    const res = await this.transporter.request<DiscoverAPIsResponse>(
+        {url: discoveryUrl, headers});
+    const items = res.data.items;
+    const apis = await Promise.all(items.map(async api => {
+      const newApi = await this.discoverAPI(api.discoveryRestUrl);
+      api.api = newApi;
+      return api;
+    }));
 
-                const versionIndex = {};
-                const apisIndex = {};
-
-                apis.forEach(api => {
-                  if (!apisIndex[api.name]) {
-                    versionIndex[api.name] = {};
-                    apisIndex[api.name] = (options) => {
-                      const type = typeof options;
-                      let version: string;
-                      if (type === 'string') {
-                        version = options;
-                        options = {};
-                      } else if (type === 'object') {
-                        version = options.version;
-                        delete options.version;
-                      } else {
-                        throw new Error(
-                            'Argument error: Accepts only string or object');
-                      }
-                      try {
-                        const endpointCreator: EndpointCreator =
-                            versionIndex[api.name][version];
-                        const ep = endpointCreator(options);
-                        ep.google = this;  // for drive.google.transporter
-                        return Object.freeze(ep);  // create new & freeze
-                      } catch (e) {
-                        throw new Error(util.format(
-                            'Unable to load endpoint %s("%s"): %s', api.name,
-                            version, e.message));
-                      }
-                    };
-                  }
-                  versionIndex[api.name][api.version] = api.api;
-                });
-
-                return callback(null, apisIndex);
-              });
-        })
-        .catch(e => {
-          return handleError(e, callback);
-        });
+    const versionIndex = {};
+    const apisIndex = {};
+    for (const api of apis) {
+      if (!apisIndex[api.name]) {
+        versionIndex[api.name] = {};
+        apisIndex[api.name] = (options) => {
+          const type = typeof options;
+          let version: string;
+          if (type === 'string') {
+            version = options;
+            options = {};
+          } else if (type === 'object') {
+            version = options.version;
+            delete options.version;
+          } else {
+            throw new Error('Argument error: Accepts only string or object');
+          }
+          try {
+            const endpointCreator: EndpointCreator =
+                versionIndex[api.name][version];
+            const ep = endpointCreator(options);
+            ep.google = this;          // for drive.google.transporter
+            return Object.freeze(ep);  // create new & freeze
+          } catch (e) {
+            throw new Error(util.format(
+                'Unable to load endpoint %s("%s"): %s', api.name, version,
+                e.message));
+          }
+        };
+      }
+      versionIndex[api.name][api.version] = api.api;
+    }
+    return apisIndex;
   }
 
   /**
    * Generate API file given discovery URL
    *
    * @param apiDiscoveryUrl URL or filename of discovery doc for API
-   * @param callback Callback when successful write of API
+   * @returns A promise that resolves with a function that creates the endpoint
    */
-  async discoverAPI(
-      apiDiscoveryUrl: string|APIRequestMethodParams,
-      callback: (err: Error|null, endpointCreator: EndpointCreator) => void) {
-    const _generate = (err: Error|null, res?: APIRequest) => {
-      if (err) {
-        return handleError(err, callback);
-      }
-      return callback(null, this.makeEndpoint(res!));
-    };
-
+  async discoverAPI(apiDiscoveryUrl: string|
+                    APIRequestMethodParams): Promise<EndpointCreator> {
     if (typeof apiDiscoveryUrl === 'string') {
       const parts = url.parse(apiDiscoveryUrl);
-
       if (apiDiscoveryUrl && !parts.protocol) {
         this.log('Reading from file ' + apiDiscoveryUrl);
-        try {
-          return fs.readFile(
-              apiDiscoveryUrl, {encoding: 'utf8'}, (err, file) => {
-                _generate(err, JSON.parse(file));
-              });
-        } catch (err) {
-          return handleError(err, callback);
-        }
+        const file = await fsp.readFile(apiDiscoveryUrl, {encoding: 'utf8'});
+        return this.makeEndpoint(JSON.parse(file));
       } else {
         this.log('Requesting ' + apiDiscoveryUrl);
-        this.transporter.request<APIRequest>(
-            {url: apiDiscoveryUrl}, (err, res) => {
-              if (err || (res && !res.data)) {
-                return _generate(err);
-              }
-              return _generate(err, res!.data);
-            });
+        const res =
+            await this.transporter.request<APIRequest>({url: apiDiscoveryUrl});
+        return this.makeEndpoint(res.data);
       }
     } else {
       const options = apiDiscoveryUrl;
@@ -234,15 +184,9 @@ export class Discovery {
         params: options,
         context: {google: {_options: {}}, _options: {}}
       };
-      createAPIRequest<APIRequest>(parameters, (err, res) => {
-        if (err) {
-          return _generate(err);
-        } else {
-          if (res) {
-            return _generate(null, res.data);
-          }
-        }
-      });
+      const pcr = pify(createAPIRequest);
+      const res = await pcr(parameters);
+      return this.makeEndpoint(res.data);
     }
   }
 }

--- a/test/test.apikey.ts
+++ b/test/test.apikey.ts
@@ -11,11 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as async from 'async';
+import * as assert from 'assert';
 import {OAuth2Client} from 'google-auth-library';
 import * as nock from 'nock';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
 
 import {GoogleApis} from '../src';
 import {google} from '../src';
@@ -56,28 +55,13 @@ describe('API key', () => {
   let remoteUrlshortener;
   let authClient: OAuth2Client;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    async.parallel(
-        [
-          (cb) => {
-            Utils.loadApi(google, 'drive', 'v2', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'urlshortener', 'v1', {}, cb);
-          }
-        ],
-        (err, apis) => {
-          if (err) {
-            return done(err);
-          }
-          remoteDrive = apis[0];
-          remoteUrlshortener = apis[1];
-          nock.disableNetConnect();
-          done();
-        });
+    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
+    remoteUrlshortener = await Utils.loadApi(google, 'urlshortener', 'v1');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/test.apikey.ts
+++ b/test/test.apikey.ts
@@ -15,10 +15,8 @@ import * as assert from 'assert';
 import {OAuth2Client} from 'google-auth-library';
 import * as nock from 'nock';
 import * as pify from 'pify';
-
 import {GoogleApis} from '../src';
 import {google} from '../src';
-
 import {Utils} from './utils';
 
 async function testGet(drive) {
@@ -59,8 +57,10 @@ describe('API key', () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
-    remoteUrlshortener = await Utils.loadApi(google, 'urlshortener', 'v1');
+    [remoteDrive, remoteUrlshortener] = await Promise.all([
+      Utils.loadApi(google, 'drive', 'v2'),
+      Utils.loadApi(google, 'urlshortener', 'v1')
+    ]);
     nock.disableNetConnect();
   });
 

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -15,9 +15,7 @@ import * as assert from 'assert';
 import {OAuth2Client} from 'google-auth-library';
 import * as nock from 'nock';
 import * as pify from 'pify';
-
 import {GoogleApis} from '../src';
-
 import {Utils} from './utils';
 
 const googleapis = new GoogleApis();
@@ -107,8 +105,10 @@ describe('OAuth2 client', () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
-    remoteUrlshortener = await Utils.loadApi(google, 'urlshortener', 'v1');
+    [remoteDrive, remoteUrlshortener] = await Promise.all([
+      Utils.loadApi(google, 'drive', 'v2'),
+      Utils.loadApi(google, 'urlshortener', 'v1')
+    ]);
     nock.disableNetConnect();
   });
 

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -11,12 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as async from 'async';
+import * as assert from 'assert';
 import {OAuth2Client} from 'google-auth-library';
 import * as nock from 'nock';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
+
 import {GoogleApis} from '../src';
+
 import {Utils} from './utils';
 
 const googleapis = new GoogleApis();
@@ -102,28 +103,13 @@ describe('OAuth2 client', () => {
   let localDrive, remoteDrive;
   let localUrlshortener, remoteUrlshortener;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    async.parallel(
-        [
-          (cb) => {
-            Utils.loadApi(google, 'drive', 'v2', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'urlshortener', 'v1', {}, cb);
-          }
-        ],
-        (err, apis) => {
-          if (err) {
-            return done(err);
-          }
-          remoteDrive = apis[0];
-          remoteUrlshortener = apis[1];
-          nock.disableNetConnect();
-          done();
-        });
+    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
+    remoteUrlshortener = await Utils.loadApi(google, 'urlshortener', 'v1');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/test.clients.ts
+++ b/test/test.clients.ts
@@ -17,9 +17,7 @@ import * as nock from 'nock';
 import * as path from 'path';
 import * as pify from 'pify';
 import * as url from 'url';
-
 import {GoogleApis} from '../src';
-
 import {Utils} from './utils';
 
 function createNock(qs?: string) {
@@ -37,8 +35,10 @@ describe('Clients', () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    remotePlus = await Utils.loadApi(google, 'plus', 'v1');
-    remoteOauth2 = await Utils.loadApi(google, 'oauth2', 'v2');
+    [remotePlus, remoteOauth2] = await Promise.all([
+      Utils.loadApi(google, 'plus', 'v1'),
+      Utils.loadApi(google, 'oauth2', 'v2')
+    ]);
     nock.disableNetConnect();
   });
 

--- a/test/test.clients.ts
+++ b/test/test.clients.ts
@@ -36,8 +36,7 @@ describe('Clients', () => {
     const google = new GoogleApis();
     nock.enableNetConnect();
     [remotePlus, remoteOauth2] = await Promise.all([
-      Utils.loadApi(google, 'plus', 'v1'),
-      Utils.loadApi(google, 'oauth2', 'v2')
+      Utils.loadApi(google, 'plus', 'v1'), Utils.loadApi(google, 'oauth2', 'v2')
     ]);
     nock.disableNetConnect();
   });

--- a/test/test.clients.ts
+++ b/test/test.clients.ts
@@ -11,12 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as async from 'async';
+import * as assert from 'assert';
 import * as fs from 'fs';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
 import * as url from 'url';
 
 import {GoogleApis} from '../src';
@@ -34,28 +33,13 @@ describe('Clients', () => {
   let localPlus, remotePlus;
   let localOauth2, remoteOauth2;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    async.parallel(
-        [
-          (cb) => {
-            Utils.loadApi(google, 'plus', 'v1', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'oauth2', 'v2', {}, cb);
-          }
-        ],
-        (err, apis) => {
-          if (err) {
-            return done(err);
-          }
-          remotePlus = apis[0];
-          remoteOauth2 = apis[1];
-          nock.disableNetConnect();
-          done();
-        });
+    remotePlus = await Utils.loadApi(google, 'plus', 'v1');
+    remoteOauth2 = await Utils.loadApi(google, 'oauth2', 'v2');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {
@@ -157,12 +141,14 @@ describe('Clients', () => {
     const query = Utils.getQs(res) || '';
     assert.notEqual(query.indexOf('myParam=123'), -1, 'Default param in query');
     nock.enableNetConnect();
-    const datastore2 = await pify(Utils.loadApi)(
+    const datastore2 = await Utils.loadApi(
         google, 'datastore', 'v1beta3', {params: {myParam: '123'}});
     nock.disableNetConnect();
     createNock('myParam=123');
     const res2 =
-        await pify(datastore2.projects.lookup)({projectId: 'test-project-id'});
+        // tslint:disable-next-line no-any
+        await pify((datastore2 as any).projects.lookup)(
+            {projectId: 'test-project-id'});
     const query2 = Utils.getQs(res2) || '';
     assert.notEqual(
         query2.indexOf('myParam=123'), -1, 'Default param in query');
@@ -183,12 +169,13 @@ describe('Clients', () => {
     assert.notEqual(
         query.indexOf('myParam=456'), -1, 'Default param not found in query');
     nock.enableNetConnect();
-    const datastore2 = await pify(Utils.loadApi)(
+    const datastore2 = await Utils.loadApi(
         google, 'datastore', 'v1beta3', {params: {myParam: '123'}});
     nock.disableNetConnect();
     // Override the default datasetId param for this particular API call
     createNock('myParam=456');
-    const res2 = await pify(datastore2.projects.lookup)(
+    // tslint:disable-next-line no-any
+    const res2 = await pify((datastore2 as any).projects.lookup)(
         {projectId: 'test-project-id', myParam: '456'});
     // If the default param handling is broken, query might be undefined,
     // thus concealing the assertion message with some generic "cannot
@@ -222,20 +209,20 @@ describe('Clients', () => {
            'Default param not found in query');
 
        nock.enableNetConnect();
-       const datastore2 =
-           await pify(Utils.loadApi)(google, 'datastore', 'v1beta3', {
-             params: {
-               projectId: 'test-project-id',  // We must set this here - it is a
-               // required param
-               myParam: '123'
-             }
-           });
+       const datastore2 = await Utils.loadApi(google, 'datastore', 'v1beta3', {
+         params: {
+           projectId: 'test-project-id',  // We must set this here - it is a
+           // required param
+           myParam: '123'
+         }
+       });
 
        nock.disableNetConnect();
 
        // No params given - only callback
        createNock('myParam=123');
-       const res3 = await pify(datastore2.projects.lookup)();
+       // tslint:disable-next-line no-any
+       const res3 = await pify((datastore2 as any).projects.lookup)();
        // If the default param handling is broken, req or query might be
        // undefined, thus concealing the assertion message with some
        // generic "cannot call .indexOf of undefined"

--- a/test/test.discover.ts
+++ b/test/test.discover.ts
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as assert from 'power-assert';
+
 import {GoogleApis} from '../src';
 
 describe('GoogleApis#discover', () => {

--- a/test/test.drive.v2.ts
+++ b/test/test.drive.v2.ts
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as assert from 'assert';
 import * as nock from 'nock';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
+
 import {GoogleApis} from '../src';
+
 import {Utils} from './utils';
 
 const googleapis = new GoogleApis();
@@ -22,18 +24,12 @@ const googleapis = new GoogleApis();
 describe('drive:v2', () => {
   let localDrive, remoteDrive;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    Utils.loadApi(google, 'drive', 'v2', {}, (err, drive) => {
-      nock.disableNetConnect();
-      if (err) {
-        return done(err);
-      }
-      remoteDrive = drive;
-      done();
-    });
+    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/test.media.ts
+++ b/test/test.media.ts
@@ -16,9 +16,7 @@ import * as fs from 'fs';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as pify from 'pify';
-
 import {GoogleApis} from '../src';
-
 import {Utils} from './utils';
 
 const boundaryPrefix = 'multipart/related; boundary=';
@@ -75,8 +73,10 @@ describe('Media', () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
-    remoteGmail = await Utils.loadApi(google, 'gmail', 'v1');
+    [remoteDrive, remoteGmail] = await Promise.all([
+        Utils.loadApi(google, 'drive', 'v2'),
+        Utils.loadApi(google, 'gmail', 'v1')
+    ]);
     nock.disableNetConnect();
   });
 

--- a/test/test.media.ts
+++ b/test/test.media.ts
@@ -11,12 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as async from 'async';
+import * as assert from 'assert';
 import * as fs from 'fs';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
 
 import {GoogleApis} from '../src';
 
@@ -72,28 +71,13 @@ describe('Media', () => {
   let localDrive, remoteDrive;
   let localGmail, remoteGmail;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    async.parallel(
-        [
-          (cb) => {
-            Utils.loadApi(google, 'drive', 'v2', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'gmail', 'v1', {}, cb);
-          }
-        ],
-        (err, apis) => {
-          if (err) {
-            return done(err);
-          }
-          remoteDrive = apis[0];
-          remoteGmail = apis[1];
-          nock.disableNetConnect();
-          done();
-        });
+    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
+    remoteGmail = await Utils.loadApi(google, 'gmail', 'v1');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/test.media.ts
+++ b/test/test.media.ts
@@ -74,8 +74,7 @@ describe('Media', () => {
     const google = new GoogleApis();
     nock.enableNetConnect();
     [remoteDrive, remoteGmail] = await Promise.all([
-        Utils.loadApi(google, 'drive', 'v2'),
-        Utils.loadApi(google, 'gmail', 'v1')
+      Utils.loadApi(google, 'drive', 'v2'), Utils.loadApi(google, 'gmail', 'v1')
     ]);
     nock.disableNetConnect();
   });

--- a/test/test.options.ts
+++ b/test/test.options.ts
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as assert from 'assert';
 import * as nock from 'nock';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
 import * as url from 'url';
 
 import {GoogleApis} from '../src';
@@ -77,10 +77,11 @@ describe('Options', () => {
     // won't work unless I call `nock.cleanAll()` first.
     nock.cleanAll();
     nock.enableNetConnect();
-    const d = await pify(Utils.loadApi)(google, 'drive', 'v2', {});
+    const d = await Utils.loadApi(google, 'drive', 'v2');
     nock.disableNetConnect();
     nock(Utils.baseUrl).get('/drive/v2/files/123?myParam=123').reply(200);
-    const res3 = await pify(d.files.get)({fileId: '123'});
+    // tslint:disable-next-line no-any
+    const res3 = await pify((d as any).files.get)({fileId: '123'});
     // If the default param handling is broken, query might be undefined,
     // thus concealing the assertion message with some generic "cannot
     // call .indexOf of undefined"

--- a/test/test.path.ts
+++ b/test/test.path.ts
@@ -11,27 +11,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as assert from 'assert';
 import * as nock from 'nock';
-import * as assert from 'power-assert';
 import * as url from 'url';
+
 import {GoogleApis} from '../src';
+
 import {Utils} from './utils';
 
 describe('Path params', () => {
   let localDrive, remoteDrive;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    Utils.loadApi(google, 'drive', 'v2', {}, (err, drive) => {
-      nock.disableNetConnect();
-      if (err) {
-        return done(err);
-      }
-      remoteDrive = drive;
-      done();
-    });
+    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/test.query.ts
+++ b/test/test.query.ts
@@ -15,9 +15,7 @@ import * as assert from 'assert';
 import * as nock from 'nock';
 import * as pify from 'pify';
 import * as url from 'url';
-
 import {google, GoogleApis} from '../src';
-
 import {Utils} from './utils';
 
 describe('Query params', () => {
@@ -29,9 +27,11 @@ describe('Query params', () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    remoteCompute = await Utils.loadApi(google, 'compute', 'v1');
-    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
-    remoteGmail = await Utils.loadApi(google, 'gmail', 'v1');
+    [remoteCompute, remoteDrive, remoteGmail] = await Promise.all([
+        Utils.loadApi(google, 'compute', 'v1'),
+        Utils.loadApi(google, 'drive', 'v2'),
+        Utils.loadApi(google, 'gmail', 'v1')
+    ]);
     nock.disableNetConnect();
   });
 

--- a/test/test.query.ts
+++ b/test/test.query.ts
@@ -28,9 +28,8 @@ describe('Query params', () => {
     const google = new GoogleApis();
     nock.enableNetConnect();
     [remoteCompute, remoteDrive, remoteGmail] = await Promise.all([
-        Utils.loadApi(google, 'compute', 'v1'),
-        Utils.loadApi(google, 'drive', 'v2'),
-        Utils.loadApi(google, 'gmail', 'v1')
+      Utils.loadApi(google, 'compute', 'v1'),
+      Utils.loadApi(google, 'drive', 'v2'), Utils.loadApi(google, 'gmail', 'v1')
     ]);
     nock.disableNetConnect();
   });

--- a/test/test.query.ts
+++ b/test/test.query.ts
@@ -11,11 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as async from 'async';
-import {AxiosResponse} from 'axios';
+import * as assert from 'assert';
 import * as nock from 'nock';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
 import * as url from 'url';
 
 import {google, GoogleApis} from '../src';
@@ -27,32 +25,14 @@ describe('Query params', () => {
   let localDrive, remoteDrive;
   let localGmail, remoteGmail;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    async.parallel(
-        [
-          (cb) => {
-            Utils.loadApi(google, 'compute', 'v1', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'drive', 'v2', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'gmail', 'v1', {}, cb);
-          }
-        ],
-        (err, apis) => {
-          if (err) {
-            return done(err);
-          }
-          remoteCompute = apis[0];
-          remoteDrive = apis[1];
-          remoteGmail = apis[2];
-          nock.disableNetConnect();
-          done();
-        });
+    remoteCompute = await Utils.loadApi(google, 'compute', 'v1');
+    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
+    remoteGmail = await Utils.loadApi(google, 'gmail', 'v1');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -11,10 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as async from 'async';
+import * as assert from 'assert';
 import * as nock from 'nock';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
 
 import {GoogleApis} from '../src';
 
@@ -82,32 +81,14 @@ describe('Transporters', () => {
   let localOauth2, remoteOauth2;
   let localUrlshortener, remoteUrlshortener;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    async.parallel(
-        [
-          (cb) => {
-            Utils.loadApi(google, 'drive', 'v2', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'oauth2', 'v2', {}, cb);
-          },
-          (cb) => {
-            Utils.loadApi(google, 'urlshortener', 'v1', {}, cb);
-          }
-        ],
-        (err, apis) => {
-          if (err) {
-            return done(err);
-          }
-          remoteDrive = apis[0];
-          remoteOauth2 = apis[1];
-          remoteUrlshortener = apis[2];
-          nock.disableNetConnect();
-          done();
-        });
+    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
+    remoteOauth2 = await Utils.loadApi(google, 'oauth2', 'v2');
+    remoteUrlshortener = await Utils.loadApi(google, 'urlshortener', 'v1');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -14,9 +14,7 @@
 import * as assert from 'assert';
 import * as nock from 'nock';
 import * as pify from 'pify';
-
 import {GoogleApis} from '../src';
-
 import {Utils} from './utils';
 
 async function testHeaders(drive) {
@@ -85,9 +83,11 @@ describe('Transporters', () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
-    remoteOauth2 = await Utils.loadApi(google, 'oauth2', 'v2');
-    remoteUrlshortener = await Utils.loadApi(google, 'urlshortener', 'v1');
+    [remoteDrive, remoteOauth2, remoteUrlshortener] = await Promise.all([
+      Utils.loadApi(google, 'drive', 'v2'),
+      Utils.loadApi(google, 'oauth2', 'v2'),
+      Utils.loadApi(google, 'urlshortener', 'v1')
+    ]);
     nock.disableNetConnect();
   });
 

--- a/test/test.urlshortener.v1.ts
+++ b/test/test.urlshortener.v1.ts
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as assert from 'assert';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as pify from 'pify';
-import * as assert from 'power-assert';
 import * as url from 'url';
 
 import {GoogleApis} from '../src';
@@ -52,18 +52,12 @@ async function testInsert(urlshortener) {
 describe('Urlshortener', () => {
   let localUrlshortener, remoteUrlshortener;
 
-  before((done) => {
+  before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
     nock.enableNetConnect();
-    Utils.loadApi(google, 'urlshortener', 'v1', {}, (err, urlshortener) => {
-      nock.disableNetConnect();
-      if (err) {
-        return done(err);
-      }
-      remoteUrlshortener = urlshortener;
-      done();
-    });
+    remoteUrlshortener = await Utils.loadApi(google, 'urlshortener', 'v1');
+    nock.disableNetConnect();
   });
 
   beforeEach(() => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -14,6 +14,7 @@
 import {AxiosResponse} from 'axios';
 import * as url from 'url';
 import {GoogleApis} from '../src/index';
+import {Endpoint} from '../src/lib/endpoint';
 
 export abstract class Utils {
   static getQs(res: AxiosResponse) {
@@ -26,14 +27,9 @@ export abstract class Utils {
         version + '/rest';
   }
 
-  static loadApi(
-      google: GoogleApis, name: string, version: string, options, cb) {
-    if (typeof options === 'function') {
-      cb = options;
-      options = {};
-    }
-    return google.discoverAPI(
-        Utils.getDiscoveryUrl(name, version), options, cb);
+  static async loadApi(
+      google: GoogleApis, name: string, version: string, options = {}) {
+    return google.discoverAPI(Utils.getDiscoveryUrl(name, version), options);
   }
 
   static readonly noop = () => undefined;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -27,7 +27,7 @@ export abstract class Utils {
         version + '/rest';
   }
 
-  static async loadApi(
+  static loadApi(
       google: GoogleApis, name: string, version: string, options = {}) {
     return google.discoverAPI(Utils.getDiscoveryUrl(name, version), options);
   }


### PR DESCRIPTION
This change does a few things:
- Eliminates the `async` and `power-assert` npm depdendencies
- Introduces a few async APIs in the generator
- Basic cleanup

One step closer to noImplicitAny.