### PR TITLE
chore: release v27.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,13 @@
     {
       "email": "beckwith@google.com",
       "name": "Justin Beckwith"
+    },
+    {
+      "email": "fenster@google.com",
+      "name": "Alexander Fenster"
     }
   ],
-  "version": "26.0.1",
+  "version": "27.0.0",
   "scripts": {
     "posttest": "npm run check && npm run license-check",
     "test": "npm run cover",


### PR DESCRIPTION
Releasing new APIs as v27.0.0.

---

# 27.0.0

This release contains updates to various APIs and various fixes. 

## New APIs
 
- chat v1
- genomics v2alpha1
- serviceusage v1
- vision v1p2beta1

## Removed APIs

- firebaseremoteconfig v1

## Fixes
- (#1016) raise default of maxContentLength
- (#1020) treat 304 responses as success
- (#1010) move pify to deps (resolves #1007)

---

- [x] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [x] Appropriate changes to readme/docs are included in PR