### PR TITLE
chore: release 26.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "name": "Justin Beckwith"
     }
   ],
-  "version": "25.0.0",
+  "version": "26.0.1",
   "scripts": {
     "posttest": "npm run check && npm run license-check",
     "test": "npm run cover",


### PR DESCRIPTION
We messed up the last release :(  Resolves #988. 

Draft release notes are here:
https://github.com/google/google-api-nodejs-client/releases/edit/untagged-6c5a57ab1bbce712f6a8