### PR TITLE
chore: add more type information to generated files

### DIFF
--- a/src/apis/abusiveexperiencereport/v1.ts
+++ b/src/apis/abusiveexperiencereport/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Abusive Experience Report API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Abusiveexperiencereport
  */
-function Abusiveexperiencereport(options) {
+function Abusiveexperiencereport(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.sites = {
@@ -48,7 +55,8 @@ function Abusiveexperiencereport(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Abusiveexperiencereport(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -84,7 +92,9 @@ function Abusiveexperiencereport(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +115,7 @@ function Abusiveexperiencereport(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/acceleratedmobilepageurl/v1.ts
+++ b/src/apis/acceleratedmobilepageurl/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Accelerated Mobile Pages (AMP) URL API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Acceleratedmobilepageurl
  */
-function Acceleratedmobilepageurl(options) {
+function Acceleratedmobilepageurl(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.ampUrls = {
@@ -49,7 +56,9 @@ function Acceleratedmobilepageurl(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchGet(params, options, callback) {
+    batchGet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Acceleratedmobilepageurl(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adexchangebuyer/v1.2.ts
+++ b/src/apis/adexchangebuyer/v1.2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Ad Exchange Buyer API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.2
  * @param {object=} options Options for Adexchangebuyer
  */
-function Adexchangebuyer(options) {
+function Adexchangebuyer(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -48,7 +55,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.list
         * @desc Retrieves the authenticated user's list of accounts.
@@ -80,7 +88,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -100,7 +110,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.patch
         * @desc Updates an existing account. This method supports patch
@@ -115,7 +125,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -135,7 +147,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.update
         * @desc Updates an existing account.
@@ -149,7 +161,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -169,7 +183,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -188,7 +202,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -210,7 +225,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'buyerCreativeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.insert
         * @desc Submit a new creative.
@@ -223,7 +238,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -243,7 +260,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.list
         * @desc Retrieves a list of the authenticated user's active creatives. A
@@ -259,7 +276,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -279,7 +298,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adexchangebuyer/v1.3.ts
+++ b/src/apis/adexchangebuyer/v1.3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Ad Exchange Buyer API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.3
  * @param {object=} options Options for Adexchangebuyer
  */
-function Adexchangebuyer(options) {
+function Adexchangebuyer(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -48,7 +55,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.list
         * @desc Retrieves the authenticated user's list of accounts.
@@ -80,7 +88,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -100,7 +110,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.patch
         * @desc Updates an existing account. This method supports patch
@@ -115,7 +125,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -135,7 +147,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.update
         * @desc Updates an existing account.
@@ -149,7 +161,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -169,7 +183,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -187,7 +201,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +222,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.billingInfo.list
         * @desc Retrieves a list of billing information for all accounts of the
@@ -220,7 +235,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -240,7 +257,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -259,7 +276,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -280,7 +298,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'billingId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.budget.patch
         * @desc Updates the budget amount for the budget of the adgroup
@@ -297,7 +315,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -318,7 +338,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'billingId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.budget.update
         * @desc Updates the budget amount for the budget of the adgroup
@@ -335,7 +355,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -356,7 +378,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'billingId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -375,7 +397,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -397,7 +420,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'buyerCreativeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.insert
         * @desc Submit a new creative.
@@ -410,7 +433,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -430,7 +455,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.list
         * @desc Retrieves a list of the authenticated user's active creatives. A
@@ -448,7 +473,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -468,7 +495,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -485,7 +512,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -505,7 +533,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.directDeals.list
         * @desc Retrieves the authenticated user's list of direct deals.
@@ -517,7 +545,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -537,7 +567,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -558,7 +588,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -578,7 +610,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -596,7 +628,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -618,7 +652,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.get
         * @desc Gets a specific pretargeting configuration
@@ -632,7 +666,8 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -654,7 +689,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.insert
         * @desc Inserts a new pretargeting configuration.
@@ -668,7 +703,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -689,7 +726,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.list
         * @desc Retrieves a list of the authenticated user's pretargeting
@@ -703,7 +740,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -724,7 +763,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.patch
         * @desc Updates an existing pretargeting config. This method supports
@@ -740,7 +779,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -762,7 +803,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.update
         * @desc Updates an existing pretargeting config.
@@ -777,7 +818,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -799,7 +842,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adexchangebuyer/v1.4.ts
+++ b/src/apis/adexchangebuyer/v1.4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Ad Exchange Buyer API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.4
  * @param {object=} options Options for Adexchangebuyer
  */
-function Adexchangebuyer(options) {
+function Adexchangebuyer(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -48,7 +55,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.list
         * @desc Retrieves the authenticated user's list of accounts.
@@ -80,7 +88,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -100,7 +110,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.patch
         * @desc Updates an existing account. This method supports patch
@@ -116,7 +126,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -136,7 +148,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.accounts.update
         * @desc Updates an existing account.
@@ -151,7 +163,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -171,7 +185,7 @@ function Adexchangebuyer(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -189,7 +203,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -209,7 +224,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.billingInfo.list
         * @desc Retrieves a list of billing information for all accounts of the
@@ -222,7 +237,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -242,7 +259,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -261,7 +278,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -282,7 +300,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'billingId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.budget.patch
         * @desc Updates the budget amount for the budget of the adgroup
@@ -299,7 +317,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -320,7 +340,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'billingId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.budget.update
         * @desc Updates the budget amount for the budget of the adgroup
@@ -337,7 +357,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -358,7 +380,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'billingId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -377,7 +399,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addDeal(params, options, callback) {
+    addDeal(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -399,7 +423,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'buyerCreativeId', 'dealId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.get
         * @desc Gets the status for a single creative. A creative will be
@@ -414,7 +438,8 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -436,7 +461,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'buyerCreativeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.insert
         * @desc Submit a new creative.
@@ -449,7 +474,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -469,7 +496,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.list
         * @desc Retrieves a list of the authenticated user's active creatives. A
@@ -488,7 +515,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -508,7 +537,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.listDeals
         * @desc Lists the external deal ids associated with the creative.
@@ -522,7 +551,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listDeals(params, options, callback) {
+    listDeals(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -544,7 +575,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'buyerCreativeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.creatives.removeDeal
         * @desc Remove a deal id associated with the creative.
@@ -559,7 +590,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeDeal(params, options, callback) {
+    removeDeal(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -581,7 +614,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'buyerCreativeId', 'dealId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -599,7 +632,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -620,7 +655,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.marketplacedeals.insert
         * @desc Add new deals for the specified proposal
@@ -634,7 +669,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -655,7 +692,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.marketplacedeals.list
         * @desc List all the deals for a given proposal
@@ -669,7 +706,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -690,7 +729,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.marketplacedeals.update
         * @desc Replaces all the deals in the proposal with the passed in deals
@@ -704,7 +743,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -725,7 +766,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -743,7 +784,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -764,7 +807,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.marketplacenotes.list
         * @desc Get all the notes associated with a proposal
@@ -778,7 +821,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -799,7 +844,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -817,7 +862,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    updateproposal(params, options, callback) {
+    updateproposal(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -839,7 +886,7 @@ function Adexchangebuyer(options) {
         pathParams: ['privateAuctionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -860,7 +907,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -880,7 +929,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -898,7 +947,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -920,7 +971,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.get
         * @desc Gets a specific pretargeting configuration
@@ -934,7 +985,8 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -956,7 +1008,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.insert
         * @desc Inserts a new pretargeting configuration.
@@ -970,7 +1022,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -991,7 +1045,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.list
         * @desc Retrieves a list of the authenticated user's pretargeting
@@ -1005,7 +1059,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1026,7 +1082,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.patch
         * @desc Updates an existing pretargeting config. This method supports
@@ -1042,7 +1098,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1064,7 +1122,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.pretargetingConfig.update
         * @desc Updates an existing pretargeting config.
@@ -1079,7 +1137,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1101,7 +1161,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId', 'configId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1118,7 +1178,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1138,7 +1199,7 @@ function Adexchangebuyer(options) {
         pathParams: ['productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.products.search
         * @desc Gets the requested product.
@@ -1151,7 +1212,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1171,7 +1234,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1188,7 +1251,8 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1208,7 +1272,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.proposals.insert
         * @desc Create the given list of proposals
@@ -1221,7 +1285,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1241,7 +1307,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.proposals.patch
         * @desc Update the given proposal. This method supports patch semantics.
@@ -1257,7 +1323,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1279,7 +1347,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId', 'revisionNumber', 'updateAction'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.proposals.search
         * @desc Search for proposals using pql query
@@ -1292,7 +1360,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1312,7 +1382,7 @@ function Adexchangebuyer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.proposals.setupcomplete
         * @desc Update the given proposal to indicate that setup has been
@@ -1326,7 +1396,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setupcomplete(params, options, callback) {
+    setupcomplete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1348,7 +1420,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangebuyer.proposals.update
         * @desc Update the given proposal
@@ -1364,7 +1436,9 @@ function Adexchangebuyer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1386,7 +1460,7 @@ function Adexchangebuyer(options) {
         pathParams: ['proposalId', 'revisionNumber', 'updateAction'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1403,7 +1477,9 @@ function Adexchangebuyer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1424,7 +1500,7 @@ function Adexchangebuyer(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adexchangebuyer2/v2beta1.ts
+++ b/src/apis/adexchangebuyer2/v2beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Ad Exchange Buyer API II
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta1
  * @param {object=} options Options for Adexchangebuyer2
  */
-function Adexchangebuyer2(options) {
+function Adexchangebuyer2(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts =
@@ -52,7 +59,9 @@ function Adexchangebuyer2(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -73,7 +82,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.clients.get
               * @desc Gets a client buyer with a given client account ID.
@@ -87,7 +96,8 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -110,7 +120,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId', 'clientAccountId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.clients.list
               * @desc Lists all the clients for the current sponsor buyer.
@@ -126,7 +136,9 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -147,7 +159,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.clients.update
               * @desc Updates an existing client buyer.
@@ -162,7 +174,9 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -185,7 +199,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId', 'clientAccountId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           invitations: {
             /**
@@ -203,7 +217,9 @@ function Adexchangebuyer2(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -226,7 +242,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'clientAccountId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * adexchangebuyer2.accounts.clients.invitations.get
                 * @desc Retrieves an existing client user invitation.
@@ -241,7 +257,8 @@ function Adexchangebuyer2(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -265,7 +282,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'clientAccountId', 'invitationId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * adexchangebuyer2.accounts.clients.invitations.list
                 * @desc Lists all the client users invitations for a client with
@@ -282,7 +299,9 @@ function Adexchangebuyer2(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -305,7 +324,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'clientAccountId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -324,7 +343,8 @@ function Adexchangebuyer2(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -347,7 +367,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'clientAccountId', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * adexchangebuyer2.accounts.clients.users.list
                 * @desc Lists all the known client users for a specified sponsor
@@ -364,7 +384,9 @@ function Adexchangebuyer2(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -387,7 +409,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'clientAccountId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * adexchangebuyer2.accounts.clients.users.update
                 * @desc Updates an existing client user. Only the user status
@@ -404,7 +426,9 @@ function Adexchangebuyer2(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            update(params, options, callback) {
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -427,7 +451,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'clientAccountId', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -448,7 +472,9 @@ function Adexchangebuyer2(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -469,7 +495,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.creatives.get
               * @desc Gets a creative.
@@ -483,7 +509,8 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -506,7 +533,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId', 'creativeId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.creatives.list
               * @desc Lists creatives.
@@ -522,7 +549,9 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -543,7 +572,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.creatives.stopWatching
               * @desc Stops watching a creative. Will stop push notifications
@@ -559,7 +588,9 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          stopWatching(params, options, callback) {
+          stopWatching(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -582,7 +613,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId', 'creativeId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.creatives.update
               * @desc Updates a creative.
@@ -598,7 +629,9 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -621,7 +654,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId', 'creativeId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * adexchangebuyer2.accounts.creatives.watch
               * @desc Watches a creative. Will result in push notifications
@@ -637,7 +670,9 @@ function Adexchangebuyer2(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          watch(params, options, callback) {
+          watch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -660,7 +695,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['accountId', 'creativeId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           dealAssociations: {
             /**
@@ -677,7 +712,8 @@ function Adexchangebuyer2(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            add(params, options, callback) {
+            add(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -700,7 +736,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'creativeId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * adexchangebuyer2.accounts.creatives.dealAssociations.list
                 * @desc List all creative-deal associations.
@@ -718,7 +754,9 @@ function Adexchangebuyer2(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -741,7 +779,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'creativeId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * adexchangebuyer2.accounts.creatives.dealAssociations.remove
                 * @desc Remove the association between a deal and a creative.
@@ -757,7 +795,9 @@ function Adexchangebuyer2(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            remove(params, options, callback) {
+            remove(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -780,7 +820,7 @@ function Adexchangebuyer2(options) {
                 pathParams: ['accountId', 'creativeId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -806,7 +846,10 @@ function Adexchangebuyer2(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -827,7 +870,7 @@ function Adexchangebuyer2(options) {
                     pathParams: ['ownerName'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * adexchangebuyer2.bidders.accounts.filterSets.delete
                     * @desc Deletes the requested filter set from the account
@@ -841,7 +884,10 @@ function Adexchangebuyer2(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -862,7 +908,7 @@ function Adexchangebuyer2(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * adexchangebuyer2.bidders.accounts.filterSets.get
                     * @desc Retrieves the requested filter set for the account
@@ -876,7 +922,9 @@ function Adexchangebuyer2(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -897,7 +945,7 @@ function Adexchangebuyer2(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * adexchangebuyer2.bidders.accounts.filterSets.list
                     * @desc Lists all filter sets for the account with the given
@@ -913,7 +961,10 @@ function Adexchangebuyer2(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -934,7 +985,7 @@ function Adexchangebuyer2(options) {
                     pathParams: ['ownerName'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 },
                 bidMetrics: {
                   /**
@@ -953,7 +1004,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -975,7 +1029,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -996,7 +1050,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1018,7 +1075,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1040,7 +1097,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1063,7 +1123,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1085,7 +1145,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1108,7 +1171,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1129,7 +1192,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1151,7 +1217,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   },
                   creatives: {
                     /**
@@ -1172,7 +1238,10 @@ function Adexchangebuyer2(options) {
                      * @param {callback} callback The callback that handles the response.
                      * @return {object} Request object
                      */
-                    list(params, options, callback) {
+                    list(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -1195,7 +1264,7 @@ function Adexchangebuyer2(options) {
                         pathParams: ['creativeStatusId', 'filterSetName'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }
 
                   },
@@ -1218,7 +1287,10 @@ function Adexchangebuyer2(options) {
                      * @param {callback} callback The callback that handles the response.
                      * @return {object} Request object
                      */
-                    list(params, options, callback) {
+                    list(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -1241,7 +1313,7 @@ function Adexchangebuyer2(options) {
                         pathParams: ['creativeStatusId', 'filterSetName'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }
 
                   }
@@ -1263,7 +1335,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1285,7 +1360,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1306,7 +1381,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1328,7 +1406,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1350,7 +1428,10 @@ function Adexchangebuyer2(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1373,7 +1454,7 @@ function Adexchangebuyer2(options) {
                       pathParams: ['filterSetName'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 }
@@ -1395,7 +1476,9 @@ function Adexchangebuyer2(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1416,7 +1499,7 @@ function Adexchangebuyer2(options) {
           pathParams: ['ownerName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adexchangebuyer2.bidders.filterSets.delete
           * @desc Deletes the requested filter set from the account with the
@@ -1430,7 +1513,9 @@ function Adexchangebuyer2(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1451,7 +1536,7 @@ function Adexchangebuyer2(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adexchangebuyer2.bidders.filterSets.get
           * @desc Retrieves the requested filter set for the account with the
@@ -1465,7 +1550,8 @@ function Adexchangebuyer2(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1486,7 +1572,7 @@ function Adexchangebuyer2(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adexchangebuyer2.bidders.filterSets.list
           * @desc Lists all filter sets for the account with the given account
@@ -1502,7 +1588,9 @@ function Adexchangebuyer2(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1523,7 +1611,7 @@ function Adexchangebuyer2(options) {
           pathParams: ['ownerName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       bidMetrics: {
         /**
@@ -1540,7 +1628,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1561,7 +1651,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -1581,7 +1671,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1602,7 +1694,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -1624,7 +1716,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1646,7 +1740,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -1667,7 +1761,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1689,7 +1785,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -1709,7 +1805,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1730,7 +1828,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         creatives: {
           /**
@@ -1751,7 +1849,9 @@ function Adexchangebuyer2(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1774,7 +1874,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['creativeStatusId', 'filterSetName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1797,7 +1897,9 @@ function Adexchangebuyer2(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1820,7 +1922,7 @@ function Adexchangebuyer2(options) {
               pathParams: ['creativeStatusId', 'filterSetName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }
@@ -1841,7 +1943,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1862,7 +1966,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -1882,7 +1986,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1903,7 +2009,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -1924,7 +2030,9 @@ function Adexchangebuyer2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1946,7 +2054,7 @@ function Adexchangebuyer2(options) {
             pathParams: ['filterSetName'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/adexchangeseller/v1.1.ts
+++ b/src/apis/adexchangeseller/v1.1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Ad Exchange Seller API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.1
  * @param {object=} options Options for Adexchangeseller
  */
-function Adexchangeseller(options) {
+function Adexchangeseller(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -47,7 +54,8 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Adexchangeseller(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -85,7 +93,9 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +115,7 @@ function Adexchangeseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -123,7 +133,8 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -145,7 +156,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId', 'adUnitId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangeseller.adunits.list
         * @desc List all ad units in the specified ad client for this Ad
@@ -162,7 +173,9 @@ function Adexchangeseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -183,7 +196,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     customchannels: {
       /**
@@ -201,7 +214,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -223,7 +238,7 @@ function Adexchangeseller(options) {
           pathParams: ['adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -241,7 +256,9 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -261,7 +278,7 @@ function Adexchangeseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -279,7 +296,8 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -301,7 +319,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId', 'customChannelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangeseller.customchannels.list
         * @desc List all custom channels in the specified ad client for this Ad
@@ -317,7 +335,9 @@ function Adexchangeseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -339,7 +359,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     adunits: {
       /**
@@ -358,7 +378,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -380,7 +402,7 @@ function Adexchangeseller(options) {
           pathParams: ['adClientId', 'customChannelId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -399,7 +421,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -419,7 +443,7 @@ function Adexchangeseller(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -436,7 +460,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -456,7 +482,7 @@ function Adexchangeseller(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -474,7 +500,8 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -494,7 +521,7 @@ function Adexchangeseller(options) {
         pathParams: ['dealId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangeseller.preferreddeals.list
         * @desc List the preferred deals for this Ad Exchange account.
@@ -506,7 +533,9 @@ function Adexchangeseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -526,7 +555,7 @@ function Adexchangeseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -553,7 +582,9 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generate(params, options, callback) {
+    generate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -573,7 +604,7 @@ function Adexchangeseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     saved: {
       /**
@@ -592,7 +623,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      generate(params, options, callback) {
+      generate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -613,7 +646,7 @@ function Adexchangeseller(options) {
           pathParams: ['savedReportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adexchangeseller.reports.saved.list
           * @desc List all saved reports in this Ad Exchange account.
@@ -627,7 +660,9 @@ function Adexchangeseller(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -647,7 +682,7 @@ function Adexchangeseller(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -668,7 +703,9 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -689,7 +726,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adexchangeseller/v1.ts
+++ b/src/apis/adexchangeseller/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Ad Exchange Seller API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Adexchangeseller
  */
-function Adexchangeseller(options) {
+function Adexchangeseller(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.adclients = {
@@ -48,7 +55,9 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Adexchangeseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -86,7 +95,8 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -108,7 +118,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId', 'adUnitId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangeseller.adunits.list
         * @desc List all ad units in the specified ad client for this Ad
@@ -125,7 +135,9 @@ function Adexchangeseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -146,7 +158,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     customchannels: {
       /**
@@ -164,7 +176,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -186,7 +200,7 @@ function Adexchangeseller(options) {
           pathParams: ['adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -205,7 +219,8 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -227,7 +242,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId', 'customChannelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangeseller.customchannels.list
         * @desc List all custom channels in the specified ad client for this Ad
@@ -243,7 +258,9 @@ function Adexchangeseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -265,7 +282,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     adunits: {
       /**
@@ -284,7 +301,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -306,7 +325,7 @@ function Adexchangeseller(options) {
           pathParams: ['adClientId', 'customChannelId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -334,7 +353,9 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generate(params, options, callback) {
+    generate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -354,7 +375,7 @@ function Adexchangeseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     saved: {
       /**
@@ -373,7 +394,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      generate(params, options, callback) {
+      generate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -393,7 +416,7 @@ function Adexchangeseller(options) {
           pathParams: ['savedReportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adexchangeseller.reports.saved.list
           * @desc List all saved reports in this Ad Exchange account.
@@ -407,7 +430,9 @@ function Adexchangeseller(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -427,7 +452,7 @@ function Adexchangeseller(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -448,7 +473,9 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -469,7 +496,7 @@ function Adexchangeseller(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adexchangeseller/v2.0.ts
+++ b/src/apis/adexchangeseller/v2.0.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Ad Exchange Seller API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2.0
  * @param {object=} options Options for Adexchangeseller
  */
-function Adexchangeseller(options) {
+function Adexchangeseller(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -47,7 +54,8 @@ function Adexchangeseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Adexchangeseller(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adexchangeseller.accounts.list
         * @desc List all accounts available to this Ad Exchange account.
@@ -81,7 +89,9 @@ function Adexchangeseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -101,7 +111,7 @@ function Adexchangeseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     adclients: {
       /**
@@ -118,7 +128,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -139,7 +151,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -157,7 +169,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -178,7 +192,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -197,7 +211,8 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -219,7 +234,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId', 'adClientId', 'customChannelId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adexchangeseller.accounts.customchannels.list
           * @desc List all custom channels in the specified ad client for this
@@ -236,7 +251,9 @@ function Adexchangeseller(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -258,7 +275,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -277,7 +294,9 @@ function Adexchangeseller(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -299,7 +318,7 @@ function Adexchangeseller(options) {
             pathParams: ['accountId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -317,7 +336,9 @@ function Adexchangeseller(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -339,7 +360,7 @@ function Adexchangeseller(options) {
             pathParams: ['accountId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -358,7 +379,8 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -380,7 +402,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId', 'dealId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adexchangeseller.accounts.preferreddeals.list
           * @desc List the preferred deals for this Ad Exchange account.
@@ -393,7 +415,9 @@ function Adexchangeseller(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -415,7 +439,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -443,7 +467,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      generate(params, options, callback) {
+      generate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -464,7 +490,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       saved: {
         /**
@@ -484,7 +510,9 @@ function Adexchangeseller(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        generate(params, options, callback) {
+        generate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -506,7 +534,7 @@ function Adexchangeseller(options) {
             pathParams: ['accountId', 'savedReportId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * adexchangeseller.accounts.reports.saved.list
             * @desc List all saved reports in this Ad Exchange account.
@@ -521,7 +549,9 @@ function Adexchangeseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -543,7 +573,7 @@ function Adexchangeseller(options) {
             pathParams: ['accountId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -565,7 +595,9 @@ function Adexchangeseller(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -587,7 +619,7 @@ function Adexchangeseller(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/adexperiencereport/v1.ts
+++ b/src/apis/adexperiencereport/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Ad Experience Report API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Adexperiencereport
  */
-function Adexperiencereport(options) {
+function Adexperiencereport(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.sites = {
@@ -48,7 +55,8 @@ function Adexperiencereport(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Adexperiencereport(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -85,7 +93,9 @@ function Adexperiencereport(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -106,7 +116,7 @@ function Adexperiencereport(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/admin/datatransfer_v1.ts
+++ b/src/apis/admin/datatransfer_v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Admin Data Transfer API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation datatransfer_v1
  * @param {object=} options Options for Admin
  */
-function Admin(options) {
+function Admin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.applications = {
@@ -48,7 +55,8 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Admin(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datatransfer.applications.list
         * @desc Lists the applications available for data transfer for a
@@ -85,7 +93,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +115,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -122,7 +132,8 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -143,7 +154,7 @@ function Admin(options) {
         pathParams: ['dataTransferId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datatransfer.transfers.insert
         * @desc Inserts a data transfer request.
@@ -156,7 +167,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -176,7 +189,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datatransfer.transfers.list
         * @desc Lists the transfers for a customer by source user, destination
@@ -195,7 +208,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -215,7 +230,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/admin/directory_v1.ts
+++ b/src/apis/admin/directory_v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Admin Directory API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation directory_v1
  * @param {object=} options Options for Admin
  */
-function Admin(options) {
+function Admin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.asps = {
@@ -50,7 +57,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Admin(options) {
         pathParams: ['codeId', 'userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.asps.get
         * @desc Get information about an ASP issued by a user.
@@ -85,7 +94,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -106,7 +116,7 @@ function Admin(options) {
         pathParams: ['codeId', 'userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.asps.list
         * @desc List the ASPs issued by a user.
@@ -119,7 +129,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +151,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -156,7 +168,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -177,7 +191,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -196,7 +210,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    action(params, options, callback) {
+    action(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -218,7 +234,7 @@ function Admin(options) {
         pathParams: ['customerId', 'resourceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.chromeosdevices.get
         * @desc Retrieve Chrome OS Device
@@ -233,7 +249,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -255,7 +272,7 @@ function Admin(options) {
         pathParams: ['customerId', 'deviceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.chromeosdevices.list
         * @desc Retrieve all Chrome OS Devices of a customer (paginated)
@@ -275,7 +292,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -297,7 +316,7 @@ function Admin(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.chromeosdevices.moveDevicesToOu
         * @desc Move or insert multiple Chrome OS Devices to organizational unit
@@ -312,7 +331,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    moveDevicesToOu(params, options, callback) {
+    moveDevicesToOu(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -334,7 +355,7 @@ function Admin(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.chromeosdevices.patch
         * @desc Update Chrome OS Device. This method supports patch semantics.
@@ -350,7 +371,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -372,7 +395,7 @@ function Admin(options) {
         pathParams: ['customerId', 'deviceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.chromeosdevices.update
         * @desc Update Chrome OS Device
@@ -388,7 +411,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -410,7 +435,7 @@ function Admin(options) {
         pathParams: ['customerId', 'deviceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -427,7 +452,8 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -447,7 +473,7 @@ function Admin(options) {
         pathParams: ['customerKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.customers.patch
         * @desc Updates a customer. This method supports patch semantics.
@@ -461,7 +487,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -481,7 +509,7 @@ function Admin(options) {
         pathParams: ['customerKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.customers.update
         * @desc Updates a customer.
@@ -495,7 +523,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -515,7 +545,7 @@ function Admin(options) {
         pathParams: ['customerKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -533,7 +563,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -555,7 +587,7 @@ function Admin(options) {
         pathParams: ['customer', 'domainAliasName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.domainAliases.get
         * @desc Retrieves a domain alias of the customer.
@@ -569,7 +601,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -591,7 +624,7 @@ function Admin(options) {
         pathParams: ['customer', 'domainAliasName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.domainAliases.insert
         * @desc Inserts a Domain alias of the customer.
@@ -605,7 +638,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -626,7 +661,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.domainAliases.list
         * @desc Lists the domain aliases of the customer.
@@ -640,7 +675,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -661,7 +698,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -679,7 +716,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -701,7 +740,7 @@ function Admin(options) {
         pathParams: ['customer', 'domainName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.domains.get
         * @desc Retrieves a domain of the customer.
@@ -715,7 +754,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -737,7 +777,7 @@ function Admin(options) {
         pathParams: ['customer', 'domainName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.domains.insert
         * @desc Inserts a domain of the customer.
@@ -751,7 +791,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -771,7 +813,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.domains.list
         * @desc Lists the domains of the customer.
@@ -784,7 +826,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -804,7 +848,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -821,7 +865,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -841,7 +887,7 @@ function Admin(options) {
         pathParams: ['groupKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.groups.get
         * @desc Retrieve Group
@@ -854,7 +900,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -874,7 +921,7 @@ function Admin(options) {
         pathParams: ['groupKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.groups.insert
         * @desc Create Group
@@ -887,7 +934,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -907,7 +956,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.groups.list
         * @desc Retrieve all groups in a domain (paginated)
@@ -924,7 +973,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -944,7 +995,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.groups.patch
         * @desc Update Group. This method supports patch semantics.
@@ -958,7 +1009,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -978,7 +1031,7 @@ function Admin(options) {
         pathParams: ['groupKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.groups.update
         * @desc Update Group
@@ -992,7 +1045,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1012,7 +1067,7 @@ function Admin(options) {
         pathParams: ['groupKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     aliases: {
       /**
@@ -1028,7 +1083,9 @@ function Admin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1049,7 +1106,7 @@ function Admin(options) {
           pathParams: ['alias', 'groupKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.groups.aliases.insert
           * @desc Add a alias for the group
@@ -1063,7 +1120,9 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      insert(params, options, callback) {
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1083,7 +1142,7 @@ function Admin(options) {
           pathParams: ['groupKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.groups.aliases.list
           * @desc List all aliases for a group
@@ -1096,7 +1155,9 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1116,7 +1177,7 @@ function Admin(options) {
           pathParams: ['groupKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1135,7 +1196,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1156,7 +1219,7 @@ function Admin(options) {
         pathParams: ['groupKey', 'memberKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.members.get
         * @desc Retrieve Group Member
@@ -1170,7 +1233,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1191,7 +1255,7 @@ function Admin(options) {
         pathParams: ['groupKey', 'memberKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.members.hasMember
         * @desc Checks Membership of an user within a Group
@@ -1205,7 +1269,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    hasMember(params, options, callback) {
+    hasMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1227,7 +1293,7 @@ function Admin(options) {
         pathParams: ['groupKey', 'memberKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.members.insert
         * @desc Add user to the specified group.
@@ -1241,7 +1307,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1261,7 +1329,7 @@ function Admin(options) {
         pathParams: ['groupKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.members.list
         * @desc Retrieve all members in a group (paginated)
@@ -1277,7 +1345,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1297,7 +1367,7 @@ function Admin(options) {
         pathParams: ['groupKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.members.patch
         * @desc Update membership of a user in the specified group. This method
@@ -1313,7 +1383,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1334,7 +1406,7 @@ function Admin(options) {
         pathParams: ['groupKey', 'memberKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.members.update
         * @desc Update membership of a user in the specified group.
@@ -1349,7 +1421,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1370,7 +1444,7 @@ function Admin(options) {
         pathParams: ['groupKey', 'memberKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1389,7 +1463,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    action(params, options, callback) {
+    action(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1411,7 +1487,7 @@ function Admin(options) {
         pathParams: ['customerId', 'resourceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.mobiledevices.delete
         * @desc Delete Mobile Device
@@ -1425,7 +1501,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1447,7 +1525,7 @@ function Admin(options) {
         pathParams: ['customerId', 'resourceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.mobiledevices.get
         * @desc Retrieve Mobile Device
@@ -1462,7 +1540,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1484,7 +1563,7 @@ function Admin(options) {
         pathParams: ['customerId', 'resourceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.mobiledevices.list
         * @desc Retrieve all Mobile Devices of a customer (paginated)
@@ -1503,7 +1582,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1524,7 +1605,7 @@ function Admin(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1542,7 +1623,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1564,7 +1647,7 @@ function Admin(options) {
         pathParams: ['customer', 'notificationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.notifications.get
         * @desc Retrieves a notification.
@@ -1578,7 +1661,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1600,7 +1684,7 @@ function Admin(options) {
         pathParams: ['customer', 'notificationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.notifications.list
         * @desc Retrieves a list of notifications.
@@ -1616,7 +1700,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1637,7 +1723,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.notifications.patch
         * @desc Updates a notification. This method supports patch semantics.
@@ -1652,7 +1738,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1674,7 +1762,7 @@ function Admin(options) {
         pathParams: ['customer', 'notificationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.notifications.update
         * @desc Updates a notification.
@@ -1689,7 +1777,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1711,7 +1801,7 @@ function Admin(options) {
         pathParams: ['customer', 'notificationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1729,7 +1819,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1751,7 +1843,7 @@ function Admin(options) {
         pathParams: ['customerId', 'orgUnitPath'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.orgunits.get
         * @desc Retrieve organizational unit
@@ -1765,7 +1857,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1787,7 +1880,7 @@ function Admin(options) {
         pathParams: ['customerId', 'orgUnitPath'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.orgunits.insert
         * @desc Add organizational unit
@@ -1801,7 +1894,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1822,7 +1917,7 @@ function Admin(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.orgunits.list
         * @desc Retrieve all organizational units
@@ -1837,7 +1932,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1858,7 +1955,7 @@ function Admin(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.orgunits.patch
         * @desc Update organizational unit. This method supports patch
@@ -1874,7 +1971,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1896,7 +1995,7 @@ function Admin(options) {
         pathParams: ['customerId', 'orgUnitPath'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.orgunits.update
         * @desc Update organizational unit
@@ -1911,7 +2010,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1933,7 +2034,7 @@ function Admin(options) {
         pathParams: ['customerId', 'orgUnitPath'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1950,7 +2051,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1972,7 +2075,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1988,7 +2091,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    GetSettings(params, options, callback) {
+    GetSettings(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2008,7 +2113,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.resolvedAppAccessSettings.ListTrustedApps
         * @desc Retrieves the list of apps trusted by the admin of the logged in
@@ -2021,7 +2126,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    ListTrustedApps(params, options, callback) {
+    ListTrustedApps(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2041,7 +2148,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2061,7 +2168,9 @@ function Admin(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2083,7 +2192,7 @@ function Admin(options) {
               pathParams: ['buildingId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.buildings.get
               * @desc Retrieves a building.
@@ -2097,7 +2206,8 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2119,7 +2229,7 @@ function Admin(options) {
               pathParams: ['buildingId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.buildings.insert
               * @desc Inserts a building.
@@ -2133,7 +2243,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          insert(params, options, callback) {
+          insert(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2155,7 +2267,7 @@ function Admin(options) {
               pathParams: ['customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.buildings.list
               * @desc Retrieves a list of buildings for an account.
@@ -2168,7 +2280,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2190,7 +2304,7 @@ function Admin(options) {
               pathParams: ['customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.buildings.patch
               * @desc Updates a building. This method supports patch semantics.
@@ -2205,7 +2319,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2227,7 +2343,7 @@ function Admin(options) {
               pathParams: ['buildingId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.buildings.update
               * @desc Updates a building.
@@ -2242,7 +2358,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2264,7 +2382,7 @@ function Admin(options) {
               pathParams: ['buildingId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -2282,7 +2400,9 @@ function Admin(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2304,7 +2424,7 @@ function Admin(options) {
               pathParams: ['calendarResourceId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.calendars.get
               * @desc Retrieves a calendar resource.
@@ -2318,7 +2438,8 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2340,7 +2461,7 @@ function Admin(options) {
               pathParams: ['calendarResourceId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.calendars.insert
               * @desc Inserts a calendar resource.
@@ -2354,7 +2475,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          insert(params, options, callback) {
+          insert(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2376,7 +2499,7 @@ function Admin(options) {
               pathParams: ['customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.calendars.list
               * @desc Retrieves a list of calendar resources for an account.
@@ -2393,7 +2516,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2415,7 +2540,7 @@ function Admin(options) {
               pathParams: ['customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.calendars.patch
               * @desc Updates a calendar resource.  This method supports patch
@@ -2433,7 +2558,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2455,7 +2582,7 @@ function Admin(options) {
               pathParams: ['calendarResourceId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * directory.resources.calendars.update
               * @desc Updates a calendar resource.  This method supports patch
@@ -2473,7 +2600,9 @@ function Admin(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2495,7 +2624,7 @@ function Admin(options) {
               pathParams: ['calendarResourceId', 'customer'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -2514,7 +2643,9 @@ function Admin(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2537,7 +2668,7 @@ function Admin(options) {
                   pathParams: ['customer', 'featureKey'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * directory.resources.features.get
                   * @desc Retrieves a feature.
@@ -2551,7 +2682,8 @@ function Admin(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2574,7 +2706,7 @@ function Admin(options) {
                   pathParams: ['customer', 'featureKey'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * directory.resources.features.insert
                   * @desc Inserts a feature.
@@ -2588,7 +2720,9 @@ function Admin(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              insert(params, options, callback) {
+              insert(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2611,7 +2745,7 @@ function Admin(options) {
                   pathParams: ['customer'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * directory.resources.features.list
                   * @desc Retrieves a list of features for an account.
@@ -2625,7 +2759,9 @@ function Admin(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2648,7 +2784,7 @@ function Admin(options) {
                   pathParams: ['customer'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * directory.resources.features.patch
                   * @desc Updates a feature. This method supports patch
@@ -2664,7 +2800,9 @@ function Admin(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              patch(params, options, callback) {
+              patch(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2687,7 +2825,7 @@ function Admin(options) {
                   pathParams: ['customer', 'featureKey'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * directory.resources.features.rename
                   * @desc Renames a feature.
@@ -2702,7 +2840,9 @@ function Admin(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              rename(params, options, callback) {
+              rename(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2725,7 +2865,7 @@ function Admin(options) {
                   pathParams: ['customer', 'oldName'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * directory.resources.features.update
                   * @desc Updates a feature.
@@ -2740,7 +2880,9 @@ function Admin(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              update(params, options, callback) {
+              update(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2763,7 +2905,7 @@ function Admin(options) {
                   pathParams: ['customer', 'featureKey'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             }
@@ -2782,7 +2924,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2804,7 +2948,7 @@ function Admin(options) {
         pathParams: ['customer', 'roleAssignmentId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roleAssignments.get
         * @desc Retrieve a role assignment.
@@ -2818,7 +2962,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2840,7 +2985,7 @@ function Admin(options) {
         pathParams: ['customer', 'roleAssignmentId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roleAssignments.insert
         * @desc Creates a role assignment.
@@ -2854,7 +2999,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2875,7 +3022,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roleAssignments.list
         * @desc Retrieves a paginated list of all roleAssignments.
@@ -2892,7 +3039,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2913,7 +3062,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2931,7 +3080,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2952,7 +3103,7 @@ function Admin(options) {
         pathParams: ['customer', 'roleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roles.get
         * @desc Retrieves a role.
@@ -2966,7 +3117,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2987,7 +3139,7 @@ function Admin(options) {
         pathParams: ['customer', 'roleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roles.insert
         * @desc Creates a role.
@@ -3001,7 +3153,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3021,7 +3175,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roles.list
         * @desc Retrieves a paginated list of all the roles in a domain.
@@ -3036,7 +3190,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3056,7 +3212,7 @@ function Admin(options) {
         pathParams: ['customer'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roles.patch
         * @desc Updates a role. This method supports patch semantics.
@@ -3071,7 +3227,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3092,7 +3250,7 @@ function Admin(options) {
         pathParams: ['customer', 'roleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.roles.update
         * @desc Updates a role.
@@ -3107,7 +3265,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3128,7 +3288,7 @@ function Admin(options) {
         pathParams: ['customer', 'roleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3146,7 +3306,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3168,7 +3330,7 @@ function Admin(options) {
         pathParams: ['customerId', 'schemaKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.schemas.get
         * @desc Retrieve schema
@@ -3182,7 +3344,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3204,7 +3367,7 @@ function Admin(options) {
         pathParams: ['customerId', 'schemaKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.schemas.insert
         * @desc Create schema.
@@ -3218,7 +3381,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3239,7 +3404,7 @@ function Admin(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.schemas.list
         * @desc Retrieve all schemas for a customer
@@ -3252,7 +3417,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3273,7 +3440,7 @@ function Admin(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.schemas.patch
         * @desc Update schema. This method supports patch semantics.
@@ -3288,7 +3455,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3310,7 +3479,7 @@ function Admin(options) {
         pathParams: ['customerId', 'schemaKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.schemas.update
         * @desc Update schema
@@ -3325,7 +3494,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3347,7 +3518,7 @@ function Admin(options) {
         pathParams: ['customerId', 'schemaKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3365,7 +3536,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3386,7 +3559,7 @@ function Admin(options) {
         pathParams: ['clientId', 'userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.tokens.get
         * @desc Get information about an access token issued by a user.
@@ -3400,7 +3573,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3421,7 +3595,7 @@ function Admin(options) {
         pathParams: ['clientId', 'userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.tokens.list
         * @desc Returns the set of tokens specified user has issued to 3rd party
@@ -3435,7 +3609,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3455,7 +3631,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3472,7 +3648,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3492,7 +3670,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.get
         * @desc retrieve user
@@ -3508,7 +3686,8 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3528,7 +3707,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.insert
         * @desc create user.
@@ -3541,7 +3720,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3561,7 +3742,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.list
         * @desc Retrieve either deleted users or all users in a domain
@@ -3586,7 +3767,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3606,7 +3789,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.makeAdmin
         * @desc change admin status of a user
@@ -3620,7 +3803,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    makeAdmin(params, options, callback) {
+    makeAdmin(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3640,7 +3825,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.patch
         * @desc update user. This method supports patch semantics.
@@ -3654,7 +3839,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3674,7 +3861,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.undelete
         * @desc Undelete a deleted user
@@ -3688,7 +3875,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    undelete(params, options, callback) {
+    undelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3708,7 +3897,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.update
         * @desc update user
@@ -3722,7 +3911,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3742,7 +3933,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.users.watch
         * @desc Watch for changes in users list
@@ -3767,7 +3958,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3787,7 +3980,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     aliases: {
       /**
@@ -3803,7 +3996,9 @@ function Admin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3824,7 +4019,7 @@ function Admin(options) {
           pathParams: ['alias', 'userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.users.aliases.insert
           * @desc Add a alias for the user
@@ -3838,7 +4033,9 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      insert(params, options, callback) {
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3858,7 +4055,7 @@ function Admin(options) {
           pathParams: ['userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.users.aliases.list
           * @desc List all aliases for a user
@@ -3872,7 +4069,9 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3892,7 +4091,7 @@ function Admin(options) {
           pathParams: ['userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.users.aliases.watch
           * @desc Watch for changes in user aliases list
@@ -3907,7 +4106,9 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      watch(params, options, callback) {
+      watch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3928,7 +4129,7 @@ function Admin(options) {
           pathParams: ['userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -3945,7 +4146,9 @@ function Admin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3966,7 +4169,7 @@ function Admin(options) {
           pathParams: ['userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.users.photos.get
           * @desc Retrieve photo of a user
@@ -3979,7 +4182,8 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -4000,7 +4204,7 @@ function Admin(options) {
           pathParams: ['userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.users.photos.patch
           * @desc Add a photo for the user. This method supports patch
@@ -4015,7 +4219,9 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -4036,7 +4242,7 @@ function Admin(options) {
           pathParams: ['userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * directory.users.photos.update
           * @desc Add a photo for the user
@@ -4050,7 +4256,9 @@ function Admin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -4071,7 +4279,7 @@ function Admin(options) {
           pathParams: ['userKey'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -4089,7 +4297,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generate(params, options, callback) {
+    generate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4111,7 +4321,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.verificationCodes.invalidate
         * @desc Invalidate the current backup verification codes for the user.
@@ -4124,7 +4334,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    invalidate(params, options, callback) {
+    invalidate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4146,7 +4358,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * directory.verificationCodes.list
         * @desc Returns the current set of valid backup verification codes for
@@ -4160,7 +4372,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4181,7 +4395,7 @@ function Admin(options) {
         pathParams: ['userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/admin/reports_v1.ts
+++ b/src/apis/admin/reports_v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Admin Reports API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation reports_v1
  * @param {object=} options Options for Admin
  */
-function Admin(options) {
+function Admin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.activities = {
@@ -58,7 +65,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -80,7 +89,7 @@ function Admin(options) {
         pathParams: ['applicationName', 'userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * reports.activities.watch
         * @desc Push changes to activities
@@ -103,7 +112,9 @@ function Admin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -125,7 +136,7 @@ function Admin(options) {
         pathParams: ['applicationName', 'userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -142,7 +153,9 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -163,7 +176,7 @@ function Admin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -184,7 +197,8 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -204,7 +218,7 @@ function Admin(options) {
         pathParams: ['date'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -229,7 +243,8 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -251,7 +266,7 @@ function Admin(options) {
         pathParams: ['date', 'entityKey', 'entityType'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -275,7 +290,8 @@ function Admin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -296,7 +312,7 @@ function Admin(options) {
         pathParams: ['date', 'userKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adsense/v1.4.ts
+++ b/src/apis/adsense/v1.4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * AdSense Management API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.4
  * @param {object=} options Options for Adsense
  */
-function Adsense(options) {
+function Adsense(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -48,7 +55,8 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Adsense(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsense.accounts.list
         * @desc List all accounts available to this AdSense account.
@@ -82,7 +90,9 @@ function Adsense(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +112,7 @@ function Adsense(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     adclients: {
       /**
@@ -119,7 +129,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -139,7 +151,7 @@ function Adsense(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -159,7 +171,8 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -181,7 +194,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsense.accounts.adunits.getAdCode
           * @desc Get ad code for the specified ad unit.
@@ -196,7 +209,9 @@ function Adsense(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getAdCode(params, options, callback) {
+      getAdCode(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -218,7 +233,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsense.accounts.adunits.list
           * @desc List all ad units in the specified ad client for the specified
@@ -236,7 +251,9 @@ function Adsense(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -258,7 +275,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       customchannels: {
         /**
@@ -278,7 +295,9 @@ function Adsense(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -300,7 +319,7 @@ function Adsense(options) {
             pathParams: ['accountId', 'adClientId', 'adUnitId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -320,7 +339,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -341,7 +362,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'alertId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsense.accounts.alerts.list
           * @desc List the alerts for the specified AdSense account.
@@ -355,7 +376,9 @@ function Adsense(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -375,7 +398,7 @@ function Adsense(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -395,7 +418,8 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -417,7 +441,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'adClientId', 'customChannelId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsense.accounts.customchannels.list
           * @desc List all custom channels in the specified ad client for the
@@ -434,7 +458,9 @@ function Adsense(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -456,7 +482,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       adunits: {
         /**
@@ -476,7 +502,9 @@ function Adsense(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -498,7 +526,7 @@ function Adsense(options) {
             pathParams: ['accountId', 'adClientId', 'customChannelId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -516,7 +544,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -536,7 +566,7 @@ function Adsense(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -566,7 +596,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      generate(params, options, callback) {
+      generate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -586,7 +618,7 @@ function Adsense(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       saved: {
         /**
@@ -606,7 +638,9 @@ function Adsense(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        generate(params, options, callback) {
+        generate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -628,7 +662,7 @@ function Adsense(options) {
             pathParams: ['accountId', 'savedReportId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * adsense.accounts.reports.saved.list
             * @desc List all saved reports in the specified AdSense account.
@@ -643,7 +677,9 @@ function Adsense(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -664,7 +700,7 @@ function Adsense(options) {
             pathParams: ['accountId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -683,7 +719,8 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -705,7 +742,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'savedAdStyleId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsense.accounts.savedadstyles.list
           * @desc List all saved ad styles in the specified account.
@@ -720,7 +757,9 @@ function Adsense(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -741,7 +780,7 @@ function Adsense(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -762,7 +801,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -784,7 +825,7 @@ function Adsense(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -803,7 +844,9 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -823,7 +866,7 @@ function Adsense(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -841,7 +884,8 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -862,7 +906,7 @@ function Adsense(options) {
         pathParams: ['adClientId', 'adUnitId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsense.adunits.getAdCode
         * @desc Get ad code for the specified ad unit.
@@ -876,7 +920,9 @@ function Adsense(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getAdCode(params, options, callback) {
+    getAdCode(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -898,7 +944,7 @@ function Adsense(options) {
         pathParams: ['adClientId', 'adUnitId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsense.adunits.list
         * @desc List all ad units in the specified ad client for this AdSense
@@ -915,7 +961,9 @@ function Adsense(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -935,7 +983,7 @@ function Adsense(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     customchannels: {
       /**
@@ -953,7 +1001,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -975,7 +1025,7 @@ function Adsense(options) {
           pathParams: ['adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -994,7 +1044,9 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1014,7 +1066,7 @@ function Adsense(options) {
         pathParams: ['alertId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsense.alerts.list
         * @desc List the alerts for this AdSense account.
@@ -1027,7 +1079,9 @@ function Adsense(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1047,7 +1101,7 @@ function Adsense(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1065,7 +1119,8 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1087,7 +1142,7 @@ function Adsense(options) {
         pathParams: ['adClientId', 'customChannelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsense.customchannels.list
         * @desc List all custom channels in the specified ad client for this
@@ -1103,7 +1158,9 @@ function Adsense(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1124,7 +1181,7 @@ function Adsense(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     adunits: {
       /**
@@ -1143,7 +1200,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1165,7 +1224,7 @@ function Adsense(options) {
           pathParams: ['adClientId', 'customChannelId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1184,7 +1243,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1204,7 +1265,7 @@ function Adsense(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1221,7 +1282,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1241,7 +1304,7 @@ function Adsense(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1258,7 +1321,9 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1278,7 +1343,7 @@ function Adsense(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1308,7 +1373,9 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generate(params, options, callback) {
+    generate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1328,7 +1395,7 @@ function Adsense(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     saved: {
       /**
@@ -1347,7 +1414,9 @@ function Adsense(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      generate(params, options, callback) {
+      generate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1367,7 +1436,7 @@ function Adsense(options) {
           pathParams: ['savedReportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsense.reports.saved.list
           * @desc List all saved reports in this AdSense account.
@@ -1381,7 +1450,9 @@ function Adsense(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1401,7 +1472,7 @@ function Adsense(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1419,7 +1490,8 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1439,7 +1511,7 @@ function Adsense(options) {
         pathParams: ['savedAdStyleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsense.savedadstyles.list
         * @desc List all saved ad styles in the user's account.
@@ -1453,7 +1525,9 @@ function Adsense(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1473,7 +1547,7 @@ function Adsense(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1493,7 +1567,9 @@ function Adsense(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1514,7 +1590,7 @@ function Adsense(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/adsensehost/v4.1.ts
+++ b/src/apis/adsensehost/v4.1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * AdSense Host API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v4.1
  * @param {object=} options Options for Adsensehost
  */
-function Adsensehost(options) {
+function Adsensehost(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -48,7 +55,8 @@ function Adsensehost(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Adsensehost(options) {
         pathParams: ['accountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.accounts.list
         * @desc List hosted accounts associated with this AdSense account by ad
@@ -82,7 +90,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +112,7 @@ function Adsensehost(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     adclients: {
       /**
@@ -119,7 +129,8 @@ function Adsensehost(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -141,7 +152,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsensehost.accounts.adclients.list
           * @desc List all hosted ad clients in the specified hosted account.
@@ -156,7 +167,9 @@ function Adsensehost(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -177,7 +190,7 @@ function Adsensehost(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -197,7 +210,9 @@ function Adsensehost(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -219,7 +234,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsensehost.accounts.adunits.get
           * @desc Get the specified host ad unit in this AdSense account.
@@ -234,7 +249,8 @@ function Adsensehost(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -256,7 +272,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsensehost.accounts.adunits.getAdCode
           * @desc Get ad code for the specified ad unit, attaching the specified
@@ -273,7 +289,9 @@ function Adsensehost(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getAdCode(params, options, callback) {
+      getAdCode(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -295,7 +313,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId', 'adUnitId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsensehost.accounts.adunits.insert
           * @desc Insert the supplied ad unit into the specified publisher
@@ -311,7 +329,9 @@ function Adsensehost(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      insert(params, options, callback) {
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -333,7 +353,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsensehost.accounts.adunits.list
           * @desc List all ad units in the specified publisher's AdSense
@@ -351,7 +371,9 @@ function Adsensehost(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -373,7 +395,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsensehost.accounts.adunits.patch
           * @desc Update the supplied ad unit in the specified publisher AdSense
@@ -390,7 +412,9 @@ function Adsensehost(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -412,7 +436,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * adsensehost.accounts.adunits.update
           * @desc Update the supplied ad unit in the specified publisher AdSense
@@ -428,7 +452,9 @@ function Adsensehost(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -450,7 +476,7 @@ function Adsensehost(options) {
           pathParams: ['accountId', 'adClientId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -478,7 +504,9 @@ function Adsensehost(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      generate(params, options, callback) {
+      generate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -499,7 +527,7 @@ function Adsensehost(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -518,7 +546,8 @@ function Adsensehost(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -538,7 +567,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.adclients.list
         * @desc List all host ad clients in this AdSense account.
@@ -552,7 +581,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -572,7 +603,7 @@ function Adsensehost(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -593,7 +624,9 @@ function Adsensehost(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    start(params, options, callback) {
+    start(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -613,7 +646,7 @@ function Adsensehost(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.associationsessions.verify
         * @desc Verify an association session after the association callback
@@ -627,7 +660,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    verify(params, options, callback) {
+    verify(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -647,7 +682,7 @@ function Adsensehost(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -665,7 +700,9 @@ function Adsensehost(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -687,7 +724,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId', 'customChannelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.customchannels.get
         * @desc Get a specific custom channel from the host AdSense account.
@@ -701,7 +738,8 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -723,7 +761,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId', 'customChannelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.customchannels.insert
         * @desc Add a new custom channel to the host AdSense account.
@@ -737,7 +775,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -758,7 +798,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.customchannels.list
         * @desc List all host custom channels in this AdSense account.
@@ -773,7 +813,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -794,7 +836,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.customchannels.patch
         * @desc Update a custom channel in the host AdSense account. This method
@@ -810,7 +852,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -831,7 +875,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.customchannels.update
         * @desc Update a custom channel in the host AdSense account.
@@ -845,7 +889,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -866,7 +912,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -893,7 +939,9 @@ function Adsensehost(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generate(params, options, callback) {
+    generate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -913,7 +961,7 @@ function Adsensehost(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -931,7 +979,9 @@ function Adsensehost(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -953,7 +1003,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId', 'urlChannelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.urlchannels.insert
         * @desc Add a new URL channel to the host AdSense account.
@@ -967,7 +1017,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -988,7 +1040,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * adsensehost.urlchannels.list
         * @desc List all host URL channels in the host AdSense account.
@@ -1003,7 +1055,9 @@ function Adsensehost(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1024,7 +1078,7 @@ function Adsensehost(options) {
         pathParams: ['adClientId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/analytics/v2.4.ts
+++ b/src/apis/analytics/v2.4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Analytics API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2.4
  * @param {object=} options Options for Analytics
  */
-function Analytics(options) {
+function Analytics(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.data = {
@@ -56,7 +63,8 @@ function Analytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -76,7 +84,7 @@ function Analytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -95,7 +103,9 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -115,7 +125,7 @@ function Analytics(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -136,7 +146,9 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -158,7 +170,7 @@ function Analytics(options) {
           pathParams: ['accountId', 'profileId', 'webPropertyId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -178,7 +190,9 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -200,7 +214,7 @@ function Analytics(options) {
           pathParams: ['accountId', 'webPropertyId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -218,7 +232,9 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -238,7 +254,7 @@ function Analytics(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -257,7 +273,9 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -279,7 +297,7 @@ function Analytics(options) {
           pathParams: ['accountId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/analytics/v3.ts
+++ b/src/apis/analytics/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Analytics API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Analytics
  */
-function Analytics(options) {
+function Analytics(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.data = {
@@ -60,7 +67,8 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -80,7 +88,7 @@ function Analytics(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -107,7 +115,8 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -127,7 +136,7 @@ function Analytics(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -149,7 +158,8 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -169,2289 +179,2342 @@ function Analytics(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
   };
-  self.management =
-      {
-        accounts: {
-          /**
-           * analytics.management.accounts.list
-           * @desc Lists all accounts to which the user has access.
-           * @alias analytics.management.accounts.list
-           * @memberOf! analytics(v3)
-           *
-           * @param {object=} params Parameters for request
-           * @param {integer=} params.max-results The maximum number of accounts to include in this response.
-           * @param {integer=} params.start-index An index of the first account to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url: (rootUrl + '/analytics/v3/management/accounts')
-                             .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: [],
-              pathParams: [],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+  self.management = {
+    accounts: {
+      /**
+       * analytics.management.accounts.list
+       * @desc Lists all accounts to which the user has access.
+       * @alias analytics.management.accounts.list
+       * @memberOf! analytics(v3)
+       *
+       * @param {object=} params Parameters for request
+       * @param {integer=} params.max-results The maximum number of accounts to include in this response.
+       * @param {integer=} params.start-index An index of the first account to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/analytics/v3/management/accounts')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        accountSummaries: {
-          /**
-           * analytics.management.accountSummaries.list
-           * @desc Lists account summaries (lightweight tree comprised of
-           * accounts/properties/profiles) to which the user has access.
-           * @alias analytics.management.accountSummaries.list
-           * @memberOf! analytics(v3)
-           *
-           * @param {object=} params Parameters for request
-           * @param {integer=} params.max-results The maximum number of account summaries to include in this response, where the largest acceptable value is 1000.
-           * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url: (rootUrl + '/analytics/v3/management/accountSummaries')
-                             .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: [],
-              pathParams: [],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    accountSummaries: {
+      /**
+       * analytics.management.accountSummaries.list
+       * @desc Lists account summaries (lightweight tree comprised of
+       * accounts/properties/profiles) to which the user has access.
+       * @alias analytics.management.accountSummaries.list
+       * @memberOf! analytics(v3)
+       *
+       * @param {object=} params Parameters for request
+       * @param {integer=} params.max-results The maximum number of account summaries to include in this response, where the largest acceptable value is 1000.
+       * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/analytics/v3/management/accountSummaries')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        accountUserLinks: {
-          /**
-           * analytics.management.accountUserLinks.delete
-           * @desc Removes a user from the given account.
-           * @alias analytics.management.accountUserLinks.delete
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID to delete the user link for.
-           * @param {string} params.linkId Link ID to delete the user link for.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          delete (params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/entityUserLinks/{linkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'DELETE'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'linkId'],
-              pathParams: ['accountId', 'linkId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.accountUserLinks.insert
-              * @desc Adds a new user to the given account.
-              * @alias analytics.management.accountUserLinks.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to create the user link for.
-              * @param {analytics(v3).EntityUserLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/entityUserLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.accountUserLinks.list
-              * @desc Lists account-user links for a given account.
-              * @alias analytics.management.accountUserLinks.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to retrieve the user links for.
-              * @param {integer=} params.max-results The maximum number of account-user links to include in this response.
-              * @param {integer=} params.start-index An index of the first account-user link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/entityUserLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.accountUserLinks.update
-              * @desc Updates permissions for an existing user on the given
-              * account.
-              * @alias analytics.management.accountUserLinks.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to update the account-user link for.
-              * @param {string} params.linkId Link ID to update the account-user link for.
-              * @param {analytics(v3).EntityUserLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/entityUserLinks/{linkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'linkId'],
-              pathParams: ['accountId', 'linkId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    accountUserLinks: {
+      /**
+       * analytics.management.accountUserLinks.delete
+       * @desc Removes a user from the given account.
+       * @alias analytics.management.accountUserLinks.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to delete the user link for.
+       * @param {string} params.linkId Link ID to delete the user link for.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/entityUserLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'linkId'],
+          pathParams: ['accountId', 'linkId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.accountUserLinks.insert
+          * @desc Adds a new user to the given account.
+          * @alias analytics.management.accountUserLinks.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create the user link for.
+          * @param {analytics(v3).EntityUserLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/entityUserLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.accountUserLinks.list
+          * @desc Lists account-user links for a given account.
+          * @alias analytics.management.accountUserLinks.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve the user links for.
+          * @param {integer=} params.max-results The maximum number of account-user links to include in this response.
+          * @param {integer=} params.start-index An index of the first account-user link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/entityUserLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.accountUserLinks.update
+          * @desc Updates permissions for an existing user on the given account.
+          * @alias analytics.management.accountUserLinks.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to update the account-user link for.
+          * @param {string} params.linkId Link ID to update the account-user link for.
+          * @param {analytics(v3).EntityUserLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/entityUserLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'linkId'],
+          pathParams: ['accountId', 'linkId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        customDataSources: {
-          /**
-           * analytics.management.customDataSources.list
-           * @desc List custom data sources to which the user has access.
-           * @alias analytics.management.customDataSources.list
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account Id for the custom data sources to retrieve.
-           * @param {integer=} params.max-results The maximum number of custom data sources to include in this response.
-           * @param {integer=} params.start-index A 1-based index of the first custom data source to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-           * @param {string} params.webPropertyId Web property Id for the custom data sources to retrieve.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    customDataSources: {
+      /**
+       * analytics.management.customDataSources.list
+       * @desc List custom data sources to which the user has access.
+       * @alias analytics.management.customDataSources.list
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account Id for the custom data sources to retrieve.
+       * @param {integer=} params.max-results The maximum number of custom data sources to include in this response.
+       * @param {integer=} params.start-index A 1-based index of the first custom data source to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+       * @param {string} params.webPropertyId Web property Id for the custom data sources to retrieve.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        customDimensions: {
-          /**
-           * analytics.management.customDimensions.get
-           * @desc Get a custom dimension to which the user has access.
-           * @alias analytics.management.customDimensions.get
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID for the custom dimension to retrieve.
-           * @param {string} params.customDimensionId The ID of the custom dimension to retrieve.
-           * @param {string} params.webPropertyId Web property ID for the custom dimension to retrieve.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'customDimensionId'],
-              pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customDimensions.insert
-              * @desc Create a new custom dimension.
-              * @alias analytics.management.customDimensions.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom dimension to create.
-              * @param {string} params.webPropertyId Web property ID for the custom dimension to create.
-              * @param {analytics(v3).CustomDimension} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customDimensions.list
-              * @desc Lists custom dimensions to which the user has access.
-              * @alias analytics.management.customDimensions.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom dimensions to retrieve.
-              * @param {integer=} params.max-results The maximum number of custom dimensions to include in this response.
-              * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web property ID for the custom dimensions to retrieve.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customDimensions.patch
-              * @desc Updates an existing custom dimension. This method supports
-              * patch semantics.
-              * @alias analytics.management.customDimensions.patch
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom dimension to update.
-              * @param {string} params.customDimensionId Custom dimension ID for the custom dimension to update.
-              * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom dimension being linked to a custom data source / data set.
-              * @param {string} params.webPropertyId Web property ID for the custom dimension to update.
-              * @param {analytics(v3).CustomDimension} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          patch(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PATCH'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'customDimensionId'],
-              pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customDimensions.update
-              * @desc Updates an existing custom dimension.
-              * @alias analytics.management.customDimensions.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom dimension to update.
-              * @param {string} params.customDimensionId Custom dimension ID for the custom dimension to update.
-              * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom dimension being linked to a custom data source / data set.
-              * @param {string} params.webPropertyId Web property ID for the custom dimension to update.
-              * @param {analytics(v3).CustomDimension} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'customDimensionId'],
-              pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    customDimensions: {
+      /**
+       * analytics.management.customDimensions.get
+       * @desc Get a custom dimension to which the user has access.
+       * @alias analytics.management.customDimensions.get
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID for the custom dimension to retrieve.
+       * @param {string} params.customDimensionId The ID of the custom dimension to retrieve.
+       * @param {string} params.webPropertyId Web property ID for the custom dimension to retrieve.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
+          pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customDimensions.insert
+          * @desc Create a new custom dimension.
+          * @alias analytics.management.customDimensions.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom dimension to create.
+          * @param {string} params.webPropertyId Web property ID for the custom dimension to create.
+          * @param {analytics(v3).CustomDimension} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customDimensions.list
+          * @desc Lists custom dimensions to which the user has access.
+          * @alias analytics.management.customDimensions.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom dimensions to retrieve.
+          * @param {integer=} params.max-results The maximum number of custom dimensions to include in this response.
+          * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property ID for the custom dimensions to retrieve.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customDimensions.patch
+          * @desc Updates an existing custom dimension. This method supports
+          * patch semantics.
+          * @alias analytics.management.customDimensions.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom dimension to update.
+          * @param {string} params.customDimensionId Custom dimension ID for the custom dimension to update.
+          * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom dimension being linked to a custom data source / data set.
+          * @param {string} params.webPropertyId Web property ID for the custom dimension to update.
+          * @param {analytics(v3).CustomDimension} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
+          pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customDimensions.update
+          * @desc Updates an existing custom dimension.
+          * @alias analytics.management.customDimensions.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom dimension to update.
+          * @param {string} params.customDimensionId Custom dimension ID for the custom dimension to update.
+          * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom dimension being linked to a custom data source / data set.
+          * @param {string} params.webPropertyId Web property ID for the custom dimension to update.
+          * @param {analytics(v3).CustomDimension} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDimensions/{customDimensionId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
+          pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        customMetrics: {
-          /**
-           * analytics.management.customMetrics.get
-           * @desc Get a custom metric to which the user has access.
-           * @alias analytics.management.customMetrics.get
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID for the custom metric to retrieve.
-           * @param {string} params.customMetricId The ID of the custom metric to retrieve.
-           * @param {string} params.webPropertyId Web property ID for the custom metric to retrieve.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
-              pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customMetrics.insert
-              * @desc Create a new custom metric.
-              * @alias analytics.management.customMetrics.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom metric to create.
-              * @param {string} params.webPropertyId Web property ID for the custom dimension to create.
-              * @param {analytics(v3).CustomMetric} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customMetrics.list
-              * @desc Lists custom metrics to which the user has access.
-              * @alias analytics.management.customMetrics.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom metrics to retrieve.
-              * @param {integer=} params.max-results The maximum number of custom metrics to include in this response.
-              * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web property ID for the custom metrics to retrieve.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customMetrics.patch
-              * @desc Updates an existing custom metric. This method supports
-              * patch semantics.
-              * @alias analytics.management.customMetrics.patch
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom metric to update.
-              * @param {string} params.customMetricId Custom metric ID for the custom metric to update.
-              * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom metric being linked to a custom data source / data set.
-              * @param {string} params.webPropertyId Web property ID for the custom metric to update.
-              * @param {analytics(v3).CustomMetric} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          patch(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PATCH'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
-              pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.customMetrics.update
-              * @desc Updates an existing custom metric.
-              * @alias analytics.management.customMetrics.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the custom metric to update.
-              * @param {string} params.customMetricId Custom metric ID for the custom metric to update.
-              * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom metric being linked to a custom data source / data set.
-              * @param {string} params.webPropertyId Web property ID for the custom metric to update.
-              * @param {analytics(v3).CustomMetric} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
-              pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    customMetrics: {
+      /**
+       * analytics.management.customMetrics.get
+       * @desc Get a custom metric to which the user has access.
+       * @alias analytics.management.customMetrics.get
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID for the custom metric to retrieve.
+       * @param {string} params.customMetricId The ID of the custom metric to retrieve.
+       * @param {string} params.webPropertyId Web property ID for the custom metric to retrieve.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
+          pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customMetrics.insert
+          * @desc Create a new custom metric.
+          * @alias analytics.management.customMetrics.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom metric to create.
+          * @param {string} params.webPropertyId Web property ID for the custom dimension to create.
+          * @param {analytics(v3).CustomMetric} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customMetrics.list
+          * @desc Lists custom metrics to which the user has access.
+          * @alias analytics.management.customMetrics.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom metrics to retrieve.
+          * @param {integer=} params.max-results The maximum number of custom metrics to include in this response.
+          * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property ID for the custom metrics to retrieve.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customMetrics.patch
+          * @desc Updates an existing custom metric. This method supports patch
+          * semantics.
+          * @alias analytics.management.customMetrics.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom metric to update.
+          * @param {string} params.customMetricId Custom metric ID for the custom metric to update.
+          * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom metric being linked to a custom data source / data set.
+          * @param {string} params.webPropertyId Web property ID for the custom metric to update.
+          * @param {analytics(v3).CustomMetric} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
+          pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.customMetrics.update
+          * @desc Updates an existing custom metric.
+          * @alias analytics.management.customMetrics.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the custom metric to update.
+          * @param {string} params.customMetricId Custom metric ID for the custom metric to update.
+          * @param {boolean=} params.ignoreCustomDataSourceLinks Force the update and ignore any warnings related to the custom metric being linked to a custom data source / data set.
+          * @param {string} params.webPropertyId Web property ID for the custom metric to update.
+          * @param {analytics(v3).CustomMetric} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customMetrics/{customMetricId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
+          pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        experiments:
-            {
-              /**
-               * analytics.management.experiments.delete
-               * @desc Delete an experiment.
-               * @alias analytics.management.experiments.delete
-               * @memberOf! analytics(v3)
-               *
-               * @param {object} params Parameters for request
-               * @param {string} params.accountId Account ID to which the experiment belongs
-               * @param {string} params.experimentId ID of the experiment to delete
-               * @param {string} params.profileId View (Profile) ID to which the experiment belongs
-               * @param {string} params.webPropertyId Web property ID to which the experiment belongs
-               * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-               * @param {callback} callback The callback that handles the response.
-               * @return {object} Request object
-               */
-              delete (params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'DELETE'
-                      },
-                      options),
-                  params,
-                  requiredParams: [
-                    'accountId', 'webPropertyId', 'profileId', 'experimentId'
-                  ],
-                  pathParams: [
-                    'accountId', 'experimentId', 'profileId', 'webPropertyId'
-                  ],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.experiments.get
-                  * @desc Returns an experiment to which the user has access.
-                  * @alias analytics.management.experiments.get
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to retrieve the experiment for.
-                  * @param {string} params.experimentId Experiment ID to retrieve the experiment for.
-                  * @param {string} params.profileId View (Profile) ID to retrieve the experiment for.
-                  * @param {string} params.webPropertyId Web property ID to retrieve the experiment for.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              get(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'GET'
-                      },
-                      options),
-                  params,
-                  requiredParams: [
-                    'accountId', 'webPropertyId', 'profileId', 'experimentId'
-                  ],
-                  pathParams: [
-                    'accountId', 'experimentId', 'profileId', 'webPropertyId'
-                  ],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.experiments.insert
-                  * @desc Create a new experiment.
-                  * @alias analytics.management.experiments.insert
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to create the experiment for.
-                  * @param {string} params.profileId View (Profile) ID to create the experiment for.
-                  * @param {string} params.webPropertyId Web property ID to create the experiment for.
-                  * @param {analytics(v3).Experiment} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              insert(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'POST'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-                  pathParams: ['accountId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.experiments.list
-                  * @desc Lists experiments to which the user has access.
-                  * @alias analytics.management.experiments.list
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to retrieve experiments for.
-                  * @param {integer=} params.max-results The maximum number of experiments to include in this response.
-                  * @param {string} params.profileId View (Profile) ID to retrieve experiments for.
-                  * @param {integer=} params.start-index An index of the first experiment to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-                  * @param {string} params.webPropertyId Web property ID to retrieve experiments for.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              list(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'GET'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-                  pathParams: ['accountId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.experiments.patch
-                  * @desc Update an existing experiment. This method supports
-                  * patch semantics.
-                  * @alias analytics.management.experiments.patch
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID of the experiment to update.
-                  * @param {string} params.experimentId Experiment ID of the experiment to update.
-                  * @param {string} params.profileId View (Profile) ID of the experiment to update.
-                  * @param {string} params.webPropertyId Web property ID of the experiment to update.
-                  * @param {analytics(v3).Experiment} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              patch(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'PATCH'
-                      },
-                      options),
-                  params,
-                  requiredParams: [
-                    'accountId', 'webPropertyId', 'profileId', 'experimentId'
-                  ],
-                  pathParams: [
-                    'accountId', 'experimentId', 'profileId', 'webPropertyId'
-                  ],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.experiments.update
-                  * @desc Update an existing experiment.
-                  * @alias analytics.management.experiments.update
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID of the experiment to update.
-                  * @param {string} params.experimentId Experiment ID of the experiment to update.
-                  * @param {string} params.profileId View (Profile) ID of the experiment to update.
-                  * @param {string} params.webPropertyId Web property ID of the experiment to update.
-                  * @param {analytics(v3).Experiment} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              update(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'PUT'
-                      },
-                      options),
-                  params,
-                  requiredParams: [
-                    'accountId', 'webPropertyId', 'profileId', 'experimentId'
-                  ],
-                  pathParams: [
-                    'accountId', 'experimentId', 'profileId', 'webPropertyId'
-                  ],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }
+    },
+    experiments: {
+      /**
+       * analytics.management.experiments.delete
+       * @desc Delete an experiment.
+       * @alias analytics.management.experiments.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to which the experiment belongs
+       * @param {string} params.experimentId ID of the experiment to delete
+       * @param {string} params.profileId View (Profile) ID to which the experiment belongs
+       * @param {string} params.webPropertyId Web property ID to which the experiment belongs
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
+          pathParams:
+              ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.experiments.get
+          * @desc Returns an experiment to which the user has access.
+          * @alias analytics.management.experiments.get
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve the experiment for.
+          * @param {string} params.experimentId Experiment ID to retrieve the experiment for.
+          * @param {string} params.profileId View (Profile) ID to retrieve the experiment for.
+          * @param {string} params.webPropertyId Web property ID to retrieve the experiment for.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
+          pathParams:
+              ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.experiments.insert
+          * @desc Create a new experiment.
+          * @alias analytics.management.experiments.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create the experiment for.
+          * @param {string} params.profileId View (Profile) ID to create the experiment for.
+          * @param {string} params.webPropertyId Web property ID to create the experiment for.
+          * @param {analytics(v3).Experiment} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.experiments.list
+          * @desc Lists experiments to which the user has access.
+          * @alias analytics.management.experiments.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve experiments for.
+          * @param {integer=} params.max-results The maximum number of experiments to include in this response.
+          * @param {string} params.profileId View (Profile) ID to retrieve experiments for.
+          * @param {integer=} params.start-index An index of the first experiment to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property ID to retrieve experiments for.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any,
+          options:
+              MethodOptions|BodyResponseCallback<any>, callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.experiments.patch
+          * @desc Update an existing experiment. This method supports patch
+          * semantics.
+          * @alias analytics.management.experiments.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID of the experiment to update.
+          * @param {string} params.experimentId Experiment ID of the experiment to update.
+          * @param {string} params.profileId View (Profile) ID of the experiment to update.
+          * @param {string} params.webPropertyId Web property ID of the experiment to update.
+          * @param {analytics(v3).Experiment} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
+          pathParams:
+              ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.experiments.update
+          * @desc Update an existing experiment.
+          * @alias analytics.management.experiments.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID of the experiment to update.
+          * @param {string} params.experimentId Experiment ID of the experiment to update.
+          * @param {string} params.profileId View (Profile) ID of the experiment to update.
+          * @param {string} params.webPropertyId Web property ID of the experiment to update.
+          * @param {analytics(v3).Experiment} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/experiments/{experimentId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
+          pathParams:
+              ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-            },
-        filters: {
-          /**
-           * analytics.management.filters.delete
-           * @desc Delete a filter.
-           * @alias analytics.management.filters.delete
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID to delete the filter for.
-           * @param {string} params.filterId ID of the filter to be deleted.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          delete (params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'DELETE'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'filterId'],
-              pathParams: ['accountId', 'filterId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.filters.get
-              * @desc Returns a filters to which the user has access.
-              * @alias analytics.management.filters.get
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to retrieve filters for.
-              * @param {string} params.filterId Filter ID to retrieve filters for.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'filterId'],
-              pathParams: ['accountId', 'filterId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.filters.insert
-              * @desc Create a new filter.
-              * @alias analytics.management.filters.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to create filter for.
-              * @param {analytics(v3).Filter} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/filters')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.filters.list
-              * @desc Lists all filters for an account
-              * @alias analytics.management.filters.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to retrieve filters for.
-              * @param {integer=} params.max-results The maximum number of filters to include in this response.
-              * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/filters')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.filters.patch
-              * @desc Updates an existing filter. This method supports patch
-              * semantics.
-              * @alias analytics.management.filters.patch
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to which the filter belongs.
-              * @param {string} params.filterId ID of the filter to be updated.
-              * @param {analytics(v3).Filter} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          patch(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PATCH'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'filterId'],
-              pathParams: ['accountId', 'filterId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.filters.update
-              * @desc Updates an existing filter.
-              * @alias analytics.management.filters.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to which the filter belongs.
-              * @param {string} params.filterId ID of the filter to be updated.
-              * @param {analytics(v3).Filter} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'filterId'],
-              pathParams: ['accountId', 'filterId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    filters: {
+      /**
+       * analytics.management.filters.delete
+       * @desc Delete a filter.
+       * @alias analytics.management.filters.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to delete the filter for.
+       * @param {string} params.filterId ID of the filter to be deleted.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'filterId'],
+          pathParams: ['accountId', 'filterId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.filters.get
+          * @desc Returns a filters to which the user has access.
+          * @alias analytics.management.filters.get
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve filters for.
+          * @param {string} params.filterId Filter ID to retrieve filters for.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'filterId'],
+          pathParams: ['accountId', 'filterId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.filters.insert
+          * @desc Create a new filter.
+          * @alias analytics.management.filters.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create filter for.
+          * @param {analytics(v3).Filter} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl +
+                      '/analytics/v3/management/accounts/{accountId}/filters')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.filters.list
+          * @desc Lists all filters for an account
+          * @alias analytics.management.filters.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve filters for.
+          * @param {integer=} params.max-results The maximum number of filters to include in this response.
+          * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl +
+                      '/analytics/v3/management/accounts/{accountId}/filters')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.filters.patch
+          * @desc Updates an existing filter. This method supports patch
+          * semantics.
+          * @alias analytics.management.filters.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which the filter belongs.
+          * @param {string} params.filterId ID of the filter to be updated.
+          * @param {analytics(v3).Filter} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'filterId'],
+          pathParams: ['accountId', 'filterId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.filters.update
+          * @desc Updates an existing filter.
+          * @alias analytics.management.filters.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which the filter belongs.
+          * @param {string} params.filterId ID of the filter to be updated.
+          * @param {analytics(v3).Filter} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/filters/{filterId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'filterId'],
+          pathParams: ['accountId', 'filterId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        goals: {
-          /**
-           * analytics.management.goals.get
-           * @desc Gets a goal to which the user has access.
-           * @alias analytics.management.goals.get
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID to retrieve the goal for.
-           * @param {string} params.goalId Goal ID to retrieve the goal for.
-           * @param {string} params.profileId View (Profile) ID to retrieve the goal for.
-           * @param {string} params.webPropertyId Web property ID to retrieve the goal for.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'profileId', 'goalId'],
-              pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.goals.insert
-              * @desc Create a new goal.
-              * @alias analytics.management.goals.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to create the goal for.
-              * @param {string} params.profileId View (Profile) ID to create the goal for.
-              * @param {string} params.webPropertyId Web property ID to create the goal for.
-              * @param {analytics(v3).Goal} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.goals.list
-              * @desc Lists goals to which the user has access.
-              * @alias analytics.management.goals.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to retrieve goals for. Can either be a specific account ID or '~all', which refers to all the accounts that user has access to.
-              * @param {integer=} params.max-results The maximum number of goals to include in this response.
-              * @param {string} params.profileId View (Profile) ID to retrieve goals for. Can either be a specific view (profile) ID or '~all', which refers to all the views (profiles) that user has access to.
-              * @param {integer=} params.start-index An index of the first goal to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web property ID to retrieve goals for. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.goals.patch
-              * @desc Updates an existing goal. This method supports patch
-              * semantics.
-              * @alias analytics.management.goals.patch
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to update the goal.
-              * @param {string} params.goalId Index of the goal to be updated.
-              * @param {string} params.profileId View (Profile) ID to update the goal.
-              * @param {string} params.webPropertyId Web property ID to update the goal.
-              * @param {analytics(v3).Goal} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          patch(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PATCH'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'profileId', 'goalId'],
-              pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.goals.update
-              * @desc Updates an existing goal.
-              * @alias analytics.management.goals.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to update the goal.
-              * @param {string} params.goalId Index of the goal to be updated.
-              * @param {string} params.profileId View (Profile) ID to update the goal.
-              * @param {string} params.webPropertyId Web property ID to update the goal.
-              * @param {analytics(v3).Goal} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'profileId', 'goalId'],
-              pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    goals: {
+      /**
+       * analytics.management.goals.get
+       * @desc Gets a goal to which the user has access.
+       * @alias analytics.management.goals.get
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to retrieve the goal for.
+       * @param {string} params.goalId Goal ID to retrieve the goal for.
+       * @param {string} params.profileId View (Profile) ID to retrieve the goal for.
+       * @param {string} params.webPropertyId Web property ID to retrieve the goal for.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
+          pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.goals.insert
+          * @desc Create a new goal.
+          * @alias analytics.management.goals.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create the goal for.
+          * @param {string} params.profileId View (Profile) ID to create the goal for.
+          * @param {string} params.webPropertyId Web property ID to create the goal for.
+          * @param {analytics(v3).Goal} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.goals.list
+          * @desc Lists goals to which the user has access.
+          * @alias analytics.management.goals.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve goals for. Can either be a specific account ID or '~all', which refers to all the accounts that user has access to.
+          * @param {integer=} params.max-results The maximum number of goals to include in this response.
+          * @param {string} params.profileId View (Profile) ID to retrieve goals for. Can either be a specific view (profile) ID or '~all', which refers to all the views (profiles) that user has access to.
+          * @param {integer=} params.start-index An index of the first goal to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property ID to retrieve goals for. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.goals.patch
+          * @desc Updates an existing goal. This method supports patch
+          * semantics.
+          * @alias analytics.management.goals.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to update the goal.
+          * @param {string} params.goalId Index of the goal to be updated.
+          * @param {string} params.profileId View (Profile) ID to update the goal.
+          * @param {string} params.webPropertyId Web property ID to update the goal.
+          * @param {analytics(v3).Goal} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
+          pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.goals.update
+          * @desc Updates an existing goal.
+          * @alias analytics.management.goals.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to update the goal.
+          * @param {string} params.goalId Index of the goal to be updated.
+          * @param {string} params.profileId View (Profile) ID to update the goal.
+          * @param {string} params.webPropertyId Web property ID to update the goal.
+          * @param {analytics(v3).Goal} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/goals/{goalId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
+          pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        profileFilterLinks:
-            {
-              /**
-               * analytics.management.profileFilterLinks.delete
-               * @desc Delete a profile filter link.
-               * @alias analytics.management.profileFilterLinks.delete
-               * @memberOf! analytics(v3)
-               *
-               * @param {object} params Parameters for request
-               * @param {string} params.accountId Account ID to which the profile filter link belongs.
-               * @param {string} params.linkId ID of the profile filter link to delete.
-               * @param {string} params.profileId Profile ID to which the filter link belongs.
-               * @param {string} params.webPropertyId Web property Id to which the profile filter link belongs.
-               * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-               * @param {callback} callback The callback that handles the response.
-               * @return {object} Request object
-               */
-              delete (params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'DELETE'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'profileId', 'linkId'],
-                  pathParams:
-                      ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.profileFilterLinks.get
-                  * @desc Returns a single profile filter link.
-                  * @alias analytics.management.profileFilterLinks.get
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to retrieve profile filter link for.
-                  * @param {string} params.linkId ID of the profile filter link.
-                  * @param {string} params.profileId Profile ID to retrieve filter link for.
-                  * @param {string} params.webPropertyId Web property Id to retrieve profile filter link for.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              get(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'GET'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'profileId', 'linkId'],
-                  pathParams:
-                      ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.profileFilterLinks.insert
-                  * @desc Create a new profile filter link.
-                  * @alias analytics.management.profileFilterLinks.insert
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to create profile filter link for.
-                  * @param {string} params.profileId Profile ID to create filter link for.
-                  * @param {string} params.webPropertyId Web property Id to create profile filter link for.
-                  * @param {analytics(v3).ProfileFilterLink} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              insert(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'POST'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-                  pathParams: ['accountId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.profileFilterLinks.list
-                  * @desc Lists all profile filter links for a profile.
-                  * @alias analytics.management.profileFilterLinks.list
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to retrieve profile filter links for.
-                  * @param {integer=} params.max-results The maximum number of profile filter links to include in this response.
-                  * @param {string} params.profileId Profile ID to retrieve filter links for. Can either be a specific profile ID or '~all', which refers to all the profiles that user has access to.
-                  * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-                  * @param {string} params.webPropertyId Web property Id for profile filter links for. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              list(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'GET'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-                  pathParams: ['accountId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.profileFilterLinks.patch
-                  * @desc Update an existing profile filter link. This method
-                  * supports patch semantics.
-                  * @alias analytics.management.profileFilterLinks.patch
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to which profile filter link belongs.
-                  * @param {string} params.linkId ID of the profile filter link to be updated.
-                  * @param {string} params.profileId Profile ID to which filter link belongs
-                  * @param {string} params.webPropertyId Web property Id to which profile filter link belongs
-                  * @param {analytics(v3).ProfileFilterLink} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              patch(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'PATCH'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'profileId', 'linkId'],
-                  pathParams:
-                      ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.profileFilterLinks.update
-                  * @desc Update an existing profile filter link.
-                  * @alias analytics.management.profileFilterLinks.update
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId Account ID to which profile filter link belongs.
-                  * @param {string} params.linkId ID of the profile filter link to be updated.
-                  * @param {string} params.profileId Profile ID to which filter link belongs
-                  * @param {string} params.webPropertyId Web property Id to which profile filter link belongs
-                  * @param {analytics(v3).ProfileFilterLink} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              update(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'PUT'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'profileId', 'linkId'],
-                  pathParams:
-                      ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }
+    },
+    profileFilterLinks: {
+      /**
+       * analytics.management.profileFilterLinks.delete
+       * @desc Delete a profile filter link.
+       * @alias analytics.management.profileFilterLinks.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to which the profile filter link belongs.
+       * @param {string} params.linkId ID of the profile filter link to delete.
+       * @param {string} params.profileId Profile ID to which the filter link belongs.
+       * @param {string} params.webPropertyId Web property Id to which the profile filter link belongs.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileFilterLinks.get
+          * @desc Returns a single profile filter link.
+          * @alias analytics.management.profileFilterLinks.get
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve profile filter link for.
+          * @param {string} params.linkId ID of the profile filter link.
+          * @param {string} params.profileId Profile ID to retrieve filter link for.
+          * @param {string} params.webPropertyId Web property Id to retrieve profile filter link for.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileFilterLinks.insert
+          * @desc Create a new profile filter link.
+          * @alias analytics.management.profileFilterLinks.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create profile filter link for.
+          * @param {string} params.profileId Profile ID to create filter link for.
+          * @param {string} params.webPropertyId Web property Id to create profile filter link for.
+          * @param {analytics(v3).ProfileFilterLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileFilterLinks.list
+          * @desc Lists all profile filter links for a profile.
+          * @alias analytics.management.profileFilterLinks.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve profile filter links for.
+          * @param {integer=} params.max-results The maximum number of profile filter links to include in this response.
+          * @param {string} params.profileId Profile ID to retrieve filter links for. Can either be a specific profile ID or '~all', which refers to all the profiles that user has access to.
+          * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property Id for profile filter links for. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileFilterLinks.patch
+          * @desc Update an existing profile filter link. This method supports
+          * patch semantics.
+          * @alias analytics.management.profileFilterLinks.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which profile filter link belongs.
+          * @param {string} params.linkId ID of the profile filter link to be updated.
+          * @param {string} params.profileId Profile ID to which filter link belongs
+          * @param {string} params.webPropertyId Web property Id to which profile filter link belongs
+          * @param {analytics(v3).ProfileFilterLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileFilterLinks.update
+          * @desc Update an existing profile filter link.
+          * @alias analytics.management.profileFilterLinks.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which profile filter link belongs.
+          * @param {string} params.linkId ID of the profile filter link to be updated.
+          * @param {string} params.profileId Profile ID to which filter link belongs
+          * @param {string} params.webPropertyId Web property Id to which profile filter link belongs
+          * @param {analytics(v3).ProfileFilterLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/profileFilterLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-            },
-        profiles: {
-          /**
-           * analytics.management.profiles.delete
-           * @desc Deletes a view (profile).
-           * @alias analytics.management.profiles.delete
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID to delete the view (profile) for.
-           * @param {string} params.profileId ID of the view (profile) to be deleted.
-           * @param {string} params.webPropertyId Web property ID to delete the view (profile) for.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          delete (params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'DELETE'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profiles.get
-              * @desc Gets a view (profile) to which the user has access.
-              * @alias analytics.management.profiles.get
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to retrieve the view (profile) for.
-              * @param {string} params.profileId View (Profile) ID to retrieve the view (profile) for.
-              * @param {string} params.webPropertyId Web property ID to retrieve the view (profile) for.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profiles.insert
-              * @desc Create a new view (profile).
-              * @alias analytics.management.profiles.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to create the view (profile) for.
-              * @param {string} params.webPropertyId Web property ID to create the view (profile) for.
-              * @param {analytics(v3).Profile} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profiles.list
-              * @desc Lists views (profiles) to which the user has access.
-              * @alias analytics.management.profiles.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID for the view (profiles) to retrieve. Can either be a specific account ID or '~all', which refers to all the accounts to which the user has access.
-              * @param {integer=} params.max-results The maximum number of views (profiles) to include in this response.
-              * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web property ID for the views (profiles) to retrieve. Can either be a specific web property ID or '~all', which refers to all the web properties to which the user has access.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profiles.patch
-              * @desc Updates an existing view (profile). This method supports
-              * patch semantics.
-              * @alias analytics.management.profiles.patch
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to which the view (profile) belongs
-              * @param {string} params.profileId ID of the view (profile) to be updated.
-              * @param {string} params.webPropertyId Web property ID to which the view (profile) belongs
-              * @param {analytics(v3).Profile} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          patch(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PATCH'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profiles.update
-              * @desc Updates an existing view (profile).
-              * @alias analytics.management.profiles.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to which the view (profile) belongs
-              * @param {string} params.profileId ID of the view (profile) to be updated.
-              * @param {string} params.webPropertyId Web property ID to which the view (profile) belongs
-              * @param {analytics(v3).Profile} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    profiles: {
+      /**
+       * analytics.management.profiles.delete
+       * @desc Deletes a view (profile).
+       * @alias analytics.management.profiles.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to delete the view (profile) for.
+       * @param {string} params.profileId ID of the view (profile) to be deleted.
+       * @param {string} params.webPropertyId Web property ID to delete the view (profile) for.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profiles.get
+          * @desc Gets a view (profile) to which the user has access.
+          * @alias analytics.management.profiles.get
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve the view (profile) for.
+          * @param {string} params.profileId View (Profile) ID to retrieve the view (profile) for.
+          * @param {string} params.webPropertyId Web property ID to retrieve the view (profile) for.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profiles.insert
+          * @desc Create a new view (profile).
+          * @alias analytics.management.profiles.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create the view (profile) for.
+          * @param {string} params.webPropertyId Web property ID to create the view (profile) for.
+          * @param {analytics(v3).Profile} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profiles.list
+          * @desc Lists views (profiles) to which the user has access.
+          * @alias analytics.management.profiles.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID for the view (profiles) to retrieve. Can either be a specific account ID or '~all', which refers to all the accounts to which the user has access.
+          * @param {integer=} params.max-results The maximum number of views (profiles) to include in this response.
+          * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property ID for the views (profiles) to retrieve. Can either be a specific web property ID or '~all', which refers to all the web properties to which the user has access.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profiles.patch
+          * @desc Updates an existing view (profile). This method supports patch
+          * semantics.
+          * @alias analytics.management.profiles.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which the view (profile) belongs
+          * @param {string} params.profileId ID of the view (profile) to be updated.
+          * @param {string} params.webPropertyId Web property ID to which the view (profile) belongs
+          * @param {analytics(v3).Profile} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profiles.update
+          * @desc Updates an existing view (profile).
+          * @alias analytics.management.profiles.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which the view (profile) belongs
+          * @param {string} params.profileId ID of the view (profile) to be updated.
+          * @param {string} params.webPropertyId Web property ID to which the view (profile) belongs
+          * @param {analytics(v3).Profile} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        profileUserLinks: {
-          /**
-           * analytics.management.profileUserLinks.delete
-           * @desc Removes a user from the given view (profile).
-           * @alias analytics.management.profileUserLinks.delete
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID to delete the user link for.
-           * @param {string} params.linkId Link ID to delete the user link for.
-           * @param {string} params.profileId View (Profile) ID to delete the user link for.
-           * @param {string} params.webPropertyId Web Property ID to delete the user link for.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          delete (params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks/{linkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'DELETE'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'profileId', 'linkId'],
-              pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profileUserLinks.insert
-              * @desc Adds a new user to the given view (profile).
-              * @alias analytics.management.profileUserLinks.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to create the user link for.
-              * @param {string} params.profileId View (Profile) ID to create the user link for.
-              * @param {string} params.webPropertyId Web Property ID to create the user link for.
-              * @param {analytics(v3).EntityUserLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profileUserLinks.list
-              * @desc Lists profile-user links for a given view (profile).
-              * @alias analytics.management.profileUserLinks.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID which the given view (profile) belongs to.
-              * @param {integer=} params.max-results The maximum number of profile-user links to include in this response.
-              * @param {string} params.profileId View (Profile) ID to retrieve the profile-user links for. Can either be a specific profile ID or '~all', which refers to all the profiles that user has access to.
-              * @param {integer=} params.start-index An index of the first profile-user link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web Property ID which the given view (profile) belongs to. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'profileId'],
-              pathParams: ['accountId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.profileUserLinks.update
-              * @desc Updates permissions for an existing user on the given view
-              * (profile).
-              * @alias analytics.management.profileUserLinks.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to update the user link for.
-              * @param {string} params.linkId Link ID to update the user link for.
-              * @param {string} params.profileId View (Profile ID) to update the user link for.
-              * @param {string} params.webPropertyId Web Property ID to update the user link for.
-              * @param {analytics(v3).EntityUserLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks/{linkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'profileId', 'linkId'],
-              pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    profileUserLinks: {
+      /**
+       * analytics.management.profileUserLinks.delete
+       * @desc Removes a user from the given view (profile).
+       * @alias analytics.management.profileUserLinks.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to delete the user link for.
+       * @param {string} params.linkId Link ID to delete the user link for.
+       * @param {string} params.profileId View (Profile) ID to delete the user link for.
+       * @param {string} params.webPropertyId Web Property ID to delete the user link for.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileUserLinks.insert
+          * @desc Adds a new user to the given view (profile).
+          * @alias analytics.management.profileUserLinks.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create the user link for.
+          * @param {string} params.profileId View (Profile) ID to create the user link for.
+          * @param {string} params.webPropertyId Web Property ID to create the user link for.
+          * @param {analytics(v3).EntityUserLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileUserLinks.list
+          * @desc Lists profile-user links for a given view (profile).
+          * @alias analytics.management.profileUserLinks.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID which the given view (profile) belongs to.
+          * @param {integer=} params.max-results The maximum number of profile-user links to include in this response.
+          * @param {string} params.profileId View (Profile) ID to retrieve the profile-user links for. Can either be a specific profile ID or '~all', which refers to all the profiles that user has access to.
+          * @param {integer=} params.start-index An index of the first profile-user link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web Property ID which the given view (profile) belongs to. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId'],
+          pathParams: ['accountId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.profileUserLinks.update
+          * @desc Updates permissions for an existing user on the given view
+          * (profile).
+          * @alias analytics.management.profileUserLinks.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to update the user link for.
+          * @param {string} params.linkId Link ID to update the user link for.
+          * @param {string} params.profileId View (Profile ID) to update the user link for.
+          * @param {string} params.webPropertyId Web Property ID to update the user link for.
+          * @param {analytics(v3).EntityUserLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/profiles/{profileId}/entityUserLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        remarketingAudience:
-            {
-              /**
-               * analytics.management.remarketingAudience.delete
-               * @desc Delete a remarketing audience.
-               * @alias analytics.management.remarketingAudience.delete
-               * @memberOf! analytics(v3)
-               *
-               * @param {object} params Parameters for request
-               * @param {string} params.accountId Account ID to which the remarketing audience belongs.
-               * @param {string} params.remarketingAudienceId The ID of the remarketing audience to delete.
-               * @param {string} params.webPropertyId Web property ID to which the remarketing audience belongs.
-               * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-               * @param {callback} callback The callback that handles the response.
-               * @return {object} Request object
-               */
-              delete (params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'DELETE'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'remarketingAudienceId'],
-                  pathParams:
-                      ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.remarketingAudience.get
-                  * @desc Gets a remarketing audience to which the user has
-                  * access.
-                  * @alias analytics.management.remarketingAudience.get
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The account ID of the remarketing audience to retrieve.
-                  * @param {string} params.remarketingAudienceId The ID of the remarketing audience to retrieve.
-                  * @param {string} params.webPropertyId The web property ID of the remarketing audience to retrieve.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              get(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'GET'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'remarketingAudienceId'],
-                  pathParams:
-                      ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.remarketingAudience.insert
-                  * @desc Creates a new remarketing audience.
-                  * @alias analytics.management.remarketingAudience.insert
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The account ID for which to create the remarketing audience.
-                  * @param {string} params.webPropertyId Web property ID for which to create the remarketing audience.
-                  * @param {analytics(v3).RemarketingAudience} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              insert(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'POST'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'webPropertyId'],
-                  pathParams: ['accountId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.remarketingAudience.list
-                  * @desc Lists remarketing audiences to which the user has
-                  * access.
-                  * @alias analytics.management.remarketingAudience.list
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The account ID of the remarketing audiences to retrieve.
-                  * @param {integer=} params.max-results The maximum number of remarketing audiences to include in this response.
-                  * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-                  * @param {string=} params.type
-                  * @param {string} params.webPropertyId The web property ID of the remarketing audiences to retrieve.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              list(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'GET'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'webPropertyId'],
-                  pathParams: ['accountId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.remarketingAudience.patch
-                  * @desc Updates an existing remarketing audience. This method
-                  * supports patch semantics.
-                  * @alias analytics.management.remarketingAudience.patch
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The account ID of the remarketing audience to update.
-                  * @param {string} params.remarketingAudienceId The ID of the remarketing audience to update.
-                  * @param {string} params.webPropertyId The web property ID of the remarketing audience to update.
-                  * @param {analytics(v3).RemarketingAudience} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              patch(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'PATCH'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'remarketingAudienceId'],
-                  pathParams:
-                      ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * analytics.management.remarketingAudience.update
-                  * @desc Updates an existing remarketing audience.
-                  * @alias analytics.management.remarketingAudience.update
-                  * @memberOf! analytics(v3)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The account ID of the remarketing audience to update.
-                  * @param {string} params.remarketingAudienceId The ID of the remarketing audience to update.
-                  * @param {string} params.webPropertyId The web property ID of the remarketing audience to update.
-                  * @param {analytics(v3).RemarketingAudience} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              update(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'PUT'
-                      },
-                      options),
-                  params,
-                  requiredParams:
-                      ['accountId', 'webPropertyId', 'remarketingAudienceId'],
-                  pathParams:
-                      ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }
+    },
+    remarketingAudience: {
+      /**
+       * analytics.management.remarketingAudience.delete
+       * @desc Delete a remarketing audience.
+       * @alias analytics.management.remarketingAudience.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to which the remarketing audience belongs.
+       * @param {string} params.remarketingAudienceId The ID of the remarketing audience to delete.
+       * @param {string} params.webPropertyId Web property ID to which the remarketing audience belongs.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'remarketingAudienceId'],
+          pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.remarketingAudience.get
+          * @desc Gets a remarketing audience to which the user has access.
+          * @alias analytics.management.remarketingAudience.get
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The account ID of the remarketing audience to retrieve.
+          * @param {string} params.remarketingAudienceId The ID of the remarketing audience to retrieve.
+          * @param {string} params.webPropertyId The web property ID of the remarketing audience to retrieve.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'remarketingAudienceId'],
+          pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.remarketingAudience.insert
+          * @desc Creates a new remarketing audience.
+          * @alias analytics.management.remarketingAudience.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The account ID for which to create the remarketing audience.
+          * @param {string} params.webPropertyId Web property ID for which to create the remarketing audience.
+          * @param {analytics(v3).RemarketingAudience} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.remarketingAudience.list
+          * @desc Lists remarketing audiences to which the user has access.
+          * @alias analytics.management.remarketingAudience.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The account ID of the remarketing audiences to retrieve.
+          * @param {integer=} params.max-results The maximum number of remarketing audiences to include in this response.
+          * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string=} params.type
+          * @param {string} params.webPropertyId The web property ID of the remarketing audiences to retrieve.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.remarketingAudience.patch
+          * @desc Updates an existing remarketing audience. This method supports
+          * patch semantics.
+          * @alias analytics.management.remarketingAudience.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The account ID of the remarketing audience to update.
+          * @param {string} params.remarketingAudienceId The ID of the remarketing audience to update.
+          * @param {string} params.webPropertyId The web property ID of the remarketing audience to update.
+          * @param {analytics(v3).RemarketingAudience} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'remarketingAudienceId'],
+          pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.remarketingAudience.update
+          * @desc Updates an existing remarketing audience.
+          * @alias analytics.management.remarketingAudience.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The account ID of the remarketing audience to update.
+          * @param {string} params.remarketingAudienceId The ID of the remarketing audience to update.
+          * @param {string} params.webPropertyId The web property ID of the remarketing audience to update.
+          * @param {analytics(v3).RemarketingAudience} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/remarketingAudiences/{remarketingAudienceId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'remarketingAudienceId'],
+          pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-            },
-        segments: {
-          /**
-           * analytics.management.segments.list
-           * @desc Lists segments to which the user has access.
-           * @alias analytics.management.segments.list
-           * @memberOf! analytics(v3)
-           *
-           * @param {object=} params Parameters for request
-           * @param {integer=} params.max-results The maximum number of segments to include in this response.
-           * @param {integer=} params.start-index An index of the first segment to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url: (rootUrl + '/analytics/v3/management/segments')
-                             .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: [],
-              pathParams: [],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
+    },
+    segments: {
+      /**
+       * analytics.management.segments.list
+       * @desc Lists segments to which the user has access.
+       * @alias analytics.management.segments.list
+       * @memberOf! analytics(v3)
+       *
+       * @param {object=} params Parameters for request
+       * @param {integer=} params.max-results The maximum number of segments to include in this response.
+       * @param {integer=} params.start-index An index of the first segment to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/analytics/v3/management/segments')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
 
-        },
-        unsampledReports: {
+    },
+    unsampledReports:
+        {
           /**
            * analytics.management.unsampledReports.delete
            * @desc Deletes an unsampled report.
@@ -2467,7 +2530,9 @@ function Analytics(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2493,7 +2558,7 @@ function Analytics(options) {
               ],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * analytics.management.unsampledReports.get
               * @desc Returns a single unsampled report.
@@ -2509,7 +2574,8 @@ function Analytics(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2535,7 +2601,7 @@ function Analytics(options) {
               ],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * analytics.management.unsampledReports.insert
               * @desc Create a new unsampled report.
@@ -2551,7 +2617,9 @@ function Analytics(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          insert(params, options, callback) {
+          insert(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2573,7 +2641,7 @@ function Analytics(options) {
               pathParams: ['accountId', 'profileId', 'webPropertyId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * analytics.management.unsampledReports.list
               * @desc Lists unsampled reports to which the user has access.
@@ -2590,7 +2658,9 @@ function Analytics(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2612,765 +2682,795 @@ function Analytics(options) {
               pathParams: ['accountId', 'profileId', 'webPropertyId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
-        uploads: {
-          /**
-           * analytics.management.uploads.deleteUploadData
-           * @desc Delete data associated with a previous upload.
-           * @alias analytics.management.uploads.deleteUploadData
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account Id for the uploads to be deleted.
-           * @param {string} params.customDataSourceId Custom data source Id for the uploads to be deleted.
-           * @param {string} params.webPropertyId Web property Id for the uploads to be deleted.
-           * @param {analytics(v3).AnalyticsDataimportDeleteUploadDataRequest} params.resource Request body data
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          deleteUploadData(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/deleteUploadData')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'customDataSourceId'],
-              pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.uploads.get
-              * @desc List uploads to which the user has access.
-              * @alias analytics.management.uploads.get
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account Id for the upload to retrieve.
-              * @param {string} params.customDataSourceId Custom data source Id for upload to retrieve.
-              * @param {string} params.uploadId Upload Id to retrieve.
-              * @param {string} params.webPropertyId Web property Id for the upload to retrieve.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads/{uploadId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: [
-                'accountId', 'webPropertyId', 'customDataSourceId', 'uploadId'
-              ],
-              pathParams: [
-                'accountId', 'customDataSourceId', 'uploadId', 'webPropertyId'
-              ],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.uploads.list
-              * @desc List uploads to which the user has access.
-              * @alias analytics.management.uploads.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account Id for the uploads to retrieve.
-              * @param {string} params.customDataSourceId Custom data source Id for uploads to retrieve.
-              * @param {integer=} params.max-results The maximum number of uploads to include in this response.
-              * @param {integer=} params.start-index A 1-based index of the first upload to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web property Id for the uploads to retrieve.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'customDataSourceId'],
-              pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.uploads.uploadData
-              * @desc Upload data for a custom data source.
-              * @alias analytics.management.uploads.uploadData
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account Id associated with the upload.
-              * @param {string} params.customDataSourceId Custom data source Id to which the data being uploaded belongs.
-              * @param {string} params.webPropertyId Web property UA-string associated with the upload.
-              * @param {object} params.media Media object
-              * @param {string} params.media.mimeType Media mime-type
-              * @param {string|object} params.media.body Media body contents
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          uploadData(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              mediaUrl:
-                  (rootUrl +
-                   '/upload/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'customDataSourceId'],
-              pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
-
-        },
-        webproperties: {
-          /**
-           * analytics.management.webproperties.get
-           * @desc Gets a web property to which the user has access.
-           * @alias analytics.management.webproperties.get
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID to retrieve the web property for.
-           * @param {string} params.webPropertyId ID to retrieve the web property for.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webproperties.insert
-              * @desc Create a new property if the account has fewer than 20
-              * properties. Web properties are visible in the Google Analytics
-              * interface only if they have at least one profile.
-              * @alias analytics.management.webproperties.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to create the web property for.
-              * @param {analytics(v3).Webproperty} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webproperties.list
-              * @desc Lists web properties to which the user has access.
-              * @alias analytics.management.webproperties.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to retrieve web properties for. Can either be a specific account ID or '~all', which refers to all the accounts that user has access to.
-              * @param {integer=} params.max-results The maximum number of web properties to include in this response.
-              * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webproperties.patch
-              * @desc Updates an existing web property. This method supports
-              * patch semantics.
-              * @alias analytics.management.webproperties.patch
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to which the web property belongs
-              * @param {string} params.webPropertyId Web property ID
-              * @param {analytics(v3).Webproperty} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          patch(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PATCH'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webproperties.update
-              * @desc Updates an existing web property.
-              * @alias analytics.management.webproperties.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to which the web property belongs
-              * @param {string} params.webPropertyId Web property ID
-              * @param {analytics(v3).Webproperty} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
-
-        },
-        webPropertyAdWordsLinks: {
-          /**
-           * analytics.management.webPropertyAdWordsLinks.delete
-           * @desc Deletes a web property-AdWords link.
-           * @alias analytics.management.webPropertyAdWordsLinks.delete
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId ID of the account which the given web property belongs to.
-           * @param {string} params.webPropertyAdWordsLinkId Web property AdWords link ID.
-           * @param {string} params.webPropertyId Web property ID to delete the AdWords link for.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          delete (params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'DELETE'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
-              pathParams:
-                  ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webPropertyAdWordsLinks.get
-              * @desc Returns a web property-AdWords link to which the user has
-              * access.
-              * @alias analytics.management.webPropertyAdWordsLinks.get
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId ID of the account which the given web property belongs to.
-              * @param {string} params.webPropertyAdWordsLinkId Web property-AdWords link ID.
-              * @param {string} params.webPropertyId Web property ID to retrieve the AdWords link for.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
-              pathParams:
-                  ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webPropertyAdWordsLinks.insert
-              * @desc Creates a webProperty-AdWords link.
-              * @alias analytics.management.webPropertyAdWordsLinks.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId ID of the Google Analytics account to create the link for.
-              * @param {string} params.webPropertyId Web property ID to create the link for.
-              * @param {analytics(v3).EntityAdWordsLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webPropertyAdWordsLinks.list
-              * @desc Lists webProperty-AdWords links for a given web property.
-              * @alias analytics.management.webPropertyAdWordsLinks.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId ID of the account which the given web property belongs to.
-              * @param {integer=} params.max-results The maximum number of webProperty-AdWords links to include in this response.
-              * @param {integer=} params.start-index An index of the first webProperty-AdWords link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web property ID to retrieve the AdWords links for.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webPropertyAdWordsLinks.patch
-              * @desc Updates an existing webProperty-AdWords link. This method
-              * supports patch semantics.
-              * @alias analytics.management.webPropertyAdWordsLinks.patch
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId ID of the account which the given web property belongs to.
-              * @param {string} params.webPropertyAdWordsLinkId Web property-AdWords link ID.
-              * @param {string} params.webPropertyId Web property ID to retrieve the AdWords link for.
-              * @param {analytics(v3).EntityAdWordsLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          patch(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PATCH'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
-              pathParams:
-                  ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webPropertyAdWordsLinks.update
-              * @desc Updates an existing webProperty-AdWords link.
-              * @alias analytics.management.webPropertyAdWordsLinks.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId ID of the account which the given web property belongs to.
-              * @param {string} params.webPropertyAdWordsLinkId Web property-AdWords link ID.
-              * @param {string} params.webPropertyId Web property ID to retrieve the AdWords link for.
-              * @param {analytics(v3).EntityAdWordsLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams:
-                  ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
-              pathParams:
-                  ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
-
-        },
-        webpropertyUserLinks: {
-          /**
-           * analytics.management.webpropertyUserLinks.delete
-           * @desc Removes a user from the given web property.
-           * @alias analytics.management.webpropertyUserLinks.delete
-           * @memberOf! analytics(v3)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId Account ID to delete the user link for.
-           * @param {string} params.linkId Link ID to delete the user link for.
-           * @param {string} params.webPropertyId Web Property ID to delete the user link for.
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          delete (params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks/{linkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'DELETE'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'linkId'],
-              pathParams: ['accountId', 'linkId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webpropertyUserLinks.insert
-              * @desc Adds a new user to the given web property.
-              * @alias analytics.management.webpropertyUserLinks.insert
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to create the user link for.
-              * @param {string} params.webPropertyId Web Property ID to create the user link for.
-              * @param {analytics(v3).EntityUserLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          insert(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webpropertyUserLinks.list
-              * @desc Lists webProperty-user links for a given web property.
-              * @alias analytics.management.webpropertyUserLinks.list
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID which the given web property belongs to.
-              * @param {integer=} params.max-results The maximum number of webProperty-user Links to include in this response.
-              * @param {integer=} params.start-index An index of the first webProperty-user link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
-              * @param {string} params.webPropertyId Web Property ID for the webProperty-user links to retrieve. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId'],
-              pathParams: ['accountId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * analytics.management.webpropertyUserLinks.update
-              * @desc Updates permissions for an existing user on the given web
-              * property.
-              * @alias analytics.management.webpropertyUserLinks.update
-              * @memberOf! analytics(v3)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId Account ID to update the account-user link for.
-              * @param {string} params.linkId Link ID to update the account-user link for.
-              * @param {string} params.webPropertyId Web property ID to update the account-user link for.
-              * @param {analytics(v3).EntityUserLink} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks/{linkId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'webPropertyId', 'linkId'],
-              pathParams: ['accountId', 'linkId', 'webPropertyId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
-
+    uploads: {
+      /**
+       * analytics.management.uploads.deleteUploadData
+       * @desc Delete data associated with a previous upload.
+       * @alias analytics.management.uploads.deleteUploadData
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account Id for the uploads to be deleted.
+       * @param {string} params.customDataSourceId Custom data source Id for the uploads to be deleted.
+       * @param {string} params.webPropertyId Web property Id for the uploads to be deleted.
+       * @param {analytics(v3).AnalyticsDataimportDeleteUploadDataRequest} params.resource Request body data
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      deleteUploadData(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
         }
-      };
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/deleteUploadData')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
+          pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.uploads.get
+          * @desc List uploads to which the user has access.
+          * @alias analytics.management.uploads.get
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account Id for the upload to retrieve.
+          * @param {string} params.customDataSourceId Custom data source Id for upload to retrieve.
+          * @param {string} params.uploadId Upload Id to retrieve.
+          * @param {string} params.webPropertyId Web property Id for the upload to retrieve.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads/{uploadId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'customDataSourceId', 'uploadId'],
+          pathParams:
+              ['accountId', 'customDataSourceId', 'uploadId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.uploads.list
+          * @desc List uploads to which the user has access.
+          * @alias analytics.management.uploads.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account Id for the uploads to retrieve.
+          * @param {string} params.customDataSourceId Custom data source Id for uploads to retrieve.
+          * @param {integer=} params.max-results The maximum number of uploads to include in this response.
+          * @param {integer=} params.start-index A 1-based index of the first upload to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property Id for the uploads to retrieve.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
+          pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.uploads.uploadData
+          * @desc Upload data for a custom data source.
+          * @alias analytics.management.uploads.uploadData
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account Id associated with the upload.
+          * @param {string} params.customDataSourceId Custom data source Id to which the data being uploaded belongs.
+          * @param {string} params.webPropertyId Web property UA-string associated with the upload.
+          * @param {object} params.media Media object
+          * @param {string} params.media.mimeType Media mime-type
+          * @param {string|object} params.media.body Media body contents
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      uploadData(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          mediaUrl:
+              (rootUrl +
+               '/upload/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/customDataSources/{customDataSourceId}/uploads')
+                  .replace(/([^:]\/)\/+/g, '$1'),
+          requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
+          pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
+
+    },
+    webproperties: {
+      /**
+       * analytics.management.webproperties.get
+       * @desc Gets a web property to which the user has access.
+       * @alias analytics.management.webproperties.get
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to retrieve the web property for.
+       * @param {string} params.webPropertyId ID to retrieve the web property for.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webproperties.insert
+          * @desc Create a new property if the account has fewer than 20
+          * properties. Web properties are visible in the Google Analytics
+          * interface only if they have at least one profile.
+          * @alias analytics.management.webproperties.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create the web property for.
+          * @param {analytics(v3).Webproperty} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webproperties.list
+          * @desc Lists web properties to which the user has access.
+          * @alias analytics.management.webproperties.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to retrieve web properties for. Can either be a specific account ID or '~all', which refers to all the accounts that user has access to.
+          * @param {integer=} params.max-results The maximum number of web properties to include in this response.
+          * @param {integer=} params.start-index An index of the first entity to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webproperties.patch
+          * @desc Updates an existing web property. This method supports patch
+          * semantics.
+          * @alias analytics.management.webproperties.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which the web property belongs
+          * @param {string} params.webPropertyId Web property ID
+          * @param {analytics(v3).Webproperty} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webproperties.update
+          * @desc Updates an existing web property.
+          * @alias analytics.management.webproperties.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to which the web property belongs
+          * @param {string} params.webPropertyId Web property ID
+          * @param {analytics(v3).Webproperty} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
+
+    },
+    webPropertyAdWordsLinks: {
+      /**
+       * analytics.management.webPropertyAdWordsLinks.delete
+       * @desc Deletes a web property-AdWords link.
+       * @alias analytics.management.webPropertyAdWordsLinks.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId ID of the account which the given web property belongs to.
+       * @param {string} params.webPropertyAdWordsLinkId Web property AdWords link ID.
+       * @param {string} params.webPropertyId Web property ID to delete the AdWords link for.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
+          pathParams:
+              ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webPropertyAdWordsLinks.get
+          * @desc Returns a web property-AdWords link to which the user has
+          * access.
+          * @alias analytics.management.webPropertyAdWordsLinks.get
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId ID of the account which the given web property belongs to.
+          * @param {string} params.webPropertyAdWordsLinkId Web property-AdWords link ID.
+          * @param {string} params.webPropertyId Web property ID to retrieve the AdWords link for.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
+          pathParams:
+              ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webPropertyAdWordsLinks.insert
+          * @desc Creates a webProperty-AdWords link.
+          * @alias analytics.management.webPropertyAdWordsLinks.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId ID of the Google Analytics account to create the link for.
+          * @param {string} params.webPropertyId Web property ID to create the link for.
+          * @param {analytics(v3).EntityAdWordsLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webPropertyAdWordsLinks.list
+          * @desc Lists webProperty-AdWords links for a given web property.
+          * @alias analytics.management.webPropertyAdWordsLinks.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId ID of the account which the given web property belongs to.
+          * @param {integer=} params.max-results The maximum number of webProperty-AdWords links to include in this response.
+          * @param {integer=} params.start-index An index of the first webProperty-AdWords link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web property ID to retrieve the AdWords links for.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webPropertyAdWordsLinks.patch
+          * @desc Updates an existing webProperty-AdWords link. This method
+          * supports patch semantics.
+          * @alias analytics.management.webPropertyAdWordsLinks.patch
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId ID of the account which the given web property belongs to.
+          * @param {string} params.webPropertyAdWordsLinkId Web property-AdWords link ID.
+          * @param {string} params.webPropertyId Web property ID to retrieve the AdWords link for.
+          * @param {analytics(v3).EntityAdWordsLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PATCH'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
+          pathParams:
+              ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webPropertyAdWordsLinks.update
+          * @desc Updates an existing webProperty-AdWords link.
+          * @alias analytics.management.webPropertyAdWordsLinks.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId ID of the account which the given web property belongs to.
+          * @param {string} params.webPropertyAdWordsLinkId Web property-AdWords link ID.
+          * @param {string} params.webPropertyId Web property ID to retrieve the AdWords link for.
+          * @param {analytics(v3).EntityAdWordsLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityAdWordsLinks/{webPropertyAdWordsLinkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams:
+              ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
+          pathParams:
+              ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
+
+    },
+    webpropertyUserLinks: {
+      /**
+       * analytics.management.webpropertyUserLinks.delete
+       * @desc Removes a user from the given web property.
+       * @alias analytics.management.webpropertyUserLinks.delete
+       * @memberOf! analytics(v3)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId Account ID to delete the user link for.
+       * @param {string} params.linkId Link ID to delete the user link for.
+       * @param {string} params.webPropertyId Web Property ID to delete the user link for.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webpropertyUserLinks.insert
+          * @desc Adds a new user to the given web property.
+          * @alias analytics.management.webpropertyUserLinks.insert
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to create the user link for.
+          * @param {string} params.webPropertyId Web Property ID to create the user link for.
+          * @param {analytics(v3).EntityUserLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webpropertyUserLinks.list
+          * @desc Lists webProperty-user links for a given web property.
+          * @alias analytics.management.webpropertyUserLinks.list
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID which the given web property belongs to.
+          * @param {integer=} params.max-results The maximum number of webProperty-user Links to include in this response.
+          * @param {integer=} params.start-index An index of the first webProperty-user link to retrieve. Use this parameter as a pagination mechanism along with the max-results parameter.
+          * @param {string} params.webPropertyId Web Property ID for the webProperty-user links to retrieve. Can either be a specific web property ID or '~all', which refers to all the web properties that user has access to.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId'],
+          pathParams: ['accountId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * analytics.management.webpropertyUserLinks.update
+          * @desc Updates permissions for an existing user on the given web
+          * property.
+          * @alias analytics.management.webpropertyUserLinks.update
+          * @memberOf! analytics(v3)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId Account ID to update the account-user link for.
+          * @param {string} params.linkId Link ID to update the account-user link for.
+          * @param {string} params.webPropertyId Web property ID to update the account-user link for.
+          * @param {analytics(v3).EntityUserLink} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/analytics/v3/management/accounts/{accountId}/webproperties/{webPropertyId}/entityUserLinks/{linkId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'webPropertyId', 'linkId'],
+          pathParams: ['accountId', 'linkId', 'webPropertyId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
+
+    }
+  };
   self.metadata = {
     columns: {
       /**
@@ -3385,7 +3485,9 @@ function Analytics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3405,7 +3507,7 @@ function Analytics(options) {
           pathParams: ['reportType'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -3423,7 +3525,9 @@ function Analytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    createAccountTicket(params, options, callback) {
+    createAccountTicket(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3443,7 +3547,7 @@ function Analytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * analytics.provisioning.createAccountTree
         * @desc Provision account.
@@ -3456,7 +3560,9 @@ function Analytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    createAccountTree(params, options, callback) {
+    createAccountTree(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3476,7 +3582,7 @@ function Analytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/analyticsreporting/v4.ts
+++ b/src/apis/analyticsreporting/v4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Analytics Reporting API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v4
  * @param {object=} options Options for Analyticsreporting
  */
-function Analyticsreporting(options) {
+function Analyticsreporting(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.reports = {
@@ -47,7 +54,9 @@ function Analyticsreporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchGet(params, options, callback) {
+    batchGet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Analyticsreporting(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/androiddeviceprovisioning/v1.ts
+++ b/src/apis/androiddeviceprovisioning/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Android Device Provisioning Partner API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Androiddeviceprovisioning
  */
-function Androiddeviceprovisioning(options) {
+function Androiddeviceprovisioning(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.customers = {
@@ -49,7 +56,9 @@ function Androiddeviceprovisioning(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Androiddeviceprovisioning(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     configurations: {
       /**
@@ -86,7 +95,9 @@ function Androiddeviceprovisioning(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -107,7 +118,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.configurations.delete
           * @desc Deletes an unused configuration. The API call fails if the
@@ -121,7 +132,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -141,7 +154,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.configurations.get
           * @desc Gets the details of a configuration.
@@ -154,7 +167,8 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -174,7 +188,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.configurations.list
           * @desc Lists a customer's configurations.
@@ -187,7 +201,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -208,7 +224,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.configurations.patch
           * @desc Updates a configuration's field values.
@@ -223,7 +239,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -243,7 +261,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -264,7 +282,9 @@ function Androiddeviceprovisioning(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      applyConfiguration(params, options, callback) {
+      applyConfiguration(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -285,7 +305,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.devices.get
           * @desc Gets the details of a device.
@@ -298,7 +318,8 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -318,7 +339,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.devices.list
           * @desc Lists a customer's devices.
@@ -333,7 +354,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -354,7 +377,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.devices.removeConfiguration
           * @desc Removes a configuration from device.
@@ -369,7 +392,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      removeConfiguration(params, options, callback) {
+      removeConfiguration(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -390,7 +415,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.customers.devices.unclaim
           * @desc Unclaims a device from a customer and removes it from
@@ -407,7 +432,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      unclaim(params, options, callback) {
+      unclaim(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -428,7 +455,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -446,7 +473,9 @@ function Androiddeviceprovisioning(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -467,7 +496,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -487,7 +516,8 @@ function Androiddeviceprovisioning(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -507,7 +537,7 @@ function Androiddeviceprovisioning(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -529,7 +559,9 @@ function Androiddeviceprovisioning(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -550,7 +582,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.customers.list
           * @desc Lists the customers that are enrolled to the reseller
@@ -566,7 +598,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -587,7 +621,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -605,7 +639,9 @@ function Androiddeviceprovisioning(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      claim(params, options, callback) {
+      claim(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -626,7 +662,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.claimAsync
           * @desc Claim devices asynchronously.
@@ -640,7 +676,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      claimAsync(params, options, callback) {
+      claimAsync(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -661,7 +699,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.findByIdentifier
           * @desc Find devices by device identifier.
@@ -675,7 +713,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      findByIdentifier(params, options, callback) {
+      findByIdentifier(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -697,7 +737,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.findByOwner
           * @desc Find devices by ownership.
@@ -711,7 +751,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      findByOwner(params, options, callback) {
+      findByOwner(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -732,7 +774,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.get
           * @desc Get a device.
@@ -745,7 +787,8 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -765,7 +808,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.metadata
           * @desc Update the metadata.
@@ -780,7 +823,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      metadata(params, options, callback) {
+      metadata(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -803,7 +848,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['deviceId', 'metadataOwnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.unclaim
           * @desc Unclaim the device identified by the `device_id` or the
@@ -818,7 +863,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      unclaim(params, options, callback) {
+      unclaim(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -839,7 +886,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.unclaimAsync
           * @desc Unclaim devices asynchronously.
@@ -853,7 +900,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      unclaimAsync(params, options, callback) {
+      unclaimAsync(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -874,7 +923,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androiddeviceprovisioning.partners.devices.updateMetadataAsync
           * @desc Set metadata in batch asynchronously.
@@ -889,7 +938,9 @@ function Androiddeviceprovisioning(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      updateMetadataAsync(params, options, callback) {
+      updateMetadataAsync(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -911,7 +962,7 @@ function Androiddeviceprovisioning(options) {
           pathParams: ['partnerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/androidenterprise/v1.ts
+++ b/src/apis/androidenterprise/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play EMM API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Androidenterprise
  */
-function Androidenterprise(options) {
+function Androidenterprise(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.devices = {
@@ -49,7 +56,8 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +79,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.devices.getState
         * @desc Retrieves whether a device's access to Google services is
@@ -91,7 +99,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getState(params, options, callback) {
+    getState(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -113,7 +123,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.devices.list
         * @desc Retrieves the IDs of all of a user's devices.
@@ -127,7 +137,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -149,7 +161,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.devices.patch
         * @desc Updates the device policy. This method supports patch semantics.
@@ -166,7 +178,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -188,7 +202,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.devices.setState
         * @desc Sets whether a device's access to Google services is enabled or
@@ -208,7 +222,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setState(params, options, callback) {
+    setState(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -230,7 +246,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.devices.update
         * @desc Updates the device policy
@@ -247,7 +263,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -269,7 +287,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -288,7 +306,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    acknowledgeNotificationSet(params, options, callback) {
+    acknowledgeNotificationSet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -310,7 +330,7 @@ function Androidenterprise(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.completeSignup
         * @desc Completes the signup flow, by specifying the Completion token
@@ -326,7 +346,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    completeSignup(params, options, callback) {
+    completeSignup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -347,7 +369,7 @@ function Androidenterprise(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.createWebToken
         * @desc Returns a unique token to access an embeddable UI. To generate a
@@ -364,7 +386,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    createWebToken(params, options, callback) {
+    createWebToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -386,7 +410,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.delete
         * @desc Deletes the binding between the EMM and enterprise. This is now
@@ -402,7 +426,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -423,7 +449,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.enroll
         * @desc Enrolls an enterprise with the calling EMM.
@@ -437,7 +463,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    enroll(params, options, callback) {
+    enroll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -457,7 +485,7 @@ function Androidenterprise(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.generateSignupUrl
         * @desc Generates a sign-up URL.
@@ -470,7 +498,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generateSignupUrl(params, options, callback) {
+    generateSignupUrl(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -490,7 +520,7 @@ function Androidenterprise(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.get
         * @desc Retrieves the name and domain of an enterprise.
@@ -503,7 +533,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -524,7 +555,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.getAndroidDevicePolicyConfig
         * @desc Returns the Android Device Policy config resource.
@@ -537,7 +568,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getAndroidDevicePolicyConfig(params, options, callback) {
+    getAndroidDevicePolicyConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -559,7 +592,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.getServiceAccount
         * @desc Returns a service account and credentials. The service account
@@ -583,7 +616,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getServiceAccount(params, options, callback) {
+    getServiceAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -605,7 +640,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.getStoreLayout
         * @desc Returns the store layout for the enterprise. If the store layout
@@ -620,7 +655,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getStoreLayout(params, options, callback) {
+    getStoreLayout(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -642,7 +679,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.insert
         * @desc Establishes the binding between the EMM and an enterprise. This
@@ -657,7 +694,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -677,7 +716,7 @@ function Androidenterprise(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.list
         * @desc Looks up an enterprise by domain name. This is only supported
@@ -694,7 +733,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -714,7 +755,7 @@ function Androidenterprise(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.pullNotificationSet
         * @desc Pulls and returns a notification set for the enterprises
@@ -741,7 +782,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    pullNotificationSet(params, options, callback) {
+    pullNotificationSet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -762,7 +805,7 @@ function Androidenterprise(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.sendTestPushNotification
         * @desc Sends a test notification to validate the EMM integration with
@@ -776,7 +819,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    sendTestPushNotification(params, options, callback) {
+    sendTestPushNotification(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -798,7 +843,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.setAccount
         * @desc Sets the account that will be used to authenticate to the API as
@@ -813,7 +858,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setAccount(params, options, callback) {
+    setAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -834,7 +881,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.setAndroidDevicePolicyConfig
         * @desc Sets the Android Device Policy config resource. EMM may use this
@@ -851,7 +898,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setAndroidDevicePolicyConfig(params, options, callback) {
+    setAndroidDevicePolicyConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -873,7 +922,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.setStoreLayout
         * @desc Sets the store layout for the enterprise. By default,
@@ -894,7 +943,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setStoreLayout(params, options, callback) {
+    setStoreLayout(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -916,7 +967,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.enterprises.unenroll
         * @desc Unenrolls an enterprise from the calling EMM.
@@ -929,7 +980,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    unenroll(params, options, callback) {
+    unenroll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -950,7 +1003,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -969,7 +1022,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -991,7 +1046,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.entitlements.get
         * @desc Retrieves details of an entitlement.
@@ -1006,7 +1061,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1028,7 +1084,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.entitlements.list
         * @desc Lists all entitlements for the specified user. Only the ID is
@@ -1043,7 +1099,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1065,7 +1123,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.entitlements.patch
         * @desc Adds or updates an entitlement to an app for a user. This method
@@ -1083,7 +1141,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1105,7 +1165,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.entitlements.update
         * @desc Adds or updates an entitlement to an app for a user.
@@ -1122,7 +1182,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1144,7 +1206,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1162,7 +1224,8 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1184,7 +1247,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'groupLicenseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.grouplicenses.list
         * @desc Retrieves IDs of all products for which the enterprise has a
@@ -1198,7 +1261,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1220,7 +1285,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1239,7 +1304,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1261,7 +1328,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'groupLicenseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1283,7 +1350,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1305,7 +1374,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.installs.get
         * @desc Retrieves details of an installation of an app on a device.
@@ -1321,7 +1390,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1343,7 +1413,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.installs.list
         * @desc Retrieves the details of all apps installed on the specified
@@ -1359,7 +1429,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1381,7 +1453,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.installs.patch
         * @desc Requests to install the latest version of an app to a device. If
@@ -1400,7 +1472,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1422,7 +1496,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.installs.update
         * @desc Requests to install the latest version of an app to a device. If
@@ -1441,7 +1515,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1463,7 +1539,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1484,7 +1560,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1512,7 +1590,7 @@ function Androidenterprise(options) {
         ],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsfordevice.get
         * @desc Retrieves details of a per-device managed configuration.
@@ -1528,7 +1606,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1556,7 +1635,7 @@ function Androidenterprise(options) {
         ],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsfordevice.list
         * @desc Lists all the per-device managed configurations for the
@@ -1572,7 +1651,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1594,7 +1675,7 @@ function Androidenterprise(options) {
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsfordevice.patch
         * @desc Adds or updates a per-device managed configuration for an app
@@ -1612,7 +1693,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1640,7 +1723,7 @@ function Androidenterprise(options) {
         ],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsfordevice.update
         * @desc Adds or updates a per-device managed configuration for an app
@@ -1658,7 +1741,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1686,7 +1771,7 @@ function Androidenterprise(options) {
         ],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1706,7 +1791,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1729,7 +1816,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsforuser.get
         * @desc Retrieves details of a per-user managed configuration for an app
@@ -1745,7 +1832,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1768,7 +1856,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsforuser.list
         * @desc Lists all the per-user managed configurations for the specified
@@ -1783,7 +1871,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1805,7 +1895,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsforuser.patch
         * @desc Adds or updates the managed configuration settings for an app
@@ -1827,7 +1917,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1850,7 +1942,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.managedconfigurationsforuser.update
         * @desc Adds or updates the managed configuration settings for an app
@@ -1871,7 +1963,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1894,7 +1988,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1913,7 +2007,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1935,7 +2031,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1954,7 +2050,8 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1975,7 +2072,7 @@ function Androidenterprise(options) {
         pathParams: ['permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1998,7 +2095,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    approve(params, options, callback) {
+    approve(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2020,7 +2119,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.products.generateApprovalUrl
         * @desc Generates a URL that can be rendered in an iframe to display the
@@ -2043,7 +2142,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generateApprovalUrl(params, options, callback) {
+    generateApprovalUrl(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2065,7 +2166,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.products.get
         * @desc Retrieves details of a product for display to an enterprise
@@ -2081,7 +2182,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2103,7 +2205,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.products.getAppRestrictionsSchema
         * @desc Retrieves the schema that defines the configurable properties
@@ -2123,7 +2225,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getAppRestrictionsSchema(params, options, callback) {
+    getAppRestrictionsSchema(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2145,7 +2249,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.products.getPermissions
         * @desc Retrieves the Android app permissions required by this app.
@@ -2159,7 +2263,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getPermissions(params, options, callback) {
+    getPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2181,7 +2287,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.products.list
         * @desc Finds approved products that match a query, or all approved
@@ -2200,7 +2306,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2221,7 +2329,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.products.unapprove
         * @desc Unapproves the specified product (and the relevant app
@@ -2236,7 +2344,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    unapprove(params, options, callback) {
+    unapprove(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2258,7 +2368,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2280,7 +2390,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2302,7 +2414,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'keyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.serviceaccountkeys.insert
         * @desc Generates new credentials for the service account associated
@@ -2321,7 +2433,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2343,7 +2457,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.serviceaccountkeys.list
         * @desc Lists all active credentials for the service account associated
@@ -2360,7 +2474,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2382,7 +2498,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2401,7 +2517,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2423,7 +2541,7 @@ function Androidenterprise(options) {
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutclusters.get
         * @desc Retrieves details of a cluster.
@@ -2438,7 +2556,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2460,7 +2579,7 @@ function Androidenterprise(options) {
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutclusters.insert
         * @desc Inserts a new cluster in a page.
@@ -2475,7 +2594,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2497,7 +2618,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutclusters.list
         * @desc Retrieves the details of all clusters on the specified page.
@@ -2511,7 +2632,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2533,7 +2656,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutclusters.patch
         * @desc Updates a cluster. This method supports patch semantics.
@@ -2549,7 +2672,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2571,7 +2696,7 @@ function Androidenterprise(options) {
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutclusters.update
         * @desc Updates a cluster.
@@ -2587,7 +2712,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2609,7 +2736,7 @@ function Androidenterprise(options) {
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2627,7 +2754,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2649,7 +2778,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutpages.get
         * @desc Retrieves details of a store page.
@@ -2663,7 +2792,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2685,7 +2815,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutpages.insert
         * @desc Inserts a new store page.
@@ -2699,7 +2829,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2721,7 +2853,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutpages.list
         * @desc Retrieves the details of all pages in the store.
@@ -2734,7 +2866,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2756,7 +2890,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutpages.patch
         * @desc Updates the content of a store page. This method supports patch
@@ -2772,7 +2906,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2794,7 +2930,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.storelayoutpages.update
         * @desc Updates the content of a store page.
@@ -2809,7 +2945,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2831,7 +2969,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2849,7 +2987,9 @@ function Androidenterprise(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2871,7 +3011,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.generateAuthenticationToken
         * @desc Generates an authentication token which the device policy client
@@ -2888,7 +3028,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generateAuthenticationToken(params, options, callback) {
+    generateAuthenticationToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2910,7 +3052,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.generateToken
         * @desc Generates a token (activation code) to allow this user to
@@ -2927,7 +3069,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generateToken(params, options, callback) {
+    generateToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2949,7 +3093,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.get
         * @desc Retrieves a user's details.
@@ -2963,7 +3107,8 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2985,7 +3130,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.getAvailableProductSet
         * @desc Retrieves the set of products a user is entitled to access.
@@ -2999,7 +3144,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getAvailableProductSet(params, options, callback) {
+    getAvailableProductSet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3021,7 +3168,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.insert
         * @desc Creates a new EMM-managed user.  The Users resource passed in
@@ -3039,7 +3186,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3060,7 +3209,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.list
         * @desc Looks up a user by primary email address. This is only supported
@@ -3077,7 +3226,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3098,7 +3249,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.patch
         * @desc Updates the details of an EMM-managed user.  Can be used with
@@ -3117,7 +3268,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3139,7 +3292,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.revokeDeviceAccess
         * @desc Revokes access to all devices currently provisioned to the user.
@@ -3156,7 +3309,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    revokeDeviceAccess(params, options, callback) {
+    revokeDeviceAccess(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3178,7 +3333,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.revokeToken
         * @desc Revokes a previously generated token (activation code) for the
@@ -3193,7 +3348,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    revokeToken(params, options, callback) {
+    revokeToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3215,7 +3372,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.setAvailableProductSet
         * @desc Modifies the set of products that a user is entitled to access
@@ -3233,7 +3390,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setAvailableProductSet(params, options, callback) {
+    setAvailableProductSet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3255,7 +3414,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidenterprise.users.update
         * @desc Updates the details of an EMM-managed user.  Can be used with
@@ -3274,7 +3433,9 @@ function Androidenterprise(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3296,7 +3457,7 @@ function Androidenterprise(options) {
         pathParams: ['enterpriseId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/androidmanagement/v1.ts
+++ b/src/apis/androidmanagement/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Android Management API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Androidmanagement
  */
-function Androidmanagement(options) {
+function Androidmanagement(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.enterprises = {
@@ -52,7 +59,9 @@ function Androidmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Androidmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidmanagement.enterprises.get
         * @desc Gets an enterprise.
@@ -85,7 +94,8 @@ function Androidmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +115,7 @@ function Androidmanagement(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidmanagement.enterprises.patch
         * @desc Updates an enterprise.
@@ -120,7 +130,9 @@ function Androidmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +152,7 @@ function Androidmanagement(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     applications: {
       /**
@@ -156,7 +168,8 @@ function Androidmanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -176,7 +189,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -193,7 +206,9 @@ function Androidmanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -213,7 +228,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.devices.get
           * @desc Gets a device.
@@ -226,7 +241,8 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -246,7 +262,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.devices.issueCommand
           * @desc Issues a command to a device. The Operation resource returned
@@ -262,7 +278,9 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      issueCommand(params, options, callback) {
+      issueCommand(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -283,7 +301,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.devices.list
           * @desc Lists devices for a given enterprise.
@@ -298,7 +316,9 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -319,7 +339,7 @@ function Androidmanagement(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.devices.patch
           * @desc Updates a device.
@@ -334,7 +354,9 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -354,7 +376,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       operations: {
         /**
@@ -378,7 +400,9 @@ function Androidmanagement(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        cancel(params, options, callback) {
+        cancel(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -399,7 +423,7 @@ function Androidmanagement(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * androidmanagement.enterprises.devices.operations.delete
             * @desc Deletes a long-running operation. This method indicates that
@@ -415,7 +439,9 @@ function Androidmanagement(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -435,7 +461,7 @@ function Androidmanagement(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * androidmanagement.enterprises.devices.operations.get
             * @desc Gets the latest state of a long-running operation. Clients
@@ -450,7 +476,8 @@ function Androidmanagement(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -470,7 +497,7 @@ function Androidmanagement(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * androidmanagement.enterprises.devices.operations.list
             * @desc Lists operations that match the specified filter in the
@@ -495,7 +522,9 @@ function Androidmanagement(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -515,7 +544,7 @@ function Androidmanagement(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -534,7 +563,9 @@ function Androidmanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -555,7 +586,7 @@ function Androidmanagement(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.enrollmentTokens.delete
           * @desc Deletes an enrollment token. This operation invalidates the
@@ -569,7 +600,9 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -589,7 +622,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -607,7 +640,9 @@ function Androidmanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -627,7 +662,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.policies.get
           * @desc Gets a policy.
@@ -640,7 +675,8 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -660,7 +696,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.policies.list
           * @desc Lists policies for a given enterprise.
@@ -675,7 +711,9 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -696,7 +734,7 @@ function Androidmanagement(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidmanagement.enterprises.policies.patch
           * @desc Updates or creates a policy.
@@ -711,7 +749,9 @@ function Androidmanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -731,7 +771,7 @@ function Androidmanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -750,7 +790,9 @@ function Androidmanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -771,7 +813,7 @@ function Androidmanagement(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -790,7 +832,9 @@ function Androidmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -810,7 +854,7 @@ function Androidmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/androidpublisher/v1.1.ts
+++ b/src/apis/androidpublisher/v1.1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play Developer API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.1
  * @param {object=} options Options for Androidpublisher
  */
-function Androidpublisher(options) {
+function Androidpublisher(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.inapppurchases = {
@@ -49,7 +56,8 @@ function Androidpublisher(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +79,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'productId', 'token'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -91,7 +99,9 @@ function Androidpublisher(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -113,7 +123,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'subscriptionId', 'token'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.purchases.get
         * @desc Checks whether a user's subscription purchase is valid and
@@ -129,7 +139,8 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -151,7 +162,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'subscriptionId', 'token'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/androidpublisher/v1.ts
+++ b/src/apis/androidpublisher/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play Developer API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Androidpublisher
  */
-function Androidpublisher(options) {
+function Androidpublisher(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.purchases = {
@@ -50,7 +57,9 @@ function Androidpublisher(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'subscriptionId', 'token'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.purchases.get
         * @desc Checks whether a user's subscription purchase is valid and
@@ -88,7 +97,8 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +120,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'subscriptionId', 'token'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/androidpublisher/v2.ts
+++ b/src/apis/androidpublisher/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play Developer API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Androidpublisher
  */
-function Androidpublisher(options) {
+function Androidpublisher(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.edits = {
@@ -48,7 +55,9 @@ function Androidpublisher(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    commit(params, options, callback) {
+    commit(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Androidpublisher(options) {
         pathParams: ['editId', 'packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.edits.delete
         * @desc Deletes an edit for an app. Creating a new edit will
@@ -86,7 +95,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -108,7 +119,7 @@ function Androidpublisher(options) {
         pathParams: ['editId', 'packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.edits.get
         * @desc Returns information about the edit specified. Calls will fail if
@@ -124,7 +135,8 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -146,7 +158,7 @@ function Androidpublisher(options) {
         pathParams: ['editId', 'packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.edits.insert
         * @desc Creates a new edit for an app, populated with the app's current
@@ -161,7 +173,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -182,7 +196,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.edits.validate
         * @desc Checks that the edit can be successfully committed. The edit's
@@ -197,7 +211,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    validate(params, options, callback) {
+    validate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +235,7 @@ function Androidpublisher(options) {
         pathParams: ['editId', 'packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     apklistings: {
       /**
@@ -238,7 +254,9 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -261,7 +279,7 @@ function Androidpublisher(options) {
           pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.apklistings.deleteall
           * @desc Deletes all the APK-specific localized listings for a
@@ -277,7 +295,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      deleteall(params, options, callback) {
+      deleteall(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -299,7 +319,7 @@ function Androidpublisher(options) {
           pathParams: ['apkVersionCode', 'editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.apklistings.get
           * @desc Fetches the APK-specific localized listing for a specified APK
@@ -316,7 +336,8 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -339,7 +360,7 @@ function Androidpublisher(options) {
           pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.apklistings.list
           * @desc Lists all the APK-specific localized listings for a specified
@@ -355,7 +376,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -377,7 +400,7 @@ function Androidpublisher(options) {
           pathParams: ['apkVersionCode', 'editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.apklistings.patch
           * @desc Updates or creates the APK-specific localized listing for a
@@ -396,7 +419,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -419,7 +444,7 @@ function Androidpublisher(options) {
           pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.apklistings.update
           * @desc Updates or creates the APK-specific localized listing for a
@@ -437,7 +462,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -460,7 +487,7 @@ function Androidpublisher(options) {
           pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -482,7 +509,9 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      addexternallyhosted(params, options, callback) {
+      addexternallyhosted(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -504,7 +533,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.apks.list
           * @alias androidpublisher.edits.apks.list
@@ -517,7 +546,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -539,7 +570,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.apks.upload
           * @alias androidpublisher.edits.apks.upload
@@ -555,7 +586,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      upload(params, options, callback) {
+      upload(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -581,7 +614,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -605,7 +638,9 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      upload(params, options, callback) {
+      upload(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -635,7 +670,7 @@ function Androidpublisher(options) {
           ],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -654,7 +689,8 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -676,7 +712,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.details.patch
           * @desc Updates app details for this edit. This method supports patch
@@ -692,7 +728,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -714,7 +752,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.details.update
           * @desc Updates app details for this edit.
@@ -729,7 +767,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -751,7 +791,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -773,7 +813,8 @@ function Androidpublisher(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -799,7 +840,7 @@ function Androidpublisher(options) {
               ],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * androidpublisher.edits.expansionfiles.patch
               * @desc Updates the APK's Expansion File configuration to
@@ -819,7 +860,9 @@ function Androidpublisher(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -845,7 +888,7 @@ function Androidpublisher(options) {
               ],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * androidpublisher.edits.expansionfiles.update
               * @desc Updates the APK's Expansion File configuration to
@@ -864,7 +907,9 @@ function Androidpublisher(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -890,7 +935,7 @@ function Androidpublisher(options) {
               ],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * androidpublisher.edits.expansionfiles.upload
               * @desc Uploads and attaches a new Expansion File to the APK
@@ -910,7 +955,9 @@ function Androidpublisher(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          upload(params, options, callback) {
+          upload(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -940,7 +987,7 @@ function Androidpublisher(options) {
               ],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -961,7 +1008,9 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -985,7 +1034,7 @@ function Androidpublisher(options) {
               ['editId', 'imageId', 'imageType', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.images.deleteall
           * @desc Deletes all images for the specified language and image type.
@@ -1001,7 +1050,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      deleteall(params, options, callback) {
+      deleteall(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1023,7 +1074,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'imageType', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.images.list
           * @desc Lists all images for the specified language and image type.
@@ -1039,7 +1090,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1061,7 +1114,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'imageType', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.images.upload
           * @desc Uploads a new image and adds it to the list of images for the
@@ -1081,7 +1134,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      upload(params, options, callback) {
+      upload(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1107,7 +1162,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'imageType', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1126,7 +1181,9 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1148,7 +1205,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.listings.deleteall
           * @desc Deletes all localized listings from an edit.
@@ -1162,7 +1219,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      deleteall(params, options, callback) {
+      deleteall(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1184,7 +1243,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.listings.get
           * @desc Fetches information about a localized store listing.
@@ -1199,7 +1258,8 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1221,7 +1281,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.listings.list
           * @desc Returns all of the localized store listings attached to this
@@ -1236,7 +1296,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1258,7 +1320,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.listings.patch
           * @desc Creates or updates a localized store listing. This method
@@ -1275,7 +1337,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1297,7 +1361,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.listings.update
           * @desc Creates or updates a localized store listing.
@@ -1313,7 +1377,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1335,7 +1401,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'language', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1353,7 +1419,8 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1375,7 +1442,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName', 'track'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.testers.patch
           * @alias androidpublisher.edits.testers.patch
@@ -1390,7 +1457,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1412,7 +1481,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName', 'track'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.testers.update
           * @alias androidpublisher.edits.testers.update
@@ -1427,7 +1496,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1449,7 +1520,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName', 'track'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1469,7 +1540,8 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1491,7 +1563,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName', 'track'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.tracks.list
           * @desc Lists all the track configurations for this edit.
@@ -1505,7 +1577,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1527,7 +1601,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.tracks.patch
           * @desc Updates the track configuration for the specified track type.
@@ -1546,7 +1620,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1568,7 +1644,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName', 'track'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.edits.tracks.update
           * @desc Updates the track configuration for the specified track type.
@@ -1586,7 +1662,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1608,7 +1686,7 @@ function Androidpublisher(options) {
           pathParams: ['editId', 'packageName', 'track'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1630,7 +1708,9 @@ function Androidpublisher(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1652,7 +1732,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1670,7 +1750,9 @@ function Androidpublisher(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1692,7 +1774,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'sku'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.inappproducts.get
         * @desc Returns information about the in-app product specified.
@@ -1706,7 +1788,8 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1728,7 +1811,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'sku'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.inappproducts.insert
         * @desc Creates a new in-app product for an app.
@@ -1743,7 +1826,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1765,7 +1850,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.inappproducts.list
         * @desc List all the in-app products for an Android app, both
@@ -1782,7 +1867,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1804,7 +1891,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.inappproducts.patch
         * @desc Updates the details of an in-app product. This method supports
@@ -1821,7 +1908,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1843,7 +1932,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'sku'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.inappproducts.update
         * @desc Updates the details of an in-app product.
@@ -1859,7 +1948,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1881,7 +1972,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'sku'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1901,7 +1992,8 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1923,7 +2015,7 @@ function Androidpublisher(options) {
           pathParams: ['packageName', 'productId', 'token'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1943,7 +2035,9 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1965,7 +2059,7 @@ function Androidpublisher(options) {
           pathParams: ['packageName', 'subscriptionId', 'token'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.purchases.subscriptions.defer
           * @desc Defers a user's subscription purchase until a specified future
@@ -1982,7 +2076,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      defer(params, options, callback) {
+      defer(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2004,7 +2100,7 @@ function Androidpublisher(options) {
           pathParams: ['packageName', 'subscriptionId', 'token'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.purchases.subscriptions.get
           * @desc Checks whether a user's subscription purchase is valid and
@@ -2020,7 +2116,8 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2042,7 +2139,7 @@ function Androidpublisher(options) {
           pathParams: ['packageName', 'subscriptionId', 'token'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.purchases.subscriptions.refund
           * @desc Refunds a user's subscription purchase, but the subscription
@@ -2059,7 +2156,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      refund(params, options, callback) {
+      refund(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2081,7 +2180,7 @@ function Androidpublisher(options) {
           pathParams: ['packageName', 'subscriptionId', 'token'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * androidpublisher.purchases.subscriptions.revoke
           * @desc Refunds and immediately revokes a user's subscription
@@ -2098,7 +2197,9 @@ function Androidpublisher(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      revoke(params, options, callback) {
+      revoke(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2120,7 +2221,7 @@ function Androidpublisher(options) {
           pathParams: ['packageName', 'subscriptionId', 'token'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -2142,7 +2243,9 @@ function Androidpublisher(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2164,7 +2267,7 @@ function Androidpublisher(options) {
           pathParams: ['packageName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -2184,7 +2287,8 @@ function Androidpublisher(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2206,7 +2310,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'reviewId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.reviews.list
         * @desc Returns a list of reviews. Only reviews from last week will be
@@ -2224,7 +2328,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2245,7 +2351,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * androidpublisher.reviews.reply
         * @desc Reply to a single review, or update an existing reply.
@@ -2260,7 +2366,9 @@ function Androidpublisher(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reply(params, options, callback) {
+    reply(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2282,7 +2390,7 @@ function Androidpublisher(options) {
         pathParams: ['packageName', 'reviewId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/appengine/v1.ts
+++ b/src/apis/appengine/v1.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
 
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
+
 /**
- * Google App Engine Admin API
+ * App Engine Admin API
  *
  * The App Engine Admin API enables developers to provision and manage their App
  * Engine applications.
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Appengine
  */
-function Appengine(options) {
+function Appengine(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.apps =
@@ -55,7 +62,9 @@ function Appengine(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -75,7 +84,7 @@ function Appengine(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.get
             * @desc Gets information about an application.
@@ -88,7 +97,8 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -109,7 +119,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.patch
             * @desc Updates the specified Application resource. You can update
@@ -128,7 +138,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -149,7 +161,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.repair
             * @desc Recreates the required App Engine features for the specified
@@ -167,7 +179,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        repair(params, options, callback) {
+        repair(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -188,7 +202,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         authorizedCertificates: {
           /**
@@ -204,7 +218,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -225,7 +241,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.delete
               * @desc Deletes the specified SSL certificate.
@@ -239,7 +255,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -262,7 +280,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'authorizedCertificatesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.get
               * @desc Gets the specified SSL certificate.
@@ -277,7 +295,8 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -300,7 +319,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'authorizedCertificatesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.list
               * @desc Lists all SSL certificates the user is authorized to
@@ -317,7 +336,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -338,7 +359,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.patch
               * @desc Updates the specified SSL certificate. To renew a
@@ -358,7 +379,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -381,7 +404,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'authorizedCertificatesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -400,7 +423,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -421,7 +446,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -443,7 +468,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -464,7 +491,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.delete
               * @desc Deletes the specified domain mapping. A user must be
@@ -480,7 +507,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -502,7 +531,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'domainMappingsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.get
               * @desc Gets the specified domain mapping.
@@ -516,7 +545,8 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -538,7 +568,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'domainMappingsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.list
               * @desc Lists the domain mappings on an application.
@@ -553,7 +583,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -574,7 +606,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.patch
               * @desc Updates the specified domain mapping. To map an SSL
@@ -594,7 +626,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -616,7 +650,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'domainMappingsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -639,7 +673,9 @@ function Appengine(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            batchUpdate(params, options, callback) {
+            batchUpdate(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -662,7 +698,7 @@ function Appengine(options) {
                 pathParams: ['appsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.create
                 * @desc Creates a firewall rule for the application.
@@ -676,7 +712,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -697,7 +735,7 @@ function Appengine(options) {
                 pathParams: ['appsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.delete
                 * @desc Deletes the specified firewall rule.
@@ -711,7 +749,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -734,7 +774,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'ingressRulesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.get
                 * @desc Gets the specified firewall rule.
@@ -748,7 +788,8 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -771,7 +812,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'ingressRulesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.list
                 * @desc Lists the firewall rules of an application.
@@ -787,7 +828,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -808,7 +851,7 @@ function Appengine(options) {
                 pathParams: ['appsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.patch
                 * @desc Updates the specified firewall rule.
@@ -824,7 +867,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -847,7 +892,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'ingressRulesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -866,7 +911,8 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -887,7 +933,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'locationsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.locations.list
               * @desc Lists information about the supported locations for this
@@ -904,7 +950,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -925,7 +973,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -945,7 +993,8 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -967,7 +1016,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'operationsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.operations.list
               * @desc Lists operations that match the specified filter in the
@@ -993,7 +1042,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1014,7 +1065,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1032,7 +1083,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1053,7 +1106,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'servicesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.services.get
               * @desc Gets the current configuration of the specified service.
@@ -1067,7 +1120,8 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1088,7 +1142,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'servicesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.services.list
               * @desc Lists all the services in the application.
@@ -1103,7 +1157,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1124,7 +1180,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.services.patch
               * @desc Updates the configuration of the specified service.
@@ -1141,7 +1197,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1162,7 +1220,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'servicesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           versions: {
             /**
@@ -1179,7 +1237,9 @@ function Appengine(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1201,7 +1261,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.delete
                 * @desc Deletes an existing Version resource.
@@ -1216,7 +1276,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1239,7 +1301,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId', 'versionsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.get
                 * @desc Gets the specified Version resource. By default, only a
@@ -1257,7 +1319,8 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1280,7 +1343,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId', 'versionsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.list
                 * @desc Lists the versions of a service.
@@ -1297,7 +1360,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1319,7 +1384,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.patch
                 * @desc Updates the specified Version resource. You can specify
@@ -1368,7 +1433,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1391,7 +1458,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId', 'versionsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             },
             instances: {
               /**
@@ -1416,7 +1483,9 @@ function Appengine(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              debug(params, options, callback) {
+              debug(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1441,7 +1510,7 @@ function Appengine(options) {
                       ['appsId', 'instancesId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.versions.instances.delete
                   * @desc Stops a running instance.
@@ -1457,7 +1526,9 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1482,7 +1553,7 @@ function Appengine(options) {
                       ['appsId', 'instancesId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.versions.instances.get
                   * @desc Gets instance information.
@@ -1498,7 +1569,8 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1523,7 +1595,7 @@ function Appengine(options) {
                       ['appsId', 'instancesId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.versions.instances.list
                   * @desc Lists the instances of a version.Tip: To aggregate
@@ -1543,7 +1615,9 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1566,7 +1640,7 @@ function Appengine(options) {
                   pathParams: ['appsId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             }

--- a/src/apis/appengine/v1alpha.ts
+++ b/src/apis/appengine/v1alpha.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
 
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
+
 /**
- * Google App Engine Admin API
+ * App Engine Admin API
  *
  * The App Engine Admin API enables developers to provision and manage their App
  * Engine applications.
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1alpha
  * @param {object=} options Options for Appengine
  */
-function Appengine(options) {
+function Appengine(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.apps = {
@@ -50,7 +57,9 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -70,7 +79,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.authorizedCertificates.delete
           * @desc Deletes the specified SSL certificate.
@@ -84,7 +93,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -106,7 +117,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'authorizedCertificatesId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.authorizedCertificates.get
           * @desc Gets the specified SSL certificate.
@@ -121,7 +132,8 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -143,7 +155,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'authorizedCertificatesId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.authorizedCertificates.list
           * @desc Lists all SSL certificates the user is authorized to
@@ -160,7 +172,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -180,7 +194,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.authorizedCertificates.patch
           * @desc Updates the specified SSL certificate. To renew a certificate
@@ -200,7 +214,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -222,7 +238,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'authorizedCertificatesId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -241,7 +257,9 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -261,7 +279,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -284,7 +302,9 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -304,7 +324,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.domainMappings.delete
           * @desc Deletes the specified domain mapping. A user must be
@@ -320,7 +340,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -342,7 +364,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'domainMappingsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.domainMappings.get
           * @desc Gets the specified domain mapping.
@@ -356,7 +378,8 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -378,7 +401,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'domainMappingsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.domainMappings.list
           * @desc Lists the domain mappings on an application.
@@ -393,7 +416,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -413,7 +438,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.domainMappings.patch
           * @desc Updates the specified domain mapping. To map an SSL
@@ -434,7 +459,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -456,7 +483,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'domainMappingsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -474,7 +501,8 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -495,7 +523,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'locationsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.locations.list
           * @desc Lists information about the supported locations for this
@@ -512,7 +540,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -532,7 +562,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -552,7 +582,8 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -573,7 +604,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'operationsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.operations.list
           * @desc Lists operations that match the specified filter in the
@@ -598,7 +629,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -618,7 +651,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/appengine/v1beta.ts
+++ b/src/apis/appengine/v1beta.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
 
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
+
 /**
- * Google App Engine Admin API
+ * App Engine Admin API
  *
  * The App Engine Admin API enables developers to provision and manage their App
  * Engine applications.
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta
  * @param {object=} options Options for Appengine
  */
-function Appengine(options) {
+function Appengine(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.apps =
@@ -55,7 +62,9 @@ function Appengine(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -75,7 +84,7 @@ function Appengine(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.get
             * @desc Gets information about an application.
@@ -88,7 +97,8 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -109,7 +119,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.patch
             * @desc Updates the specified Application resource. You can update
@@ -128,7 +138,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -149,7 +161,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.repair
             * @desc Recreates the required App Engine features for the specified
@@ -167,7 +179,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        repair(params, options, callback) {
+        repair(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -188,7 +202,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         authorizedCertificates: {
           /**
@@ -204,7 +218,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -226,7 +242,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.delete
               * @desc Deletes the specified SSL certificate.
@@ -240,7 +256,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -263,7 +281,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'authorizedCertificatesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.get
               * @desc Gets the specified SSL certificate.
@@ -278,7 +296,8 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -301,7 +320,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'authorizedCertificatesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.list
               * @desc Lists all SSL certificates the user is authorized to
@@ -318,7 +337,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -340,7 +361,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.authorizedCertificates.patch
               * @desc Updates the specified SSL certificate. To renew a
@@ -360,7 +381,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -383,7 +406,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'authorizedCertificatesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -402,7 +425,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -423,7 +448,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -445,7 +470,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -466,7 +493,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.delete
               * @desc Deletes the specified domain mapping. A user must be
@@ -482,7 +509,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -505,7 +534,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'domainMappingsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.get
               * @desc Gets the specified domain mapping.
@@ -519,7 +548,8 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -542,7 +572,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'domainMappingsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.list
               * @desc Lists the domain mappings on an application.
@@ -557,7 +587,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -578,7 +610,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.domainMappings.patch
               * @desc Updates the specified domain mapping. To map an SSL
@@ -598,7 +630,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -621,7 +655,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'domainMappingsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -644,7 +678,9 @@ function Appengine(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            batchUpdate(params, options, callback) {
+            batchUpdate(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -667,7 +703,7 @@ function Appengine(options) {
                 pathParams: ['appsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.create
                 * @desc Creates a firewall rule for the application.
@@ -681,7 +717,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -703,7 +741,7 @@ function Appengine(options) {
                 pathParams: ['appsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.delete
                 * @desc Deletes the specified firewall rule.
@@ -717,7 +755,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -740,7 +780,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'ingressRulesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.get
                 * @desc Gets the specified firewall rule.
@@ -754,7 +794,8 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -777,7 +818,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'ingressRulesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.list
                 * @desc Lists the firewall rules of an application.
@@ -793,7 +834,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -815,7 +858,7 @@ function Appengine(options) {
                 pathParams: ['appsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.firewall.ingressRules.patch
                 * @desc Updates the specified firewall rule.
@@ -831,7 +874,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -854,7 +899,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'ingressRulesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -873,7 +918,8 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -895,7 +941,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'locationsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.locations.list
               * @desc Lists information about the supported locations for this
@@ -912,7 +958,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -933,7 +981,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -953,7 +1001,8 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -975,7 +1024,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'operationsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.operations.list
               * @desc Lists operations that match the specified filter in the
@@ -1001,7 +1050,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1022,7 +1073,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1040,7 +1091,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1062,7 +1115,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'servicesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.services.get
               * @desc Gets the current configuration of the specified service.
@@ -1076,7 +1129,8 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1098,7 +1152,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'servicesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.services.list
               * @desc Lists all the services in the application.
@@ -1113,7 +1167,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1134,7 +1190,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.services.patch
               * @desc Updates the configuration of the specified service.
@@ -1151,7 +1207,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1173,7 +1231,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'servicesId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           versions: {
             /**
@@ -1190,7 +1248,9 @@ function Appengine(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1213,7 +1273,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.delete
                 * @desc Deletes an existing Version resource.
@@ -1228,7 +1288,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1251,7 +1313,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId', 'versionsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.get
                 * @desc Gets the specified Version resource. By default, only a
@@ -1269,7 +1331,8 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1292,7 +1355,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId', 'versionsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.list
                 * @desc Lists the versions of a service.
@@ -1309,7 +1372,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1332,7 +1397,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * appengine.apps.services.versions.patch
                 * @desc Updates the specified Version resource. You can specify
@@ -1381,7 +1446,9 @@ function Appengine(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1404,7 +1471,7 @@ function Appengine(options) {
                 pathParams: ['appsId', 'servicesId', 'versionsId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             },
             instances: {
               /**
@@ -1429,7 +1496,9 @@ function Appengine(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              debug(params, options, callback) {
+              debug(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1454,7 +1523,7 @@ function Appengine(options) {
                       ['appsId', 'instancesId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.versions.instances.delete
                   * @desc Stops a running instance.
@@ -1470,7 +1539,9 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1495,7 +1566,7 @@ function Appengine(options) {
                       ['appsId', 'instancesId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.versions.instances.get
                   * @desc Gets instance information.
@@ -1511,7 +1582,8 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1536,7 +1608,7 @@ function Appengine(options) {
                       ['appsId', 'instancesId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.versions.instances.list
                   * @desc Lists the instances of a version.Tip: To aggregate
@@ -1556,7 +1628,9 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1579,7 +1653,7 @@ function Appengine(options) {
                   pathParams: ['appsId', 'servicesId', 'versionsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             }

--- a/src/apis/appengine/v1beta4.ts
+++ b/src/apis/appengine/v1beta4.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
 
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
+
 /**
- * Google App Engine Admin API
+ * App Engine Admin API
  *
  * The App Engine Admin API enables developers to provision and manage their App
  * Engine applications.
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta4
  * @param {object=} options Options for Appengine
  */
-function Appengine(options) {
+function Appengine(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.apps = {
@@ -54,7 +61,9 @@ function Appengine(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -73,7 +82,7 @@ function Appengine(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * appengine.apps.get
         * @desc Gets information about an application.
@@ -87,7 +96,8 @@ function Appengine(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +117,7 @@ function Appengine(options) {
         pathParams: ['appsId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * appengine.apps.patch
         * @desc Updates the specified Application resource. You can update the
@@ -126,7 +136,9 @@ function Appengine(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -146,7 +158,7 @@ function Appengine(options) {
         pathParams: ['appsId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     locations: {
       /**
@@ -162,7 +174,8 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -183,7 +196,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'locationsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.locations.list
           * @desc Lists information about the supported locations for this
@@ -200,7 +213,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -220,7 +235,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -238,7 +253,9 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -258,7 +275,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'modulesId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.modules.get
           * @desc Gets the current configuration of the specified module.
@@ -272,7 +289,8 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -292,7 +310,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'modulesId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.modules.list
           * @desc Lists all the modules in the application.
@@ -307,7 +325,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -327,7 +347,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.modules.patch
           * @desc Updates the configuration of the specified module.
@@ -344,7 +364,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -364,7 +386,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'modulesId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       versions: {
         /**
@@ -381,7 +403,9 @@ function Appengine(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -403,7 +427,7 @@ function Appengine(options) {
             pathParams: ['appsId', 'modulesId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.modules.versions.delete
             * @desc Deletes an existing version.
@@ -418,7 +442,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -441,7 +467,7 @@ function Appengine(options) {
             pathParams: ['appsId', 'modulesId', 'versionsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.modules.versions.get
             * @desc Gets the specified Version resource. By default, only a
@@ -459,7 +485,8 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -482,7 +509,7 @@ function Appengine(options) {
             pathParams: ['appsId', 'modulesId', 'versionsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.modules.versions.list
             * @desc Lists the versions of a module.
@@ -499,7 +526,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -521,7 +550,7 @@ function Appengine(options) {
             pathParams: ['appsId', 'modulesId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.modules.versions.patch
             * @desc Updates the specified Version resource. You can specify the
@@ -553,7 +582,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -576,7 +607,7 @@ function Appengine(options) {
             pathParams: ['appsId', 'modulesId', 'versionsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         instances: {
           /**
@@ -601,7 +632,9 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          debug(params, options, callback) {
+          debug(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -625,7 +658,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'instancesId', 'modulesId', 'versionsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.modules.versions.instances.delete
               * @desc Stops a running instance.
@@ -641,7 +674,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -665,7 +700,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'instancesId', 'modulesId', 'versionsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.modules.versions.instances.get
               * @desc Gets instance information.
@@ -681,7 +716,8 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -705,7 +741,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'instancesId', 'modulesId', 'versionsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.modules.versions.instances.list
               * @desc Lists the instances of a version.Tip: To aggregate details
@@ -724,7 +760,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -747,7 +785,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'modulesId', 'versionsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }
@@ -769,7 +807,8 @@ function Appengine(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -790,7 +829,7 @@ function Appengine(options) {
           pathParams: ['appsId', 'operationsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * appengine.apps.operations.list
           * @desc Lists operations that match the specified filter in the
@@ -815,7 +854,9 @@ function Appengine(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -835,7 +876,7 @@ function Appengine(options) {
           pathParams: ['appsId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/appengine/v1beta5.ts
+++ b/src/apis/appengine/v1beta5.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
 
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
+
 /**
- * Google App Engine Admin API
+ * App Engine Admin API
  *
  * The App Engine Admin API enables developers to provision and manage their App
  * Engine applications.
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta5
  * @param {object=} options Options for Appengine
  */
-function Appengine(options) {
+function Appengine(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.apps =
@@ -55,7 +62,9 @@ function Appengine(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -76,7 +85,7 @@ function Appengine(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.get
             * @desc Gets information about an application.
@@ -90,7 +99,8 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -111,7 +121,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * appengine.apps.patch
             * @desc Updates the specified Application resource. You can update
@@ -130,7 +140,9 @@ function Appengine(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -151,7 +163,7 @@ function Appengine(options) {
             pathParams: ['appsId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         locations: {
           /**
@@ -167,7 +179,8 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -189,7 +202,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'locationsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.locations.list
               * @desc Lists information about the supported locations for this
@@ -206,7 +219,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -227,7 +242,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -247,7 +262,8 @@ function Appengine(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -269,7 +285,7 @@ function Appengine(options) {
               pathParams: ['appsId', 'operationsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * appengine.apps.operations.list
               * @desc Lists operations that match the specified filter in the
@@ -295,7 +311,9 @@ function Appengine(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -316,7 +334,7 @@ function Appengine(options) {
               pathParams: ['appsId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -335,7 +353,9 @@ function Appengine(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -357,7 +377,7 @@ function Appengine(options) {
                   pathParams: ['appsId', 'servicesId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.get
                   * @desc Gets the current configuration of the specified
@@ -372,7 +392,8 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -394,7 +415,7 @@ function Appengine(options) {
                   pathParams: ['appsId', 'servicesId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.list
                   * @desc Lists all the services in the application.
@@ -409,7 +430,9 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -430,7 +453,7 @@ function Appengine(options) {
                   pathParams: ['appsId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * appengine.apps.services.patch
                   * @desc Updates the configuration of the specified service.
@@ -447,7 +470,9 @@ function Appengine(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              patch(params, options, callback) {
+              patch(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -469,7 +494,7 @@ function Appengine(options) {
                   pathParams: ['appsId', 'servicesId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               },
               versions: {
                 /**
@@ -486,7 +511,10 @@ function Appengine(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -509,7 +537,7 @@ function Appengine(options) {
                     pathParams: ['appsId', 'servicesId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * appengine.apps.services.versions.delete
                     * @desc Deletes an existing version.
@@ -524,7 +552,10 @@ function Appengine(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -547,7 +578,7 @@ function Appengine(options) {
                     pathParams: ['appsId', 'servicesId', 'versionsId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * appengine.apps.services.versions.get
                     * @desc Gets the specified Version resource. By default,
@@ -565,7 +596,9 @@ function Appengine(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -588,7 +621,7 @@ function Appengine(options) {
                     pathParams: ['appsId', 'servicesId', 'versionsId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * appengine.apps.services.versions.list
                     * @desc Lists the versions of a service.
@@ -605,7 +638,10 @@ function Appengine(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -628,7 +664,7 @@ function Appengine(options) {
                     pathParams: ['appsId', 'servicesId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * appengine.apps.services.versions.patch
                     * @desc Updates the specified Version resource. You can
@@ -662,7 +698,10 @@ function Appengine(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                patch(params, options, callback) {
+                patch(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -685,7 +724,7 @@ function Appengine(options) {
                     pathParams: ['appsId', 'servicesId', 'versionsId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 },
                 instances:
                     {
@@ -713,7 +752,10 @@ function Appengine(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      debug(params, options, callback) {
+                      debug(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -740,7 +782,7 @@ function Appengine(options) {
                           ],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * appengine.apps.services.versions.instances.delete
                           * @desc Stops a running instance.
@@ -757,7 +799,10 @@ function Appengine(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      delete (params, options, callback) {
+                      delete (
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -784,7 +829,7 @@ function Appengine(options) {
                           ],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * appengine.apps.services.versions.instances.get
                           * @desc Gets instance information.
@@ -801,7 +846,9 @@ function Appengine(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      get(params, options, callback) {
+                      get(params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -828,7 +875,7 @@ function Appengine(options) {
                           ],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * appengine.apps.services.versions.instances.list
                           * @desc Lists the instances of a version.Tip: To
@@ -849,7 +896,10 @@ function Appengine(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      list(params, options, callback) {
+                      list(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -873,7 +923,7 @@ function Appengine(options) {
                           pathParams: ['appsId', 'servicesId', 'versionsId'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     }

--- a/src/apis/appsactivity/v1.ts
+++ b/src/apis/appsactivity/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * G Suite Activity API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Appsactivity
  */
-function Appsactivity(options) {
+function Appsactivity(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.activities = {
@@ -58,7 +65,9 @@ function Appsactivity(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -78,7 +87,7 @@ function Appsactivity(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/appstate/v1.ts
+++ b/src/apis/appstate/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google App State API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Appstate
  */
-function Appstate(options) {
+function Appstate(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.states = {
@@ -50,7 +57,9 @@ function Appstate(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clear(params, options, callback) {
+    clear(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Appstate(options) {
         pathParams: ['stateKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * appstate.states.delete
         * @desc Deletes a key and the data associated with it. The key is
@@ -88,7 +97,9 @@ function Appstate(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -108,7 +119,7 @@ function Appstate(options) {
         pathParams: ['stateKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * appstate.states.get
         * @desc Retrieves the data corresponding to the passed key. If the key
@@ -122,7 +133,8 @@ function Appstate(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -142,7 +154,7 @@ function Appstate(options) {
         pathParams: ['stateKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * appstate.states.list
         * @desc Lists all the states keys, and optionally the state data.
@@ -155,7 +167,9 @@ function Appstate(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -175,7 +189,7 @@ function Appstate(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * appstate.states.update
         * @desc Update the data associated with the input key if and only if the
@@ -192,7 +206,9 @@ function Appstate(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -212,7 +228,7 @@ function Appstate(options) {
         pathParams: ['stateKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/bigquery/v2.ts
+++ b/src/apis/bigquery/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * BigQuery API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Bigquery
  */
-function Bigquery(options) {
+function Bigquery(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.datasets = {
@@ -105,7 +112,9 @@ function Bigquery(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -126,7 +135,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.datasets.get
         * @desc Returns the dataset specified by datasetID.
@@ -196,7 +205,8 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -217,7 +227,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.datasets.insert
         * @desc Creates a new empty dataset.
@@ -288,7 +298,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -308,7 +320,7 @@ function Bigquery(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.datasets.list
         * @desc Lists all datasets in the specified project to which you have
@@ -392,7 +404,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -412,7 +426,7 @@ function Bigquery(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.datasets.patch
         * @desc Updates information in an existing dataset. The update method
@@ -492,7 +506,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -513,7 +529,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.datasets.update
         * @desc Updates information in an existing dataset. The update method
@@ -592,7 +608,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -613,7 +631,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -691,7 +709,9 @@ function Bigquery(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -712,7 +732,7 @@ function Bigquery(options) {
         pathParams: ['jobId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.jobs.get
         * @desc Returns information about a specific job. Job information is
@@ -785,7 +805,8 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -805,7 +826,7 @@ function Bigquery(options) {
         pathParams: ['jobId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.jobs.getQueryResults
         * @desc Retrieves the results of a query job.
@@ -893,7 +914,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getQueryResults(params, options, callback) {
+    getQueryResults(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -914,7 +937,7 @@ function Bigquery(options) {
         pathParams: ['jobId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.jobs.insert
         * @desc Starts a new asynchronous job. Requires the Can View project
@@ -997,7 +1020,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1019,7 +1044,7 @@ function Bigquery(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.jobs.list
         * @desc Lists all jobs that you started in the specified project. Job
@@ -1098,7 +1123,9 @@ function Bigquery(options) {
         *
         * @param {object} params Parameters for request
         * @param {boolean=} params.allUsers Whether to display jobs owned by all users in the project. Default false
+        * @param {string=} params.maxCreationTime Max value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created before or at this timestamp are returned
         * @param {integer=} params.maxResults Maximum number of results to return
+        * @param {string=} params.minCreationTime Min value for job creation time, in milliseconds since the POSIX epoch. If set, only jobs created after or at this timestamp are returned
         * @param {string=} params.pageToken Page token, returned by a previous call, to request the next page of results
         * @param {string} params.projectId Project ID of the jobs to list
         * @param {string=} params.projection Restrict information returned to a set of selected fields
@@ -1107,7 +1134,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1127,7 +1156,7 @@ function Bigquery(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.jobs.query
         * @desc Runs a BigQuery SQL query synchronously and returns query
@@ -1199,7 +1228,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1219,7 +1250,7 @@ function Bigquery(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1290,7 +1321,9 @@ function Bigquery(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getServiceAccount(params, options, callback) {
+    getServiceAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1311,7 +1344,7 @@ function Bigquery(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.projects.list
         * @desc Lists all projects to which you have been granted any project
@@ -1389,7 +1422,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1409,7 +1444,7 @@ function Bigquery(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1493,7 +1528,9 @@ function Bigquery(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insertAll(params, options, callback) {
+    insertAll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1515,7 +1552,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.tabledata.list
         * @desc Retrieves table data from a specified set of rows. Requires the
@@ -1607,7 +1644,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1629,7 +1668,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1705,7 +1744,9 @@ function Bigquery(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1727,7 +1768,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.tables.get
         * @desc Gets the specified table resource by table ID. This method does
@@ -1804,7 +1845,8 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1826,7 +1868,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.tables.insert
         * @desc Creates a new, empty table in the dataset.
@@ -1901,7 +1943,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1923,7 +1967,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.tables.list
         * @desc Lists all tables in the specified dataset. Requires the READER
@@ -2009,7 +2053,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2031,7 +2077,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.tables.patch
         * @desc Updates information in an existing table. The update method
@@ -2115,7 +2161,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2137,7 +2185,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * bigquery.tables.update
         * @desc Updates information in an existing table. The update method
@@ -2220,7 +2268,9 @@ function Bigquery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2242,7 +2292,7 @@ function Bigquery(options) {
         pathParams: ['datasetId', 'projectId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/bigquerydatatransfer/v1.ts
+++ b/src/apis/bigquerydatatransfer/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * BigQuery Data Transfer API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Bigquerydatatransfer
  */
-function Bigquerydatatransfer(options) {
+function Bigquerydatatransfer(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -54,7 +61,9 @@ function Bigquerydatatransfer(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      checkValidCreds(params, options, callback) {
+      checkValidCreds(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -75,7 +84,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.dataSources.get
           * @desc Retrieves a supported data source and returns its settings,
@@ -89,7 +98,8 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -109,7 +119,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.dataSources.list
           * @desc Lists supported data sources and returns their settings, which
@@ -125,7 +135,9 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -146,7 +158,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -163,7 +175,8 @@ function Bigquerydatatransfer(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -183,7 +196,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.locations.list
           * @desc Lists information about the supported locations for this
@@ -200,7 +213,9 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -221,7 +236,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       dataSources: {
         /**
@@ -242,7 +257,9 @@ function Bigquerydatatransfer(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        checkValidCreds(params, options, callback) {
+        checkValidCreds(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -263,7 +280,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.locations.dataSources.get
             * @desc Retrieves a supported data source and returns its settings,
@@ -277,7 +294,8 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -297,7 +315,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.locations.dataSources.list
             * @desc Lists supported data sources and returns their settings,
@@ -313,7 +331,9 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -334,7 +354,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -353,7 +373,9 @@ function Bigquerydatatransfer(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -374,7 +396,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.locations.transferConfigs.delete
             * @desc Deletes a data transfer configuration, including any
@@ -389,7 +411,9 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -409,7 +433,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.locations.transferConfigs.get
             * @desc Returns information about a data transfer config.
@@ -422,7 +446,8 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -442,7 +467,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.locations.transferConfigs.list
             * @desc Returns information about all data transfers in the project.
@@ -459,7 +484,9 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -480,7 +507,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.locations.transferConfigs.patch
             * @desc Updates a data transfer configuration. All fields must be
@@ -498,7 +525,9 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -518,7 +547,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.locations.transferConfigs.scheduleRuns
             * @desc Creates transfer runs for a time range [start_time,
@@ -536,7 +565,9 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        scheduleRuns(params, options, callback) {
+        scheduleRuns(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -557,7 +588,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         runs: {
           /**
@@ -573,7 +604,9 @@ function Bigquerydatatransfer(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -593,7 +626,7 @@ function Bigquerydatatransfer(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * bigquerydatatransfer.projects.locations.transferConfigs.runs.get
               * @desc Returns information about the particular transfer run.
@@ -607,7 +640,8 @@ function Bigquerydatatransfer(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -627,7 +661,7 @@ function Bigquerydatatransfer(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * bigquerydatatransfer.projects.locations.transferConfigs.runs.list
               * @desc Returns information about running and completed jobs.
@@ -645,7 +679,9 @@ function Bigquerydatatransfer(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -666,7 +702,7 @@ function Bigquerydatatransfer(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           transferLogs: {
             /**
@@ -685,7 +721,9 @@ function Bigquerydatatransfer(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -706,7 +744,7 @@ function Bigquerydatatransfer(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -728,7 +766,9 @@ function Bigquerydatatransfer(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -749,7 +789,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.transferConfigs.delete
           * @desc Deletes a data transfer configuration, including any
@@ -763,7 +803,9 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -783,7 +825,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.transferConfigs.get
           * @desc Returns information about a data transfer config.
@@ -796,7 +838,8 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -816,7 +859,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.transferConfigs.list
           * @desc Returns information about all data transfers in the project.
@@ -832,7 +875,9 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -853,7 +898,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.transferConfigs.patch
           * @desc Updates a data transfer configuration. All fields must be set,
@@ -870,7 +915,9 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -890,7 +937,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * bigquerydatatransfer.projects.transferConfigs.scheduleRuns
           * @desc Creates transfer runs for a time range [start_time, end_time].
@@ -907,7 +954,9 @@ function Bigquerydatatransfer(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      scheduleRuns(params, options, callback) {
+      scheduleRuns(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -928,7 +977,7 @@ function Bigquerydatatransfer(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       runs: {
         /**
@@ -943,7 +992,9 @@ function Bigquerydatatransfer(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -963,7 +1014,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.transferConfigs.runs.get
             * @desc Returns information about the particular transfer run.
@@ -976,7 +1027,8 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -996,7 +1048,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * bigquerydatatransfer.projects.transferConfigs.runs.list
             * @desc Returns information about running and completed jobs.
@@ -1013,7 +1065,9 @@ function Bigquerydatatransfer(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1034,7 +1088,7 @@ function Bigquerydatatransfer(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         transferLogs: {
           /**
@@ -1053,7 +1107,9 @@ function Bigquerydatatransfer(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1074,7 +1130,7 @@ function Bigquerydatatransfer(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }

--- a/src/apis/blogger/v2.ts
+++ b/src/apis/blogger/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Blogger API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Blogger
  */
-function Blogger(options) {
+function Blogger(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.blogs = {
@@ -47,7 +54,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -86,7 +94,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -108,7 +117,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'commentId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.comments.list
         * @desc Retrieves the comments for a blog, possibly filtered.
@@ -126,7 +135,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +158,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -165,7 +176,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -185,7 +197,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.list
         * @desc Retrieves pages for a blog, possibly filtered.
@@ -199,7 +211,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +233,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -237,7 +251,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -257,7 +272,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.list
         * @desc Retrieves a list of posts, possibly filtered.
@@ -274,7 +289,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -294,7 +311,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -311,7 +328,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -331,7 +349,7 @@ function Blogger(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     blogs: {
       /**
@@ -346,7 +364,9 @@ function Blogger(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -366,7 +386,7 @@ function Blogger(options) {
           pathParams: ['userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/blogger/v3.ts
+++ b/src/apis/blogger/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Blogger API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Blogger
  */
-function Blogger(options) {
+function Blogger(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.blogs = {
@@ -49,7 +56,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.blogs.getByUrl
         * @desc Retrieve a Blog by URL.
@@ -83,7 +91,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getByUrl(params, options, callback) {
+    getByUrl(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -103,7 +113,7 @@ function Blogger(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.blogs.listByUser
         * @desc Retrieves a list of blogs, possibly filtered.
@@ -120,7 +130,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listByUser(params, options, callback) {
+    listByUser(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +152,7 @@ function Blogger(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -159,7 +171,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -179,7 +192,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -198,7 +211,9 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    approve(params, options, callback) {
+    approve(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -220,7 +235,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'commentId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.comments.delete
         * @desc Delete a comment by ID.
@@ -235,7 +250,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -257,7 +274,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'commentId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.comments.get
         * @desc Gets one comment by ID.
@@ -273,7 +290,8 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -295,7 +313,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'commentId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.comments.list
         * @desc Retrieves the comments for a post, possibly filtered.
@@ -316,7 +334,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -337,7 +357,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.comments.listByBlog
         * @desc Retrieves the comments for a blog, across all posts, possibly
@@ -357,7 +377,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listByBlog(params, options, callback) {
+    listByBlog(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -377,7 +399,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.comments.markAsSpam
         * @desc Marks a comment as spam.
@@ -392,7 +414,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    markAsSpam(params, options, callback) {
+    markAsSpam(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -414,7 +438,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'commentId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.comments.removeContent
         * @desc Removes the content of a comment.
@@ -429,7 +453,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeContent(params, options, callback) {
+    removeContent(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -451,7 +477,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'commentId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -469,7 +495,9 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -489,7 +517,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.get
         * @desc Gets one blog page by ID.
@@ -504,7 +532,8 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -524,7 +553,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.insert
         * @desc Add a page.
@@ -539,7 +568,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -559,7 +590,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.list
         * @desc Retrieves the pages for a blog, optionally including non-LIVE
@@ -578,7 +609,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -598,7 +631,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.patch
         * @desc Update a page. This method supports patch semantics.
@@ -615,7 +648,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -635,7 +670,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.publish
         * @desc Publishes a draft page.
@@ -649,7 +684,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    publish(params, options, callback) {
+    publish(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -670,7 +707,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.revert
         * @desc Revert a published or scheduled page to draft state.
@@ -684,7 +721,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    revert(params, options, callback) {
+    revert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -705,7 +744,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.pages.update
         * @desc Update a page.
@@ -722,7 +761,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -742,7 +783,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'pageId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -760,7 +801,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -780,7 +822,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -798,7 +840,9 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -818,7 +862,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.get
         * @desc Get a post by ID.
@@ -836,7 +880,8 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -856,7 +901,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.getByPath
         * @desc Retrieve a Post by Path.
@@ -872,7 +917,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getByPath(params, options, callback) {
+    getByPath(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -892,7 +939,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.insert
         * @desc Add a post.
@@ -909,7 +956,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -929,7 +978,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.list
         * @desc Retrieves a list of posts, possibly filtered.
@@ -952,7 +1001,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -972,7 +1023,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.patch
         * @desc Update a post. This method supports patch semantics.
@@ -992,7 +1043,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1012,7 +1065,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.publish
         * @desc Publishes a draft post, optionally at the specific time of the
@@ -1028,7 +1081,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    publish(params, options, callback) {
+    publish(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1049,7 +1104,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.revert
         * @desc Revert a published or scheduled post to draft state.
@@ -1063,7 +1118,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    revert(params, options, callback) {
+    revert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1084,7 +1141,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.search
         * @desc Search for a post.
@@ -1100,7 +1157,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1120,7 +1179,7 @@ function Blogger(options) {
         pathParams: ['blogId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.posts.update
         * @desc Update a post.
@@ -1140,7 +1199,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1160,7 +1221,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1182,7 +1243,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1203,7 +1265,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'postId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * blogger.postUserInfos.list
         * @desc Retrieves a list of post and post user info pairs, possibly
@@ -1228,7 +1290,9 @@ function Blogger(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1248,7 +1312,7 @@ function Blogger(options) {
         pathParams: ['blogId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1265,7 +1329,8 @@ function Blogger(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1285,7 +1350,7 @@ function Blogger(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/books/v1.ts
+++ b/src/apis/books/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Books API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Books
  */
-function Books(options) {
+function Books(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.bookshelves = {
@@ -49,7 +56,8 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Books(options) {
         pathParams: ['shelf', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.bookshelves.list
         * @desc Retrieves a list of public bookshelves for the specified user.
@@ -83,7 +91,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -103,7 +113,7 @@ function Books(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     volumes: {
       /**
@@ -123,7 +133,9 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -144,7 +156,7 @@ function Books(options) {
           pathParams: ['shelf', 'userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -164,7 +176,9 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addBook(params, options, callback) {
+    addBook(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -184,7 +198,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.cloudloading.deleteBook
         * @desc Remove the book and its contents
@@ -197,7 +211,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteBook(params, options, callback) {
+    deleteBook(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -217,7 +233,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.cloudloading.updateBook
         * @alias books.cloudloading.updateBook
@@ -229,7 +245,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateBook(params, options, callback) {
+    updateBook(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -249,7 +267,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -266,7 +284,9 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    listOfflineMetadata(params, options, callback) {
+    listOfflineMetadata(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -286,7 +306,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -303,7 +323,9 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getFamilyInfo(params, options, callback) {
+    getFamilyInfo(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -323,7 +345,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.familysharing.share
         * @desc Initiates sharing of the content with the user's family. Empty
@@ -339,7 +361,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    share(params, options, callback) {
+    share(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -359,7 +383,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.familysharing.unshare
         * @desc Initiates revoking content that has already been shared with the
@@ -375,7 +399,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    unshare(params, options, callback) {
+    unshare(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -395,7 +421,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -415,7 +441,8 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -436,7 +463,7 @@ function Books(options) {
         pathParams: ['summaryId', 'volumeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.layers.list
         * @desc List the layer summaries for a volume.
@@ -453,7 +480,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -473,7 +502,7 @@ function Books(options) {
         pathParams: ['volumeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     annotationData: {
       /**
@@ -497,7 +526,8 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -520,7 +550,7 @@ function Books(options) {
           pathParams: ['annotationDataId', 'layerId', 'volumeId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.layers.annotationData.list
           * @desc Gets the annotation data for a volume and layer.
@@ -545,7 +575,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -566,7 +598,7 @@ function Books(options) {
           pathParams: ['layerId', 'volumeId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -587,7 +619,8 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -609,7 +642,7 @@ function Books(options) {
           pathParams: ['annotationId', 'layerId', 'volumeId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.layers.volumeAnnotations.list
           * @desc Gets the volume annotations for a volume and layer.
@@ -636,7 +669,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -656,7 +691,7 @@ function Books(options) {
           pathParams: ['layerId', 'volumeId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -673,7 +708,9 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getUserSettings(params, options, callback) {
+    getUserSettings(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -693,7 +730,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.myconfig.releaseDownloadAccess
         * @desc Release downloaded content access restriction.
@@ -709,7 +746,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    releaseDownloadAccess(params, options, callback) {
+    releaseDownloadAccess(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -729,7 +768,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.myconfig.requestAccess
         * @desc Request concurrent and download access restrictions.
@@ -747,7 +786,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    requestAccess(params, options, callback) {
+    requestAccess(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -767,7 +808,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.myconfig.syncVolumeLicenses
         * @desc Request downloaded content access for specified volumes on the
@@ -788,7 +829,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    syncVolumeLicenses(params, options, callback) {
+    syncVolumeLicenses(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -808,7 +851,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.myconfig.updateUserSettings
         * @desc Sets the settings for the user. If a sub-object is specified, it
@@ -823,7 +866,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateUserSettings(params, options, callback) {
+    updateUserSettings(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -843,7 +888,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -862,7 +907,9 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -883,7 +930,7 @@ function Books(options) {
           pathParams: ['annotationId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.annotations.insert
           * @desc Inserts a new annotation.
@@ -900,7 +947,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      insert(params, options, callback) {
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -920,7 +969,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.annotations.list
           * @desc Retrieves a list of annotations, possibly filtered.
@@ -942,7 +991,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -962,7 +1013,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.annotations.summary
           * @desc Gets the summary of specified layers.
@@ -976,7 +1027,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      summary(params, options, callback) {
+      summary(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -996,7 +1049,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.annotations.update
           * @desc Updates an existing annotation.
@@ -1011,7 +1064,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1032,7 +1087,7 @@ function Books(options) {
           pathParams: ['annotationId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1052,7 +1107,9 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      addVolume(params, options, callback) {
+      addVolume(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1073,7 +1130,7 @@ function Books(options) {
           pathParams: ['shelf'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.bookshelves.clearVolumes
           * @desc Clears all volumes from a bookshelf.
@@ -1087,7 +1144,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      clearVolumes(params, options, callback) {
+      clearVolumes(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1108,7 +1167,7 @@ function Books(options) {
           pathParams: ['shelf'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.bookshelves.get
           * @desc Retrieves metadata for a specific bookshelf belonging to the
@@ -1123,7 +1182,8 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1143,7 +1203,7 @@ function Books(options) {
           pathParams: ['shelf'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.bookshelves.list
           * @desc Retrieves a list of bookshelves belonging to the authenticated
@@ -1157,7 +1217,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1177,7 +1239,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.bookshelves.moveVolume
           * @desc Moves a volume within a bookshelf.
@@ -1193,7 +1255,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      moveVolume(params, options, callback) {
+      moveVolume(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1214,7 +1278,7 @@ function Books(options) {
           pathParams: ['shelf'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.bookshelves.removeVolume
           * @desc Removes a volume from a bookshelf.
@@ -1230,7 +1294,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      removeVolume(params, options, callback) {
+      removeVolume(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1251,7 +1317,7 @@ function Books(options) {
           pathParams: ['shelf'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       volumes: {
         /**
@@ -1273,7 +1339,9 @@ function Books(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1294,7 +1362,7 @@ function Books(options) {
             pathParams: ['shelf'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -1314,7 +1382,8 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1335,7 +1404,7 @@ function Books(options) {
           pathParams: ['volumeId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.mylibrary.readingpositions.setPosition
           * @desc Sets my reading position information for a volume.
@@ -1354,7 +1423,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setPosition(params, options, callback) {
+      setPosition(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1376,7 +1447,7 @@ function Books(options) {
           pathParams: ['volumeId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1396,7 +1467,8 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1416,7 +1488,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1433,7 +1505,9 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    listCategories(params, options, callback) {
+    listCategories(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1453,7 +1527,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.onboarding.listCategoryVolumes
         * @desc List available volumes under categories for onboarding
@@ -1471,7 +1545,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listCategoryVolumes(params, options, callback) {
+    listCategoryVolumes(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1491,7 +1567,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1510,7 +1586,8 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1530,7 +1607,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1553,7 +1630,9 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    accept(params, options, callback) {
+    accept(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1573,7 +1652,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.promooffer.dismiss
         * @alias books.promooffer.dismiss
@@ -1591,7 +1670,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    dismiss(params, options, callback) {
+    dismiss(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1611,7 +1692,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.promooffer.get
         * @desc Returns a list of promo offers available to the user
@@ -1629,7 +1710,8 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1649,7 +1731,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1666,7 +1748,8 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1686,7 +1769,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     membership: {
       /**
@@ -1703,7 +1786,8 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1723,7 +1807,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1747,7 +1831,8 @@ function Books(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1767,7 +1852,7 @@ function Books(options) {
         pathParams: ['volumeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * books.volumes.list
         * @desc Performs a book search.
@@ -1793,7 +1878,9 @@ function Books(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1813,7 +1900,7 @@ function Books(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     associated: {
       /**
@@ -1832,7 +1919,9 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1852,7 +1941,7 @@ function Books(options) {
           pathParams: ['volumeId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1875,7 +1964,9 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1895,7 +1986,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1914,7 +2005,9 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1934,7 +2027,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * books.volumes.recommended.rate
           * @desc Rate a recommended book for the current user.
@@ -1950,7 +2043,9 @@ function Books(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      rate(params, options, callback) {
+      rate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1970,7 +2065,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1992,7 +2087,9 @@ function Books(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2012,7 +2109,7 @@ function Books(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/calendar/v3.ts
+++ b/src/apis/calendar/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Calendar API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Calendar
  */
-function Calendar(options) {
+function Calendar(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.acl = {
@@ -48,7 +55,9 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'ruleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.acl.get
         * @desc Returns an access control rule.
@@ -83,7 +92,8 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +114,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'ruleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.acl.insert
         * @desc Creates an access control rule.
@@ -119,7 +129,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +151,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.acl.list
         * @desc Returns the rules in the access control list for the calendar.
@@ -156,7 +168,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -176,7 +190,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.acl.patch
         * @desc Updates an access control rule. This method supports patch
@@ -193,7 +207,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -214,7 +230,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'ruleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.acl.update
         * @desc Updates an access control rule.
@@ -230,7 +246,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -251,7 +269,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'ruleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.acl.watch
         * @desc Watch for changes to ACL resources.
@@ -269,7 +287,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -289,7 +309,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -306,7 +326,9 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -326,7 +348,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendarList.get
         * @desc Returns an entry on the user's calendar list.
@@ -339,7 +361,8 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -359,7 +382,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendarList.insert
         * @desc Adds an entry to the user's calendar list.
@@ -373,7 +396,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -393,7 +418,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendarList.list
         * @desc Returns entries on the user's calendar list.
@@ -411,7 +436,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -431,7 +458,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendarList.patch
         * @desc Updates an entry on the user's calendar list. This method
@@ -447,7 +474,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -467,7 +496,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendarList.update
         * @desc Updates an entry on the user's calendar list.
@@ -482,7 +511,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -502,7 +533,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendarList.watch
         * @desc Watch for changes to CalendarList resources.
@@ -521,7 +552,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -541,7 +574,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -559,7 +592,9 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clear(params, options, callback) {
+    clear(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -579,7 +614,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendars.delete
         * @desc Deletes a secondary calendar. Use calendars.clear for clearing
@@ -593,7 +628,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -613,7 +650,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendars.get
         * @desc Returns metadata for a calendar.
@@ -626,7 +663,8 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -646,7 +684,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendars.insert
         * @desc Creates a secondary calendar.
@@ -659,7 +697,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -679,7 +719,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendars.patch
         * @desc Updates metadata for a calendar. This method supports patch
@@ -694,7 +734,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -714,7 +756,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.calendars.update
         * @desc Updates metadata for a calendar.
@@ -728,7 +770,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -748,7 +792,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -765,7 +809,9 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -785,7 +831,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -801,7 +847,8 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -821,7 +868,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -840,7 +887,9 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -861,7 +910,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.get
         * @desc Returns an event.
@@ -878,7 +927,8 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -899,7 +949,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.import
         * @desc Imports an event. This operation is used to add a private copy
@@ -916,7 +966,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    import(params, options, callback) {
+    import(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -937,7 +989,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.insert
         * @desc Creates an event.
@@ -955,7 +1007,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -975,7 +1029,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.instances
         * @desc Returns instances of the specified recurring event.
@@ -998,7 +1052,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    instances(params, options, callback) {
+    instances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1020,7 +1076,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.list
         * @desc Returns events on the specified calendar.
@@ -1050,7 +1106,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1070,7 +1128,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.move
         * @desc Moves an event to another calendar, i.e. changes an event's
@@ -1087,7 +1145,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    move(params, options, callback) {
+    move(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1108,7 +1168,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.patch
         * @desc Updates an event. This method supports patch semantics.
@@ -1128,7 +1188,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1149,7 +1211,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.quickAdd
         * @desc Creates an event based on a simple text string.
@@ -1164,7 +1226,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    quickAdd(params, options, callback) {
+    quickAdd(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1185,7 +1249,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.update
         * @desc Updates an event.
@@ -1205,7 +1269,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1226,7 +1292,7 @@ function Calendar(options) {
         pathParams: ['calendarId', 'eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.events.watch
         * @desc Watch for changes to Events resources.
@@ -1257,7 +1323,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1278,7 +1346,7 @@ function Calendar(options) {
         pathParams: ['calendarId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1295,7 +1363,9 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1315,7 +1385,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1332,7 +1402,8 @@ function Calendar(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1352,7 +1423,7 @@ function Calendar(options) {
         pathParams: ['setting'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.settings.list
         * @desc Returns all user settings for the authenticated user.
@@ -1367,7 +1438,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1387,7 +1460,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * calendar.settings.watch
         * @desc Watch for changes to Settings resources.
@@ -1403,7 +1476,9 @@ function Calendar(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1423,7 +1498,7 @@ function Calendar(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/chat/v1.ts
+++ b/src/apis/chat/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Hangouts Chat API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Chat
  */
-function Chat(options) {
+function Chat(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.dms = {
@@ -51,7 +58,9 @@ function Chat(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -71,7 +80,7 @@ function Chat(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -91,7 +100,9 @@ function Chat(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -111,7 +122,7 @@ function Chat(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -133,7 +144,9 @@ function Chat(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -153,7 +166,7 @@ function Chat(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -173,7 +186,9 @@ function Chat(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -193,7 +208,7 @@ function Chat(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -211,7 +226,8 @@ function Chat(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -230,7 +246,7 @@ function Chat(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * chat.spaces.list
         * @desc Lists spaces the caller is a member of.
@@ -244,7 +260,9 @@ function Chat(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -263,7 +281,7 @@ function Chat(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     members: {
       /**
@@ -278,7 +296,8 @@ function Chat(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -297,7 +316,7 @@ function Chat(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * chat.spaces.members.list
           * @desc Lists human memberships in a space.
@@ -312,7 +331,9 @@ function Chat(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -332,7 +353,7 @@ function Chat(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -351,7 +372,9 @@ function Chat(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -371,7 +394,7 @@ function Chat(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * chat.spaces.messages.delete
           * @desc Deletes a message.
@@ -384,7 +407,9 @@ function Chat(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -403,7 +428,7 @@ function Chat(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * chat.spaces.messages.get
           * @desc Returns a message.
@@ -416,7 +441,8 @@ function Chat(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -435,7 +461,7 @@ function Chat(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * chat.spaces.messages.update
           * @desc Updates a message.
@@ -450,7 +476,9 @@ function Chat(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -469,7 +497,7 @@ function Chat(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/civicinfo/v2.ts
+++ b/src/apis/civicinfo/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Civic Information API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Civicinfo
  */
-function Civicinfo(options) {
+function Civicinfo(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.divisions = {
@@ -49,7 +56,9 @@ function Civicinfo(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Civicinfo(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -86,7 +95,9 @@ function Civicinfo(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    electionQuery(params, options, callback) {
+    electionQuery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -106,7 +117,7 @@ function Civicinfo(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * civicinfo.elections.voterInfoQuery
         * @desc Looks up information relevant to a voter based on the voter's
@@ -124,7 +135,9 @@ function Civicinfo(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    voterInfoQuery(params, options, callback) {
+    voterInfoQuery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -144,7 +157,7 @@ function Civicinfo(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -166,7 +179,9 @@ function Civicinfo(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    representativeInfoByAddress(params, options, callback) {
+    representativeInfoByAddress(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -186,7 +201,7 @@ function Civicinfo(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * civicinfo.representatives.representativeInfoByDivision
         * @desc Looks up representative information for a single geographic
@@ -204,7 +219,9 @@ function Civicinfo(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    representativeInfoByDivision(params, options, callback) {
+    representativeInfoByDivision(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -224,7 +241,7 @@ function Civicinfo(options) {
         pathParams: ['ocdId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/classroom/v1.ts
+++ b/src/apis/classroom/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Classroom API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Classroom
  */
-function Classroom(options) {
+function Classroom(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.courses =
@@ -56,7 +63,9 @@ function Classroom(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -76,7 +85,7 @@ function Classroom(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * classroom.courses.delete
             * @desc Deletes a course.  This method returns the following error
@@ -92,7 +101,9 @@ function Classroom(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -113,7 +124,7 @@ function Classroom(options) {
             pathParams: ['id'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * classroom.courses.get
             * @desc Returns a course.  This method returns the following error
@@ -129,7 +140,8 @@ function Classroom(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -150,7 +162,7 @@ function Classroom(options) {
             pathParams: ['id'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * classroom.courses.list
             * @desc Returns a list of courses that the requesting user is
@@ -174,7 +186,9 @@ function Classroom(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -194,7 +208,7 @@ function Classroom(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * classroom.courses.patch
             * @desc Updates one or more fields in a course.  This method returns
@@ -216,7 +230,9 @@ function Classroom(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -237,7 +253,7 @@ function Classroom(options) {
             pathParams: ['id'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * classroom.courses.update
             * @desc Updates a course.  This method returns the following error
@@ -256,7 +272,9 @@ function Classroom(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -277,7 +295,7 @@ function Classroom(options) {
             pathParams: ['id'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         aliases: {
           /**
@@ -300,7 +318,9 @@ function Classroom(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -321,7 +341,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.aliases.delete
               * @desc Deletes an alias of a course.  This method returns the
@@ -341,7 +361,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -362,7 +384,7 @@ function Classroom(options) {
               pathParams: ['alias', 'courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.aliases.list
               * @desc Returns a list of aliases for a course.  This method
@@ -380,7 +402,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -401,7 +425,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -426,7 +450,9 @@ function Classroom(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -447,7 +473,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.announcements.delete
               * @desc Deletes an announcement.  This request must be made by the
@@ -471,7 +497,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -492,7 +520,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.announcements.get
               * @desc Returns an announcement.  This method returns the
@@ -511,7 +539,8 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -532,7 +561,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.announcements.list
               * @desc Returns a list of announcements that the requester is
@@ -556,7 +585,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -577,7 +608,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.announcements.modifyAssignees
               * @desc Modifies assignee mode and options of an announcement.
@@ -599,7 +630,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          modifyAssignees(params, options, callback) {
+          modifyAssignees(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -622,7 +655,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.announcements.patch
               * @desc Updates one or more fields of an announcement.  This
@@ -645,7 +678,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -666,7 +701,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -697,7 +732,9 @@ function Classroom(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -718,7 +755,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.courseWork.delete
               * @desc Deletes a course work.  This request must be made by the
@@ -742,7 +779,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -763,7 +802,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.courseWork.get
               * @desc Returns course work.  This method returns the following
@@ -782,7 +821,8 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -803,7 +843,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.courseWork.list
               * @desc Returns a list of course work that the requester is
@@ -827,7 +867,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -848,7 +890,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.courseWork.modifyAssignees
               * @desc Modifies assignee mode and options of a coursework.  Only
@@ -869,7 +911,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          modifyAssignees(params, options, callback) {
+          modifyAssignees(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -892,7 +936,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.courseWork.patch
               * @desc Updates one or more fields of a course work.  See
@@ -921,7 +965,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -942,7 +988,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           studentSubmissions:
               {
@@ -965,7 +1011,9 @@ function Classroom(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -988,7 +1036,7 @@ function Classroom(options) {
                     pathParams: ['courseId', 'courseWorkId', 'id'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * classroom.courses.courseWork.studentSubmissions.list
                     * @desc Returns a list of student submissions that the
@@ -1019,7 +1067,10 @@ function Classroom(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1042,7 +1093,7 @@ function Classroom(options) {
                     pathParams: ['courseId', 'courseWorkId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * classroom.courses.courseWork.studentSubmissions.modifyAttachments
                     * @desc Modifies attachments of student submission.
@@ -1072,7 +1123,10 @@ function Classroom(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                modifyAttachments(params, options, callback) {
+                modifyAttachments(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1095,7 +1149,7 @@ function Classroom(options) {
                     pathParams: ['courseId', 'courseWorkId', 'id'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * classroom.courses.courseWork.studentSubmissions.patch
                     * @desc Updates one or more fields of a student submission.
@@ -1126,7 +1180,10 @@ function Classroom(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                patch(params, options, callback) {
+                patch(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1149,7 +1206,7 @@ function Classroom(options) {
                     pathParams: ['courseId', 'courseWorkId', 'id'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * classroom.courses.courseWork.studentSubmissions.reclaim
                     * @desc Reclaims a student submission on behalf of the
@@ -1183,7 +1240,10 @@ function Classroom(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                reclaim(params, options, callback) {
+                reclaim(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1206,7 +1266,7 @@ function Classroom(options) {
                     pathParams: ['courseId', 'courseWorkId', 'id'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * classroom.courses.courseWork.studentSubmissions.return
                     * @desc Returns a student submission.  Returning a student
@@ -1240,7 +1300,10 @@ function Classroom(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                return (params, options, callback) {
+                return (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1263,7 +1326,7 @@ function Classroom(options) {
                     pathParams: ['courseId', 'courseWorkId', 'id'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * classroom.courses.courseWork.studentSubmissions.turnIn
                     * @desc Turns in a student submission.  Turning in a student
@@ -1294,7 +1357,10 @@ function Classroom(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                turnIn(params, options, callback) {
+                turnIn(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1317,7 +1383,7 @@ function Classroom(options) {
                     pathParams: ['courseId', 'courseWorkId', 'id'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               }
@@ -1345,7 +1411,9 @@ function Classroom(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1366,7 +1434,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.students.delete
               * @desc Deletes a student of a course.  This method returns the
@@ -1384,7 +1452,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1405,7 +1475,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.students.get
               * @desc Returns a student of a course.  This method returns the
@@ -1423,7 +1493,8 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1444,7 +1515,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.students.list
               * @desc Returns a list of students of this course that the
@@ -1462,7 +1533,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1483,7 +1556,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1510,7 +1583,9 @@ function Classroom(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1531,7 +1606,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.teachers.delete
               * @desc Deletes a teacher of a course.  This method returns the
@@ -1551,7 +1626,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1572,7 +1649,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.teachers.get
               * @desc Returns a teacher of a course.  This method returns the
@@ -1590,7 +1667,8 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1611,7 +1689,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.teachers.list
               * @desc Returns a list of teachers of this course that the
@@ -1629,7 +1707,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1650,7 +1730,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1672,7 +1752,8 @@ function Classroom(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1693,7 +1774,7 @@ function Classroom(options) {
               pathParams: ['courseId', 'id'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * classroom.courses.topics.list
               * @desc Returns the list of topics that the requester is permitted
@@ -1713,7 +1794,9 @@ function Classroom(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1734,7 +1817,7 @@ function Classroom(options) {
               pathParams: ['courseId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }
@@ -1760,7 +1843,9 @@ function Classroom(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    accept(params, options, callback) {
+    accept(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1780,7 +1865,7 @@ function Classroom(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * classroom.invitations.create
         * @desc Creates an invitation. Only one invitation for a user and course
@@ -1801,7 +1886,9 @@ function Classroom(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1820,7 +1907,7 @@ function Classroom(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * classroom.invitations.delete
         * @desc Deletes an invitation.  This method returns the following error
@@ -1836,7 +1923,9 @@ function Classroom(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1856,7 +1945,7 @@ function Classroom(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * classroom.invitations.get
         * @desc Returns an invitation.  This method returns the following error
@@ -1872,7 +1961,8 @@ function Classroom(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1892,7 +1982,7 @@ function Classroom(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * classroom.invitations.list
         * @desc Returns a list of invitations that the requesting user is
@@ -1912,7 +2002,9 @@ function Classroom(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1931,7 +2023,7 @@ function Classroom(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1967,7 +2059,9 @@ function Classroom(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1987,7 +2081,7 @@ function Classroom(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * classroom.registrations.delete
         * @desc Deletes a `Registration`, causing Classroom to stop sending
@@ -2001,7 +2095,9 @@ function Classroom(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2021,7 +2117,7 @@ function Classroom(options) {
         pathParams: ['registrationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2041,7 +2137,8 @@ function Classroom(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2061,7 +2158,7 @@ function Classroom(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     guardianInvitations: {
       /**
@@ -2101,7 +2198,9 @@ function Classroom(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2122,7 +2221,7 @@ function Classroom(options) {
           pathParams: ['studentId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * classroom.userProfiles.guardianInvitations.get
           * @desc Returns a specific guardian invitation.  This method returns
@@ -2146,7 +2245,8 @@ function Classroom(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2168,7 +2268,7 @@ function Classroom(options) {
           pathParams: ['invitationId', 'studentId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * classroom.userProfiles.guardianInvitations.list
           * @desc Returns a list of guardian invitations that the requesting
@@ -2198,7 +2298,9 @@ function Classroom(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2219,7 +2321,7 @@ function Classroom(options) {
           pathParams: ['studentId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * classroom.userProfiles.guardianInvitations.patch
           * @desc Modifies a guardian invitation.  Currently, the only valid
@@ -2249,7 +2351,9 @@ function Classroom(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2271,7 +2375,7 @@ function Classroom(options) {
           pathParams: ['invitationId', 'studentId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -2301,7 +2405,9 @@ function Classroom(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2322,7 +2428,7 @@ function Classroom(options) {
           pathParams: ['guardianId', 'studentId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * classroom.userProfiles.guardians.get
           * @desc Returns a specific guardian.  This method returns the
@@ -2347,7 +2453,8 @@ function Classroom(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2368,7 +2475,7 @@ function Classroom(options) {
           pathParams: ['guardianId', 'studentId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * classroom.userProfiles.guardians.list
           * @desc Returns a list of guardians that the requesting user is
@@ -2400,7 +2507,9 @@ function Classroom(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2420,7 +2529,7 @@ function Classroom(options) {
           pathParams: ['studentId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/cloudbilling/v1.ts
+++ b/src/apis/cloudbilling/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Billing API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudbilling
  */
-function Cloudbilling(options) {
+function Cloudbilling(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.billingAccounts = {
@@ -105,7 +112,8 @@ function Cloudbilling(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -124,7 +132,7 @@ function Cloudbilling(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudbilling.billingAccounts.list
         * @desc Lists the billing accounts that the current authenticated user
@@ -203,7 +211,9 @@ function Cloudbilling(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -223,7 +233,7 @@ function Cloudbilling(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     projects: {
       /**
@@ -314,7 +324,9 @@ function Cloudbilling(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -335,7 +347,7 @@ function Cloudbilling(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -410,7 +422,9 @@ function Cloudbilling(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getBillingInfo(params, options, callback) {
+    getBillingInfo(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -430,7 +444,7 @@ function Cloudbilling(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudbilling.projects.updateBillingInfo
         * @desc Sets or updates the billing account associated with a project.
@@ -530,7 +544,9 @@ function Cloudbilling(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateBillingInfo(params, options, callback) {
+    updateBillingInfo(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -550,7 +566,7 @@ function Cloudbilling(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -631,7 +647,9 @@ function Cloudbilling(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -650,7 +668,7 @@ function Cloudbilling(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     skus: {
       /**
@@ -737,7 +755,9 @@ function Cloudbilling(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -758,7 +778,7 @@ function Cloudbilling(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/cloudbuild/v1.ts
+++ b/src/apis/cloudbuild/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Container Builder API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudbuild
  */
-function Cloudbuild(options) {
+function Cloudbuild(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -56,7 +63,9 @@ function Cloudbuild(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -76,7 +85,7 @@ function Cloudbuild(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudbuild.operations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -91,7 +100,8 @@ function Cloudbuild(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +120,7 @@ function Cloudbuild(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudbuild.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -134,7 +144,9 @@ function Cloudbuild(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -153,7 +165,7 @@ function Cloudbuild(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -173,7 +185,9 @@ function Cloudbuild(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -193,7 +207,7 @@ function Cloudbuild(options) {
           pathParams: ['id', 'projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.builds.create
           * @desc Starts a build with the specified configuration.  This method
@@ -210,7 +224,9 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -230,7 +246,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.builds.get
           * @desc Returns information about a previously requested build.  The
@@ -246,7 +262,8 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -266,7 +283,7 @@ function Cloudbuild(options) {
           pathParams: ['id', 'projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.builds.list
           * @desc Lists previously requested builds.  Previously requested
@@ -284,7 +301,9 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -304,7 +323,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.builds.retry
           * @desc Creates a new build based on the specified build.  This method
@@ -336,7 +355,9 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      retry(params, options, callback) {
+      retry(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -356,7 +377,7 @@ function Cloudbuild(options) {
           pathParams: ['id', 'projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -374,7 +395,9 @@ function Cloudbuild(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -394,7 +417,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.triggers.delete
           * @desc Deletes a `BuildTrigger` by its project ID and trigger ID.
@@ -409,7 +432,9 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -429,7 +454,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId', 'triggerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.triggers.get
           * @desc Returns information about a `BuildTrigger`.  This API is
@@ -444,7 +469,8 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -464,7 +490,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId', 'triggerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.triggers.list
           * @desc Lists existing `BuildTrigger`s.  This API is experimental.
@@ -477,7 +503,9 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -497,7 +525,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.triggers.patch
           * @desc Updates a `BuildTrigger` by its project ID and trigger ID.
@@ -513,7 +541,9 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -533,7 +563,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId', 'triggerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudbuild.projects.triggers.run
           * @desc Runs a `BuildTrigger` at a particular source revision.
@@ -548,7 +578,8 @@ function Cloudbuild(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      run(params, options, callback) {
+      run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -569,7 +600,7 @@ function Cloudbuild(options) {
           pathParams: ['projectId', 'triggerId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/clouddebugger/v2.ts
+++ b/src/apis/clouddebugger/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Stackdriver Debugger API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Clouddebugger
  */
-function Clouddebugger(options) {
+function Clouddebugger(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.controller = {
@@ -108,7 +115,9 @@ function Clouddebugger(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      register(params, options, callback) {
+      register(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -129,7 +138,7 @@ function Clouddebugger(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       breakpoints: {
         /**
@@ -207,7 +216,9 @@ function Clouddebugger(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -229,7 +240,7 @@ function Clouddebugger(options) {
             pathParams: ['debuggeeId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * clouddebugger.controller.debuggees.breakpoints.update
             * @desc Updates the breakpoint state or mutable fields. The entire
@@ -312,7 +323,9 @@ function Clouddebugger(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -335,7 +348,7 @@ function Clouddebugger(options) {
             pathParams: ['debuggeeId', 'id'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -405,7 +418,9 @@ function Clouddebugger(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -426,7 +441,7 @@ function Clouddebugger(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       breakpoints: {
         /**
@@ -495,7 +510,9 @@ function Clouddebugger(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -518,7 +535,7 @@ function Clouddebugger(options) {
             pathParams: ['breakpointId', 'debuggeeId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * clouddebugger.debugger.debuggees.breakpoints.get
             * @desc Gets breakpoint information.
@@ -589,7 +606,8 @@ function Clouddebugger(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -612,7 +630,7 @@ function Clouddebugger(options) {
             pathParams: ['breakpointId', 'debuggeeId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * clouddebugger.debugger.debuggees.breakpoints.list
             * @desc Lists all breakpoints for the debuggee.
@@ -683,7 +701,9 @@ function Clouddebugger(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -705,7 +725,7 @@ function Clouddebugger(options) {
             pathParams: ['debuggeeId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * clouddebugger.debugger.debuggees.breakpoints.set
             * @desc Sets the breakpoint to the debuggee.
@@ -776,7 +796,8 @@ function Clouddebugger(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        set(params, options, callback) {
+        set(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -798,7 +819,7 @@ function Clouddebugger(options) {
             pathParams: ['debuggeeId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/clouderrorreporting/v1beta1.ts
+++ b/src/apis/clouderrorreporting/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Stackdriver Error Reporting API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Clouderrorreporting
  */
-function Clouderrorreporting(options) {
+function Clouderrorreporting(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -49,7 +56,9 @@ function Clouderrorreporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    deleteEvents(params, options, callback) {
+    deleteEvents(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Clouderrorreporting(options) {
         pathParams: ['projectName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     events: {
       /**
@@ -92,7 +101,9 @@ function Clouderrorreporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -113,7 +124,7 @@ function Clouderrorreporting(options) {
           pathParams: ['projectName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * clouderrorreporting.projects.events.report
           * @desc Report an individual error event.  This endpoint accepts
@@ -132,7 +143,9 @@ function Clouderrorreporting(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      report(params, options, callback) {
+      report(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -153,7 +166,7 @@ function Clouderrorreporting(options) {
           pathParams: ['projectName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -170,7 +183,8 @@ function Clouderrorreporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -191,7 +205,7 @@ function Clouderrorreporting(options) {
           pathParams: ['groupName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * clouderrorreporting.projects.groups.update
           * @desc Replace the data for the specified group. Fails if the group
@@ -206,7 +220,9 @@ function Clouderrorreporting(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -227,7 +243,7 @@ function Clouderrorreporting(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -255,7 +271,9 @@ function Clouderrorreporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -276,7 +294,7 @@ function Clouderrorreporting(options) {
           pathParams: ['projectName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/cloudfunctions/v1.ts
+++ b/src/apis/cloudfunctions/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Functions API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudfunctions
  */
-function Cloudfunctions(options) {
+function Cloudfunctions(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -50,7 +57,8 @@ function Cloudfunctions(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +78,7 @@ function Cloudfunctions(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudfunctions.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -94,7 +102,9 @@ function Cloudfunctions(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -114,7 +124,7 @@ function Cloudfunctions(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -135,7 +145,9 @@ function Cloudfunctions(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -156,7 +168,7 @@ function Cloudfunctions(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       functions: {
         /**
@@ -173,7 +185,9 @@ function Cloudfunctions(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        call(params, options, callback) {
+        call(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -194,7 +208,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.create
             * @desc Creates a new function. If a function with the given name
@@ -210,7 +224,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -231,7 +247,7 @@ function Cloudfunctions(options) {
             pathParams: ['location'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.delete
             * @desc Deletes a function with the given name from the specified
@@ -246,7 +262,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -266,7 +284,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.generateDownloadUrl
             * @desc Returns a signed URL for downloading deployed function
@@ -285,7 +303,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        generateDownloadUrl(params, options, callback) {
+        generateDownloadUrl(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -306,7 +326,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.generateUploadUrl
             * @desc Returns a signed URL for uploading a function source code.
@@ -331,7 +351,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        generateUploadUrl(params, options, callback) {
+        generateUploadUrl(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -352,7 +374,7 @@ function Cloudfunctions(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.get
             * @desc Returns a function with the given name from the requested
@@ -366,7 +388,8 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -386,7 +409,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.list
             * @desc Returns a list of functions that belong to the requested
@@ -402,7 +425,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -423,7 +448,7 @@ function Cloudfunctions(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.patch
             * @desc Updates existing function.
@@ -438,7 +463,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -458,7 +485,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/cloudfunctions/v1beta2.ts
+++ b/src/apis/cloudfunctions/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Functions API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Cloudfunctions
  */
-function Cloudfunctions(options) {
+function Cloudfunctions(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -50,7 +57,8 @@ function Cloudfunctions(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +78,7 @@ function Cloudfunctions(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudfunctions.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -94,7 +102,9 @@ function Cloudfunctions(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -115,7 +125,7 @@ function Cloudfunctions(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -136,7 +146,9 @@ function Cloudfunctions(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -157,7 +169,7 @@ function Cloudfunctions(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       functions: {
         /**
@@ -174,7 +186,9 @@ function Cloudfunctions(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        call(params, options, callback) {
+        call(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -195,7 +209,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.create
             * @desc Creates a new function. If a function with the given name
@@ -211,7 +225,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -232,7 +248,7 @@ function Cloudfunctions(options) {
             pathParams: ['location'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.delete
             * @desc Deletes a function with the given name from the specified
@@ -247,7 +263,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -268,7 +286,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.generateDownloadUrl
             * @desc Returns a signed URL for downloading deployed function
@@ -287,7 +305,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        generateDownloadUrl(params, options, callback) {
+        generateDownloadUrl(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -308,7 +328,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.generateUploadUrl
             * @desc Returns a signed URL for uploading a function source code.
@@ -333,7 +353,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        generateUploadUrl(params, options, callback) {
+        generateUploadUrl(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -355,7 +377,7 @@ function Cloudfunctions(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.get
             * @desc Returns a function with the given name from the requested
@@ -369,7 +391,8 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -390,7 +413,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.list
             * @desc Returns a list of functions that belong to the requested
@@ -406,7 +429,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -427,7 +452,7 @@ function Cloudfunctions(options) {
             pathParams: ['location'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudfunctions.projects.locations.functions.update
             * @desc Updates existing function.
@@ -441,7 +466,9 @@ function Cloudfunctions(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -462,7 +489,7 @@ function Cloudfunctions(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/cloudiot/v1.ts
+++ b/src/apis/cloudiot/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud IoT API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudiot
  */
-function Cloudiot(options) {
+function Cloudiot(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -53,7 +60,10 @@ function Cloudiot(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -74,7 +84,7 @@ function Cloudiot(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * cloudiot.projects.locations.registries.delete
                     * @desc Deletes a device registry configuration.
@@ -87,7 +97,10 @@ function Cloudiot(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -108,7 +121,7 @@ function Cloudiot(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * cloudiot.projects.locations.registries.get
                     * @desc Gets a device registry configuration.
@@ -121,7 +134,9 @@ function Cloudiot(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -142,7 +157,7 @@ function Cloudiot(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * cloudiot.projects.locations.registries.getIamPolicy
                     * @desc Gets the access control policy for a resource.
@@ -158,7 +173,10 @@ function Cloudiot(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                getIamPolicy(params, options, callback) {
+                getIamPolicy(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -179,7 +197,7 @@ function Cloudiot(options) {
                     pathParams: ['resource'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * cloudiot.projects.locations.registries.list
                     * @desc Lists device registries.
@@ -194,7 +212,10 @@ function Cloudiot(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -215,7 +236,7 @@ function Cloudiot(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * cloudiot.projects.locations.registries.patch
                     * @desc Updates a device registry configuration.
@@ -230,7 +251,10 @@ function Cloudiot(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                patch(params, options, callback) {
+                patch(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -251,7 +275,7 @@ function Cloudiot(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * cloudiot.projects.locations.registries.setIamPolicy
                     * @desc Sets the access control policy on the specified
@@ -266,7 +290,10 @@ function Cloudiot(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                setIamPolicy(params, options, callback) {
+                setIamPolicy(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -287,7 +314,7 @@ function Cloudiot(options) {
                     pathParams: ['resource'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * cloudiot.projects.locations.registries.testIamPermissions
                     * @desc Returns permissions that a caller has on the
@@ -305,7 +332,10 @@ function Cloudiot(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                testIamPermissions(params, options, callback) {
+                testIamPermissions(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -326,7 +356,7 @@ function Cloudiot(options) {
                     pathParams: ['resource'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 },
                 devices: {
                   /**
@@ -343,7 +373,10 @@ function Cloudiot(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  create(params, options, callback) {
+                  create(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -364,7 +397,7 @@ function Cloudiot(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * cloudiot.projects.locations.registries.devices.delete
                       * @desc Deletes a device.
@@ -378,7 +411,10 @@ function Cloudiot(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  delete (params, options, callback) {
+                  delete (
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -399,7 +435,7 @@ function Cloudiot(options) {
                       pathParams: ['name'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * cloudiot.projects.locations.registries.devices.get
                       * @desc Gets details about a device.
@@ -414,7 +450,9 @@ function Cloudiot(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  get(params, options, callback) {
+                  get(params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -435,7 +473,7 @@ function Cloudiot(options) {
                       pathParams: ['name'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * cloudiot.projects.locations.registries.devices.list
                       * @desc List devices in a device registry.
@@ -454,7 +492,10 @@ function Cloudiot(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -475,7 +516,7 @@ function Cloudiot(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * cloudiot.projects.locations.registries.devices.modifyCloudToDeviceConfig
                       * @desc Modifies the configuration for the device, which
@@ -493,7 +534,10 @@ function Cloudiot(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  modifyCloudToDeviceConfig(params, options, callback) {
+                  modifyCloudToDeviceConfig(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -515,7 +559,7 @@ function Cloudiot(options) {
                       pathParams: ['name'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * cloudiot.projects.locations.registries.devices.patch
                       * @desc Updates a device.
@@ -531,7 +575,10 @@ function Cloudiot(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  patch(params, options, callback) {
+                  patch(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -552,7 +599,7 @@ function Cloudiot(options) {
                       pathParams: ['name'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   },
                   configVersions: {
                     /**
@@ -570,7 +617,10 @@ function Cloudiot(options) {
                      * @param {callback} callback The callback that handles the response.
                      * @return {object} Request object
                      */
-                    list(params, options, callback) {
+                    list(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -591,7 +641,7 @@ function Cloudiot(options) {
                         pathParams: ['name'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }
 
                   },
@@ -611,7 +661,10 @@ function Cloudiot(options) {
                      * @param {callback} callback The callback that handles the response.
                      * @return {object} Request object
                      */
-                    list(params, options, callback) {
+                    list(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -632,7 +685,7 @@ function Cloudiot(options) {
                         pathParams: ['name'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }
 
                   }

--- a/src/apis/cloudkms/v1.ts
+++ b/src/apis/cloudkms/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Key Management Service (KMS) API
@@ -32,25 +39,438 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudkms
  */
-function Cloudkms(options) {
+function Cloudkms(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
-    locations:
-        {
+    locations: {
+      /**
+       * cloudkms.projects.locations.get
+       * @desc Get information about a location.
+       * @alias cloudkms.projects.locations.get
+       * @memberOf! cloudkms(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.name Resource name for the location.
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/v1/{name}').replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['name'],
+          pathParams: ['name'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * cloudkms.projects.locations.list
+          * @desc Lists information about the supported locations for this
+          * service.
+          * @alias cloudkms.projects.locations.list
+          * @memberOf! cloudkms(v1)
+          *
+          * @param {object} params Parameters for request
+          * @param {string=} params.filter The standard list filter.
+          * @param {string} params.name The resource that owns the locations collection, if applicable.
+          * @param {integer=} params.pageSize The standard list page size.
+          * @param {string=} params.pageToken The standard list page token.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/v1/{name}/locations')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['name'],
+          pathParams: ['name'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      },
+      keyRings: {
+        /**
+         * cloudkms.projects.locations.keyRings.create
+         * @desc Create a new KeyRing in a given Project and Location.
+         * @alias cloudkms.projects.locations.keyRings.create
+         * @memberOf! cloudkms(v1)
+         *
+         * @param {object} params Parameters for request
+         * @param {string=} params.keyRingId Required. It must be unique within a location and match the regular expression `[a-zA-Z0-9_-]{1,63}`
+         * @param {string} params.parent Required. The resource name of the location associated with the KeyRings, in the format `projects/x/locations/x`.
+         * @param {cloudkms(v1).KeyRing} params.resource Request body data
+         * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+         * @param {callback} callback The callback that handles the response.
+         * @return {object} Request object
+         */
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url: (rootUrl + '/v1/{parent}/keyRings')
+                           .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'POST'
+                },
+                options),
+            params,
+            requiredParams: ['parent'],
+            pathParams: ['parent'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * cloudkms.projects.locations.keyRings.get
+            * @desc Returns metadata for a given KeyRing.
+            * @alias cloudkms.projects.locations.keyRings.get
+            * @memberOf! cloudkms(v1)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.name The name of the KeyRing to get.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url: (rootUrl + '/v1/{name}').replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['name'],
+            pathParams: ['name'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * cloudkms.projects.locations.keyRings.getIamPolicy
+            * @desc Gets the access control policy for a resource. Returns an
+            * empty policy if the resource exists and does not have a policy
+            * set.
+            * @alias cloudkms.projects.locations.keyRings.getIamPolicy
+            * @memberOf! cloudkms(v1)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.resource_ REQUIRED: The resource for which the policy is being requested. See the operation documentation for the appropriate value for this field.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        getIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url: (rootUrl + '/v1/{resource}:getIamPolicy')
+                           .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['resource'],
+            pathParams: ['resource'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * cloudkms.projects.locations.keyRings.list
+            * @desc Lists KeyRings.
+            * @alias cloudkms.projects.locations.keyRings.list
+            * @memberOf! cloudkms(v1)
+            *
+            * @param {object} params Parameters for request
+            * @param {integer=} params.pageSize Optional limit on the number of KeyRings to include in the response.  Further KeyRings can subsequently be obtained by including the ListKeyRingsResponse.next_page_token in a subsequent request.  If unspecified, the server will pick an appropriate default.
+            * @param {string=} params.pageToken Optional pagination token, returned earlier via ListKeyRingsResponse.next_page_token.
+            * @param {string} params.parent Required. The resource name of the location associated with the KeyRings, in the format `projects/x/locations/x`.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url: (rootUrl + '/v1/{parent}/keyRings')
+                           .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['parent'],
+            pathParams: ['parent'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * cloudkms.projects.locations.keyRings.setIamPolicy
+            * @desc Sets the access control policy on the specified resource.
+            * Replaces any existing policy.
+            * @alias cloudkms.projects.locations.keyRings.setIamPolicy
+            * @memberOf! cloudkms(v1)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.resource_ REQUIRED: The resource for which the policy is being specified. See the operation documentation for the appropriate value for this field.
+            * @param {cloudkms(v1).SetIamPolicyRequest} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        setIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url: (rootUrl + '/v1/{resource}:setIamPolicy')
+                           .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'POST'
+                },
+                options),
+            params,
+            requiredParams: ['resource'],
+            pathParams: ['resource'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * cloudkms.projects.locations.keyRings.testIamPermissions
+            * @desc Returns permissions that a caller has on the specified
+            * resource. If the resource does not exist, this will return an
+            * empty set of permissions, not a NOT_FOUND error.  Note: This
+            * operation is designed to be used for building permission-aware UIs
+            * and command-line tools, not for authorization checking. This
+            * operation may "fail open" without warning.
+            * @alias cloudkms.projects.locations.keyRings.testIamPermissions
+            * @memberOf! cloudkms(v1)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.resource_ REQUIRED: The resource for which the policy detail is being requested. See the operation documentation for the appropriate value for this field.
+            * @param {cloudkms(v1).TestIamPermissionsRequest} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://cloudkms.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url: (rootUrl + '/v1/{resource}:testIamPermissions')
+                           .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'POST'
+                },
+                options),
+            params,
+            requiredParams: ['resource'],
+            pathParams: ['resource'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        },
+        cryptoKeys: {
           /**
-           * cloudkms.projects.locations.get
-           * @desc Get information about a location.
-           * @alias cloudkms.projects.locations.get
+           * cloudkms.projects.locations.keyRings.cryptoKeys.create
+           * @desc Create a new CryptoKey within a KeyRing.  CryptoKey.purpose
+           * is required.
+           * @alias cloudkms.projects.locations.keyRings.cryptoKeys.create
            * @memberOf! cloudkms(v1)
            *
            * @param {object} params Parameters for request
-           * @param {string} params.name Resource name for the location.
+           * @param {string=} params.cryptoKeyId Required. It must be unique within a KeyRing and match the regular expression `[a-zA-Z0-9_-]{1,63}`
+           * @param {string} params.parent Required. The name of the KeyRing associated with the CryptoKeys.
+           * @param {cloudkms(v1).CryptoKey} params.resource Request body data
            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{parent}/cryptoKeys')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'POST'
+                  },
+                  options),
+              params,
+              requiredParams: ['parent'],
+              pathParams: ['parent'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.decrypt
+              * @desc Decrypts data that was protected by Encrypt.
+              * @alias cloudkms.projects.locations.keyRings.cryptoKeys.decrypt
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.name Required. The resource name of the CryptoKey to use for decryption. The server will choose the appropriate version.
+              * @param {cloudkms(v1).DecryptRequest} params.resource Request body data
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          decrypt(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{name}:decrypt')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'POST'
+                  },
+                  options),
+              params,
+              requiredParams: ['name'],
+              pathParams: ['name'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.encrypt
+              * @desc Encrypts data, so that it can only be recovered by a call
+              * to Decrypt.
+              * @alias cloudkms.projects.locations.keyRings.cryptoKeys.encrypt
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.name Required. The resource name of the CryptoKey or CryptoKeyVersion to use for encryption.  If a CryptoKey is specified, the server will use its primary version.
+              * @param {cloudkms(v1).EncryptRequest} params.resource Request body data
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          encrypt(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{name}:encrypt')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'POST'
+                  },
+                  options),
+              params,
+              requiredParams: ['name'],
+              pathParams: ['name'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.get
+              * @desc Returns metadata for a given CryptoKey, as well as its
+              * primary CryptoKeyVersion.
+              * @alias cloudkms.projects.locations.keyRings.cryptoKeys.get
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.name The name of the CryptoKey to get.
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -70,24 +490,25 @@ function Cloudkms(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
-              * cloudkms.projects.locations.list
-              * @desc Lists information about the supported locations for this
-              * service.
-              * @alias cloudkms.projects.locations.list
+              * cloudkms.projects.locations.keyRings.cryptoKeys.getIamPolicy
+              * @desc Gets the access control policy for a resource. Returns an
+              * empty policy if the resource exists and does not have a policy
+              * set.
+              * @alias
+              * cloudkms.projects.locations.keyRings.cryptoKeys.getIamPolicy
               * @memberOf! cloudkms(v1)
               *
               * @param {object} params Parameters for request
-              * @param {string=} params.filter The standard list filter.
-              * @param {string} params.name The resource that owns the locations collection, if applicable.
-              * @param {integer=} params.pageSize The standard list page size.
-              * @param {string=} params.pageToken The standard list page token.
+              * @param {string} params.resource_ REQUIRED: The resource for which the policy is being requested. See the operation documentation for the appropriate value for this field.
               * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          getIamPolicy(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -98,9 +519,84 @@ function Cloudkms(options) {
             const parameters = {
               options: Object.assign(
                   {
-                    url: (rootUrl + '/v1/{name}/locations')
+                    url: (rootUrl + '/v1/{resource}:getIamPolicy')
                              .replace(/([^:]\/)\/+/g, '$1'),
                     method: 'GET'
+                  },
+                  options),
+              params,
+              requiredParams: ['resource'],
+              pathParams: ['resource'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.list
+              * @desc Lists CryptoKeys.
+              * @alias cloudkms.projects.locations.keyRings.cryptoKeys.list
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {integer=} params.pageSize Optional limit on the number of CryptoKeys to include in the response.  Further CryptoKeys can subsequently be obtained by including the ListCryptoKeysResponse.next_page_token in a subsequent request.  If unspecified, the server will pick an appropriate default.
+              * @param {string=} params.pageToken Optional pagination token, returned earlier via ListCryptoKeysResponse.next_page_token.
+              * @param {string} params.parent Required. The resource name of the KeyRing to list, in the format `projects/x/locations/x/keyRings/x`.
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{parent}/cryptoKeys')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'GET'
+                  },
+                  options),
+              params,
+              requiredParams: ['parent'],
+              pathParams: ['parent'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.patch
+              * @desc Update a CryptoKey.
+              * @alias cloudkms.projects.locations.keyRings.cryptoKeys.patch
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.name Output only. The resource name for this CryptoKey in the format `projects/x/locations/x/keyRings/x/cryptoKeys/x`.
+              * @param {string=} params.updateMask Required list of fields to be updated in this request.
+              * @param {cloudkms(v1).CryptoKey} params.resource Request body data
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{name}').replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'PATCH'
                   },
                   options),
               params,
@@ -108,852 +604,377 @@ function Cloudkms(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
-          },
-          keyRings:
-              {
-                /**
-                 * cloudkms.projects.locations.keyRings.create
-                 * @desc Create a new KeyRing in a given Project and Location.
-                 * @alias cloudkms.projects.locations.keyRings.create
-                 * @memberOf! cloudkms(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string=} params.keyRingId Required. It must be unique within a location and match the regular expression `[a-zA-Z0-9_-]{1,63}`
-                 * @param {string} params.parent Required. The resource name of the location associated with the KeyRings, in the format `projects/x/locations/x`.
-                 * @param {cloudkms(v1).KeyRing} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                create(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://cloudkms.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url: (rootUrl + '/v1/{parent}/keyRings')
-                                   .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['parent'],
-                    pathParams: ['parent'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * cloudkms.projects.locations.keyRings.get
-                    * @desc Returns metadata for a given KeyRing.
-                    * @alias cloudkms.projects.locations.keyRings.get
-                    * @memberOf! cloudkms(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.name The name of the KeyRing to get.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                get(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://cloudkms.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url: (rootUrl + '/v1/{name}')
-                                   .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['name'],
-                    pathParams: ['name'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * cloudkms.projects.locations.keyRings.getIamPolicy
-                    * @desc Gets the access control policy for a resource.
-                    * Returns an empty policy if the resource exists and does
-                    * not have a policy set.
-                    * @alias cloudkms.projects.locations.keyRings.getIamPolicy
-                    * @memberOf! cloudkms(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.resource_ REQUIRED: The resource for which the policy is being requested. See the operation documentation for the appropriate value for this field.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                getIamPolicy(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://cloudkms.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url: (rootUrl + '/v1/{resource}:getIamPolicy')
-                                   .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['resource'],
-                    pathParams: ['resource'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * cloudkms.projects.locations.keyRings.list
-                    * @desc Lists KeyRings.
-                    * @alias cloudkms.projects.locations.keyRings.list
-                    * @memberOf! cloudkms(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {integer=} params.pageSize Optional limit on the number of KeyRings to include in the response.  Further KeyRings can subsequently be obtained by including the ListKeyRingsResponse.next_page_token in a subsequent request.  If unspecified, the server will pick an appropriate default.
-                    * @param {string=} params.pageToken Optional pagination token, returned earlier via ListKeyRingsResponse.next_page_token.
-                    * @param {string} params.parent Required. The resource name of the location associated with the KeyRings, in the format `projects/x/locations/x`.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                list(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://cloudkms.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url: (rootUrl + '/v1/{parent}/keyRings')
-                                   .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['parent'],
-                    pathParams: ['parent'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * cloudkms.projects.locations.keyRings.setIamPolicy
-                    * @desc Sets the access control policy on the specified
-                    * resource. Replaces any existing policy.
-                    * @alias cloudkms.projects.locations.keyRings.setIamPolicy
-                    * @memberOf! cloudkms(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.resource_ REQUIRED: The resource for which the policy is being specified. See the operation documentation for the appropriate value for this field.
-                    * @param {cloudkms(v1).SetIamPolicyRequest} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                setIamPolicy(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://cloudkms.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url: (rootUrl + '/v1/{resource}:setIamPolicy')
-                                   .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['resource'],
-                    pathParams: ['resource'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * cloudkms.projects.locations.keyRings.testIamPermissions
-                    * @desc Returns permissions that a caller has on the
-                    * specified resource. If the resource does not exist, this
-                    * will return an empty set of permissions, not a NOT_FOUND
-                    * error.  Note: This operation is designed to be used for
-                    * building permission-aware UIs and command-line tools, not
-                    * for authorization checking. This operation may "fail open"
-                    * without warning.
-                    * @alias
-                    * cloudkms.projects.locations.keyRings.testIamPermissions
-                    * @memberOf! cloudkms(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.resource_ REQUIRED: The resource for which the policy detail is being requested. See the operation documentation for the appropriate value for this field.
-                    * @param {cloudkms(v1).TestIamPermissionsRequest} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                testIamPermissions(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://cloudkms.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url: (rootUrl + '/v1/{resource}:testIamPermissions')
-                                   .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['resource'],
-                    pathParams: ['resource'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                },
-                cryptoKeys: {
-                  /**
-                   * cloudkms.projects.locations.keyRings.cryptoKeys.create
-                   * @desc Create a new CryptoKey within a KeyRing.
-                   * CryptoKey.purpose is required.
-                   * @alias
-                   * cloudkms.projects.locations.keyRings.cryptoKeys.create
-                   * @memberOf! cloudkms(v1)
-                   *
-                   * @param {object} params Parameters for request
-                   * @param {string=} params.cryptoKeyId Required. It must be unique within a KeyRing and match the regular expression `[a-zA-Z0-9_-]{1,63}`
-                   * @param {string} params.parent Required. The name of the KeyRing associated with the CryptoKeys.
-                   * @param {cloudkms(v1).CryptoKey} params.resource Request body data
-                   * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                   * @param {callback} callback The callback that handles the response.
-                   * @return {object} Request object
-                   */
-                  create(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{parent}/cryptoKeys')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'POST'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['parent'],
-                      pathParams: ['parent'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.decrypt
-                      * @desc Decrypts data that was protected by Encrypt.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.decrypt
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.name Required. The resource name of the CryptoKey to use for decryption. The server will choose the appropriate version.
-                      * @param {cloudkms(v1).DecryptRequest} params.resource Request body data
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  decrypt(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{name}:decrypt')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'POST'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['name'],
-                      pathParams: ['name'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.encrypt
-                      * @desc Encrypts data, so that it can only be recovered by
-                      * a call to Decrypt.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.encrypt
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.name Required. The resource name of the CryptoKey or CryptoKeyVersion to use for encryption.  If a CryptoKey is specified, the server will use its primary version.
-                      * @param {cloudkms(v1).EncryptRequest} params.resource Request body data
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  encrypt(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{name}:encrypt')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'POST'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['name'],
-                      pathParams: ['name'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.get
-                      * @desc Returns metadata for a given CryptoKey, as well as
-                      * its primary CryptoKeyVersion.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.get
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.name The name of the CryptoKey to get.
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  get(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{name}')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'GET'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['name'],
-                      pathParams: ['name'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.getIamPolicy
-                      * @desc Gets the access control policy for a resource.
-                      * Returns an empty policy if the resource exists and does
-                      * not have a policy set.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.getIamPolicy
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.resource_ REQUIRED: The resource for which the policy is being requested. See the operation documentation for the appropriate value for this field.
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  getIamPolicy(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{resource}:getIamPolicy')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'GET'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['resource'],
-                      pathParams: ['resource'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.list
-                      * @desc Lists CryptoKeys.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.list
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {integer=} params.pageSize Optional limit on the number of CryptoKeys to include in the response.  Further CryptoKeys can subsequently be obtained by including the ListCryptoKeysResponse.next_page_token in a subsequent request.  If unspecified, the server will pick an appropriate default.
-                      * @param {string=} params.pageToken Optional pagination token, returned earlier via ListCryptoKeysResponse.next_page_token.
-                      * @param {string} params.parent Required. The resource name of the KeyRing to list, in the format `projects/x/locations/x/keyRings/x`.
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  list(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{parent}/cryptoKeys')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'GET'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['parent'],
-                      pathParams: ['parent'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.patch
-                      * @desc Update a CryptoKey.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.patch
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.name Output only. The resource name for this CryptoKey in the format `projects/x/locations/x/keyRings/x/cryptoKeys/x`.
-                      * @param {string=} params.updateMask Required list of fields to be updated in this request.
-                      * @param {cloudkms(v1).CryptoKey} params.resource Request body data
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  patch(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{name}')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'PATCH'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['name'],
-                      pathParams: ['name'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.setIamPolicy
-                      * @desc Sets the access control policy on the specified
-                      * resource. Replaces any existing policy.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.setIamPolicy
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.resource_ REQUIRED: The resource for which the policy is being specified. See the operation documentation for the appropriate value for this field.
-                      * @param {cloudkms(v1).SetIamPolicyRequest} params.resource Request body data
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  setIamPolicy(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{resource}:setIamPolicy')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'POST'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['resource'],
-                      pathParams: ['resource'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.testIamPermissions
-                      * @desc Returns permissions that a caller has on the
-                      * specified resource. If the resource does not exist, this
-                      * will return an empty set of permissions, not a NOT_FOUND
-                      * error.  Note: This operation is designed to be used for
-                      * building permission-aware UIs and command-line tools,
-                      * not for authorization checking. This operation may "fail
-                      * open" without warning.
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.testIamPermissions
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.resource_ REQUIRED: The resource for which the policy detail is being requested. See the operation documentation for the appropriate value for this field.
-                      * @param {cloudkms(v1).TestIamPermissionsRequest} params.resource Request body data
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  testIamPermissions(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{resource}:testIamPermissions')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'POST'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['resource'],
-                      pathParams: ['resource'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }, /**
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.updatePrimaryVersion
-                      * @desc Update the version of a CryptoKey that will be
-                      * used in Encrypt
-                      * @alias
-                      * cloudkms.projects.locations.keyRings.cryptoKeys.updatePrimaryVersion
-                      * @memberOf! cloudkms(v1)
-                      *
-                      * @param {object} params Parameters for request
-                      * @param {string} params.name The resource name of the CryptoKey to update.
-                      * @param {cloudkms(v1).UpdateCryptoKeyPrimaryVersionRequest} params.resource Request body data
-                      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                      * @param {callback} callback The callback that handles the response.
-                      * @return {object} Request object
-                      */
-                  updatePrimaryVersion(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://cloudkms.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url: (rootUrl + '/v1/{name}:updatePrimaryVersion')
-                                     .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'POST'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['name'],
-                      pathParams: ['name'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.setIamPolicy
+              * @desc Sets the access control policy on the specified resource.
+              * Replaces any existing policy.
+              * @alias
+              * cloudkms.projects.locations.keyRings.cryptoKeys.setIamPolicy
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.resource_ REQUIRED: The resource for which the policy is being specified. See the operation documentation for the appropriate value for this field.
+              * @param {cloudkms(v1).SetIamPolicyRequest} params.resource Request body data
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          setIamPolicy(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{resource}:setIamPolicy')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'POST'
                   },
-                  cryptoKeyVersions:
-                      {
-                        /**
-                         * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.create
-                         * @desc Create a new CryptoKeyVersion in a CryptoKey.
-                         * The server will assign the next sequential id. If
-                         * unset, state will be set to ENABLED.
-                         * @alias
-                         * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.create
-                         * @memberOf! cloudkms(v1)
-                         *
-                         * @param {object} params Parameters for request
-                         * @param {string} params.parent Required. The name of the CryptoKey associated with the CryptoKeyVersions.
-                         * @param {cloudkms(v1).CryptoKeyVersion} params.resource Request body data
-                         * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                         * @param {callback} callback The callback that handles the response.
-                         * @return {object} Request object
-                         */
-                        create(params, options, callback) {
-                          if (typeof options === 'function') {
-                            callback = options;
-                            options = {};
-                          }
-                          options = options || {};
-                          const rootUrl = options.rootUrl ||
-                              'https://cloudkms.googleapis.com/';
-                          const parameters = {
-                            options: Object.assign(
-                                {
-                                  url: (rootUrl +
-                                        '/v1/{parent}/cryptoKeyVersions')
-                                           .replace(/([^:]\/)\/+/g, '$1'),
-                                  method: 'POST'
-                                },
-                                options),
-                            params,
-                            requiredParams: ['parent'],
-                            pathParams: ['parent'],
-                            context: self
-                          };
-                          return createAPIRequest(parameters, callback);
-                        }, /**
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.destroy
-                            * @desc Schedule a CryptoKeyVersion for destruction.
-                            * Upon calling this method, CryptoKeyVersion.state
-                            * will be set to DESTROY_SCHEDULED and destroy_time
-                            * will be set to a time 24 hours in the future, at
-                            * which point the state will be changed to
-                            * DESTROYED, and the key material will be
-                            * irrevocably destroyed.  Before the destroy_time is
-                            * reached, RestoreCryptoKeyVersion may be called to
-                            * reverse the process.
-                            * @alias
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.destroy
-                            * @memberOf! cloudkms(v1)
-                            *
-                            * @param {object} params Parameters for request
-                            * @param {string} params.name The resource name of the CryptoKeyVersion to destroy.
-                            * @param {cloudkms(v1).DestroyCryptoKeyVersionRequest} params.resource Request body data
-                            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                            * @param {callback} callback The callback that handles the response.
-                            * @return {object} Request object
-                            */
-                        destroy(params, options, callback) {
-                          if (typeof options === 'function') {
-                            callback = options;
-                            options = {};
-                          }
-                          options = options || {};
-                          const rootUrl = options.rootUrl ||
-                              'https://cloudkms.googleapis.com/';
-                          const parameters = {
-                            options: Object.assign(
-                                {
-                                  url: (rootUrl + '/v1/{name}:destroy')
-                                           .replace(/([^:]\/)\/+/g, '$1'),
-                                  method: 'POST'
-                                },
-                                options),
-                            params,
-                            requiredParams: ['name'],
-                            pathParams: ['name'],
-                            context: self
-                          };
-                          return createAPIRequest(parameters, callback);
-                        }, /**
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.get
-                            * @desc Returns metadata for a given
-                            * CryptoKeyVersion.
-                            * @alias
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.get
-                            * @memberOf! cloudkms(v1)
-                            *
-                            * @param {object} params Parameters for request
-                            * @param {string} params.name The name of the CryptoKeyVersion to get.
-                            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                            * @param {callback} callback The callback that handles the response.
-                            * @return {object} Request object
-                            */
-                        get(params, options, callback) {
-                          if (typeof options === 'function') {
-                            callback = options;
-                            options = {};
-                          }
-                          options = options || {};
-                          const rootUrl = options.rootUrl ||
-                              'https://cloudkms.googleapis.com/';
-                          const parameters = {
-                            options: Object.assign(
-                                {
-                                  url: (rootUrl + '/v1/{name}')
-                                           .replace(/([^:]\/)\/+/g, '$1'),
-                                  method: 'GET'
-                                },
-                                options),
-                            params,
-                            requiredParams: ['name'],
-                            pathParams: ['name'],
-                            context: self
-                          };
-                          return createAPIRequest(parameters, callback);
-                        }, /**
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.list
-                            * @desc Lists CryptoKeyVersions.
-                            * @alias
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.list
-                            * @memberOf! cloudkms(v1)
-                            *
-                            * @param {object} params Parameters for request
-                            * @param {integer=} params.pageSize Optional limit on the number of CryptoKeyVersions to include in the response. Further CryptoKeyVersions can subsequently be obtained by including the ListCryptoKeyVersionsResponse.next_page_token in a subsequent request. If unspecified, the server will pick an appropriate default.
-                            * @param {string=} params.pageToken Optional pagination token, returned earlier via ListCryptoKeyVersionsResponse.next_page_token.
-                            * @param {string} params.parent Required. The resource name of the CryptoKey to list, in the format `projects/x/locations/x/keyRings/x/cryptoKeys/x`.
-                            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                            * @param {callback} callback The callback that handles the response.
-                            * @return {object} Request object
-                            */
-                        list(params, options, callback) {
-                          if (typeof options === 'function') {
-                            callback = options;
-                            options = {};
-                          }
-                          options = options || {};
-                          const rootUrl = options.rootUrl ||
-                              'https://cloudkms.googleapis.com/';
-                          const parameters = {
-                            options: Object.assign(
-                                {
-                                  url: (rootUrl +
-                                        '/v1/{parent}/cryptoKeyVersions')
-                                           .replace(/([^:]\/)\/+/g, '$1'),
-                                  method: 'GET'
-                                },
-                                options),
-                            params,
-                            requiredParams: ['parent'],
-                            pathParams: ['parent'],
-                            context: self
-                          };
-                          return createAPIRequest(parameters, callback);
-                        }, /**
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.patch
-                            * @desc Update a CryptoKeyVersion's metadata.  state
-                            * may be changed between ENABLED and DISABLED using
-                            * this method. See DestroyCryptoKeyVersion and
-                            * RestoreCryptoKeyVersion to move between other
-                            * states.
-                            * @alias
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.patch
-                            * @memberOf! cloudkms(v1)
-                            *
-                            * @param {object} params Parameters for request
-                            * @param {string} params.name Output only. The resource name for this CryptoKeyVersion in the format `projects/x/locations/x/keyRings/x/cryptoKeys/x/cryptoKeyVersions/x`.
-                            * @param {string=} params.updateMask Required list of fields to be updated in this request.
-                            * @param {cloudkms(v1).CryptoKeyVersion} params.resource Request body data
-                            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                            * @param {callback} callback The callback that handles the response.
-                            * @return {object} Request object
-                            */
-                        patch(params, options, callback) {
-                          if (typeof options === 'function') {
-                            callback = options;
-                            options = {};
-                          }
-                          options = options || {};
-                          const rootUrl = options.rootUrl ||
-                              'https://cloudkms.googleapis.com/';
-                          const parameters = {
-                            options: Object.assign(
-                                {
-                                  url: (rootUrl + '/v1/{name}')
-                                           .replace(/([^:]\/)\/+/g, '$1'),
-                                  method: 'PATCH'
-                                },
-                                options),
-                            params,
-                            requiredParams: ['name'],
-                            pathParams: ['name'],
-                            context: self
-                          };
-                          return createAPIRequest(parameters, callback);
-                        }, /**
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.restore
-                            * @desc Restore a CryptoKeyVersion in the
-                            * DESTROY_SCHEDULED, state.  Upon restoration of the
-                            * CryptoKeyVersion, state will be set to DISABLED,
-                            * and destroy_time will be cleared.
-                            * @alias
-                            * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.restore
-                            * @memberOf! cloudkms(v1)
-                            *
-                            * @param {object} params Parameters for request
-                            * @param {string} params.name The resource name of the CryptoKeyVersion to restore.
-                            * @param {cloudkms(v1).RestoreCryptoKeyVersionRequest} params.resource Request body data
-                            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                            * @param {callback} callback The callback that handles the response.
-                            * @return {object} Request object
-                            */
-                        restore(params, options, callback) {
-                          if (typeof options === 'function') {
-                            callback = options;
-                            options = {};
-                          }
-                          options = options || {};
-                          const rootUrl = options.rootUrl ||
-                              'https://cloudkms.googleapis.com/';
-                          const parameters = {
-                            options: Object.assign(
-                                {
-                                  url: (rootUrl + '/v1/{name}:restore')
-                                           .replace(/([^:]\/)\/+/g, '$1'),
-                                  method: 'POST'
-                                },
-                                options),
-                            params,
-                            requiredParams: ['name'],
-                            pathParams: ['name'],
-                            context: self
-                          };
-                          return createAPIRequest(parameters, callback);
-                        }
-
-                      }
-                }
+                  options),
+              params,
+              requiredParams: ['resource'],
+              pathParams: ['resource'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.testIamPermissions
+              * @desc Returns permissions that a caller has on the specified
+              * resource. If the resource does not exist, this will return an
+              * empty set of permissions, not a NOT_FOUND error.  Note: This
+              * operation is designed to be used for building permission-aware
+              * UIs and command-line tools, not for authorization checking. This
+              * operation may "fail open" without warning.
+              * @alias
+              * cloudkms.projects.locations.keyRings.cryptoKeys.testIamPermissions
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.resource_ REQUIRED: The resource for which the policy detail is being requested. See the operation documentation for the appropriate value for this field.
+              * @param {cloudkms(v1).TestIamPermissionsRequest} params.resource Request body data
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          testIamPermissions(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{resource}:testIamPermissions')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'POST'
+                  },
+                  options),
+              params,
+              requiredParams: ['resource'],
+              pathParams: ['resource'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * cloudkms.projects.locations.keyRings.cryptoKeys.updatePrimaryVersion
+              * @desc Update the version of a CryptoKey that will be used in
+              * Encrypt
+              * @alias
+              * cloudkms.projects.locations.keyRings.cryptoKeys.updatePrimaryVersion
+              * @memberOf! cloudkms(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.name The resource name of the CryptoKey to update.
+              * @param {cloudkms(v1).UpdateCryptoKeyPrimaryVersionRequest} params.resource Request body data
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          updatePrimaryVersion(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl =
+                options.rootUrl || 'https://cloudkms.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl + '/v1/{name}:updatePrimaryVersion')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'POST'
+                  },
+                  options),
+              params,
+              requiredParams: ['name'],
+              pathParams: ['name'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          },
+          cryptoKeyVersions: {
+            /**
+             * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.create
+             * @desc Create a new CryptoKeyVersion in a CryptoKey.  The server
+             * will assign the next sequential id. If unset, state will be set
+             * to ENABLED.
+             * @alias
+             * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.create
+             * @memberOf! cloudkms(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.parent Required. The name of the CryptoKey associated with the CryptoKeyVersions.
+             * @param {cloudkms(v1).CryptoKeyVersion} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
               }
+              options = options || {};
+              const rootUrl =
+                  options.rootUrl || 'https://cloudkms.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url: (rootUrl + '/v1/{parent}/cryptoKeyVersions')
+                               .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['parent'],
+                pathParams: ['parent'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.destroy
+                * @desc Schedule a CryptoKeyVersion for destruction.  Upon
+                * calling this method, CryptoKeyVersion.state will be set to
+                * DESTROY_SCHEDULED and destroy_time will be set to a time 24
+                * hours in the future, at which point the state will be changed
+                * to DESTROYED, and the key material will be irrevocably
+                * destroyed.  Before the destroy_time is reached,
+                * RestoreCryptoKeyVersion may be called to reverse the process.
+                * @alias
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.destroy
+                * @memberOf! cloudkms(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.name The resource name of the CryptoKeyVersion to destroy.
+                * @param {cloudkms(v1).DestroyCryptoKeyVersionRequest} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            destroy(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl =
+                  options.rootUrl || 'https://cloudkms.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url: (rootUrl + '/v1/{name}:destroy')
+                               .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['name'],
+                pathParams: ['name'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.get
+                * @desc Returns metadata for a given CryptoKeyVersion.
+                * @alias
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.get
+                * @memberOf! cloudkms(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.name The name of the CryptoKeyVersion to get.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl =
+                  options.rootUrl || 'https://cloudkms.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url: (rootUrl + '/v1/{name}')
+                               .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['name'],
+                pathParams: ['name'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.list
+                * @desc Lists CryptoKeyVersions.
+                * @alias
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.list
+                * @memberOf! cloudkms(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {integer=} params.pageSize Optional limit on the number of CryptoKeyVersions to include in the response. Further CryptoKeyVersions can subsequently be obtained by including the ListCryptoKeyVersionsResponse.next_page_token in a subsequent request. If unspecified, the server will pick an appropriate default.
+                * @param {string=} params.pageToken Optional pagination token, returned earlier via ListCryptoKeyVersionsResponse.next_page_token.
+                * @param {string} params.parent Required. The resource name of the CryptoKey to list, in the format `projects/x/locations/x/keyRings/x/cryptoKeys/x`.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl =
+                  options.rootUrl || 'https://cloudkms.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url: (rootUrl + '/v1/{parent}/cryptoKeyVersions')
+                               .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['parent'],
+                pathParams: ['parent'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.patch
+                * @desc Update a CryptoKeyVersion's metadata.  state may be
+                * changed between ENABLED and DISABLED using this method. See
+                * DestroyCryptoKeyVersion and RestoreCryptoKeyVersion to move
+                * between other states.
+                * @alias
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.patch
+                * @memberOf! cloudkms(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.name Output only. The resource name for this CryptoKeyVersion in the format `projects/x/locations/x/keyRings/x/cryptoKeys/x/cryptoKeyVersions/x`.
+                * @param {string=} params.updateMask Required list of fields to be updated in this request.
+                * @param {cloudkms(v1).CryptoKeyVersion} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl =
+                  options.rootUrl || 'https://cloudkms.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url: (rootUrl + '/v1/{name}')
+                               .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PATCH'
+                    },
+                    options),
+                params,
+                requiredParams: ['name'],
+                pathParams: ['name'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.restore
+                * @desc Restore a CryptoKeyVersion in the DESTROY_SCHEDULED,
+                * state.  Upon restoration of the CryptoKeyVersion, state will
+                * be set to DISABLED, and destroy_time will be cleared.
+                * @alias
+                * cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.restore
+                * @memberOf! cloudkms(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.name The resource name of the CryptoKeyVersion to restore.
+                * @param {cloudkms(v1).RestoreCryptoKeyVersionRequest} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            restore(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl =
+                  options.rootUrl || 'https://cloudkms.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url: (rootUrl + '/v1/{name}:restore')
+                               .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['name'],
+                pathParams: ['name'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }
+
+          }
         }
+      }
+    }
   };
 }
 /**

--- a/src/apis/cloudresourcemanager/v1.ts
+++ b/src/apis/cloudresourcemanager/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Resource Manager API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudresourcemanager
  */
-function Cloudresourcemanager(options) {
+function Cloudresourcemanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.folders = {
@@ -103,7 +110,9 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clearOrgPolicy(params, options, callback) {
+    clearOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -124,7 +133,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.getEffectiveOrgPolicy
         * @desc Gets the effective `Policy` on a resource. This is the result of
@@ -198,7 +207,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getEffectiveOrgPolicy(params, options, callback) {
+    getEffectiveOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +230,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.getOrgPolicy
         * @desc Gets a `Policy` on a resource.  If no `Policy` is set on the
@@ -294,7 +305,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getOrgPolicy(params, options, callback) {
+    getOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -315,7 +328,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.listAvailableOrgPolicyConstraints
         * @desc Lists `Constraints` that could be applied on the specified
@@ -405,7 +418,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listAvailableOrgPolicyConstraints(params, options, callback) {
+    listAvailableOrgPolicyConstraints(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -427,7 +442,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.listOrgPolicies
         * @desc Lists all the `Policies` set for a particular resource.
@@ -514,7 +529,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listOrgPolicies(params, options, callback) {
+    listOrgPolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -535,7 +552,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.setOrgPolicy
         * @desc Updates the specified `Policy` on the resource. Creates a new
@@ -609,7 +626,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setOrgPolicy(params, options, callback) {
+    setOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -630,7 +649,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -705,7 +724,9 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -725,7 +746,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.liens.delete
         * @desc Delete a Lien by `name`.  Callers of this method will require
@@ -792,7 +813,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -812,7 +835,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.liens.list
         * @desc List all Liens applied to the `parent` resource.  Callers of
@@ -894,7 +917,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -914,7 +939,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -986,7 +1011,8 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1006,7 +1032,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1077,7 +1103,9 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clearOrgPolicy(params, options, callback) {
+    clearOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1098,7 +1126,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.get
         * @desc Fetches an Organization resource identified by the specified
@@ -1165,7 +1193,8 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1185,7 +1214,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.getEffectiveOrgPolicy
         * @desc Gets the effective `Policy` on a resource. This is the result of
@@ -1259,7 +1288,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getEffectiveOrgPolicy(params, options, callback) {
+    getEffectiveOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1280,7 +1311,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.getIamPolicy
         * @desc Gets the access control policy for an Organization resource. May
@@ -1357,7 +1388,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1378,7 +1411,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.getOrgPolicy
         * @desc Gets a `Policy` on a resource.  If no `Policy` is set on the
@@ -1453,7 +1486,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getOrgPolicy(params, options, callback) {
+    getOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1474,7 +1509,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.listAvailableOrgPolicyConstraints
         * @desc Lists `Constraints` that could be applied on the specified
@@ -1565,7 +1600,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listAvailableOrgPolicyConstraints(params, options, callback) {
+    listAvailableOrgPolicyConstraints(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1587,7 +1624,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.listOrgPolicies
         * @desc Lists all the `Policies` set for a particular resource.
@@ -1675,7 +1712,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listOrgPolicies(params, options, callback) {
+    listOrgPolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1696,7 +1735,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.search
         * @desc Searches Organization resources that are visible to the user and
@@ -1782,7 +1821,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1803,7 +1844,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.setIamPolicy
         * @desc Sets the access control policy on an Organization resource.
@@ -1880,7 +1921,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1901,7 +1944,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.setOrgPolicy
         * @desc Updates the specified `Policy` on the resource. Creates a new
@@ -1975,7 +2018,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setOrgPolicy(params, options, callback) {
+    setOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1996,7 +2041,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.testIamPermissions
         * @desc Returns permissions that a caller has on the specified
@@ -2072,7 +2117,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2093,7 +2140,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2165,7 +2212,9 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clearOrgPolicy(params, options, callback) {
+    clearOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2186,7 +2235,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.create
         * @desc Request that a new Project be created. The result is an
@@ -2261,7 +2310,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2281,7 +2332,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.delete
         * @desc Marks the Project identified by the specified `project_id` (for
@@ -2358,7 +2409,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2379,7 +2432,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.get
         * @desc Retrieves the Project identified by the specified `project_id`
@@ -2449,7 +2502,8 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2470,7 +2524,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.getAncestry
         * @desc Gets a list of ancestors in the resource hierarchy for the
@@ -2544,7 +2598,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getAncestry(params, options, callback) {
+    getAncestry(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2565,7 +2621,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.getEffectiveOrgPolicy
         * @desc Gets the effective `Policy` on a resource. This is the result of
@@ -2639,7 +2695,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getEffectiveOrgPolicy(params, options, callback) {
+    getEffectiveOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2660,7 +2718,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.getIamPolicy
         * @desc Returns the IAM access control policy for the specified Project.
@@ -2737,7 +2795,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2758,7 +2818,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.getOrgPolicy
         * @desc Gets a `Policy` on a resource.  If no `Policy` is set on the
@@ -2833,7 +2893,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getOrgPolicy(params, options, callback) {
+    getOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2854,7 +2916,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.list
         * @desc Lists Projects that are visible to the user and satisfy the
@@ -2939,7 +3001,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2959,7 +3023,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.listAvailableOrgPolicyConstraints
         * @desc Lists `Constraints` that could be applied on the specified
@@ -3049,7 +3113,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listAvailableOrgPolicyConstraints(params, options, callback) {
+    listAvailableOrgPolicyConstraints(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3071,7 +3137,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.listOrgPolicies
         * @desc Lists all the `Policies` set for a particular resource.
@@ -3158,7 +3224,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listOrgPolicies(params, options, callback) {
+    listOrgPolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3179,7 +3247,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.setIamPolicy
         * @desc Sets the IAM access control policy for the specified Project.
@@ -3278,7 +3346,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3299,7 +3369,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.setOrgPolicy
         * @desc Updates the specified `Policy` on the resource. Creates a new
@@ -3373,7 +3443,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setOrgPolicy(params, options, callback) {
+    setOrgPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3394,7 +3466,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.testIamPermissions
         * @desc Returns permissions that a caller has on the specified Project.
@@ -3468,7 +3540,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3489,7 +3563,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.undelete
         * @desc Restores the Project identified by the specified `project_id`
@@ -3563,7 +3637,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    undelete(params, options, callback) {
+    undelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3584,7 +3660,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.update
         * @desc Updates the attributes of the Project identified by the
@@ -3659,7 +3735,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3680,7 +3758,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/cloudresourcemanager/v1beta1.ts
+++ b/src/apis/cloudresourcemanager/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Resource Manager API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Cloudresourcemanager
  */
-function Cloudresourcemanager(options) {
+function Cloudresourcemanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.organizations = {
@@ -102,7 +109,8 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -122,7 +130,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.getIamPolicy
         * @desc Gets the access control policy for an Organization resource. May
@@ -196,7 +204,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -217,7 +227,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.list
         * @desc Lists Organization resources that are visible to the user and
@@ -300,7 +310,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -321,7 +333,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.setIamPolicy
         * @desc Sets the access control policy on an Organization resource.
@@ -395,7 +407,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -416,7 +430,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.testIamPermissions
         * @desc Returns permissions that a caller has on the specified
@@ -491,7 +505,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -512,7 +528,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.organizations.update
         * @desc Updates an Organization resource identified by the specified
@@ -588,7 +604,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -608,7 +626,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -683,7 +701,9 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -704,7 +724,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.delete
         * @desc Marks the Project identified by the specified `project_id` (for
@@ -781,7 +801,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -802,7 +824,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.get
         * @desc Retrieves the Project identified by the specified `project_id`
@@ -872,7 +894,8 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -893,7 +916,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.getAncestry
         * @desc Gets a list of ancestors in the resource hierarchy for the
@@ -967,7 +990,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getAncestry(params, options, callback) {
+    getAncestry(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -988,7 +1013,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.getIamPolicy
         * @desc Returns the IAM access control policy for the specified Project.
@@ -1063,7 +1088,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1084,7 +1111,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.list
         * @desc Lists Projects that are visible to the user and satisfy the
@@ -1169,7 +1196,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1190,7 +1219,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.setIamPolicy
         * @desc Sets the IAM access control policy for the specified Project.
@@ -1287,7 +1316,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1308,7 +1339,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.testIamPermissions
         * @desc Returns permissions that a caller has on the specified Project.
@@ -1381,7 +1412,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1402,7 +1435,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.undelete
         * @desc Restores the Project identified by the specified `project_id`
@@ -1476,7 +1509,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    undelete(params, options, callback) {
+    undelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1497,7 +1532,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.projects.update
         * @desc Updates the attributes of the Project identified by the
@@ -1572,7 +1607,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1593,7 +1630,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/cloudresourcemanager/v2beta1.ts
+++ b/src/apis/cloudresourcemanager/v2beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Resource Manager API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta1
  * @param {object=} options Options for Cloudresourcemanager
  */
-function Cloudresourcemanager(options) {
+function Cloudresourcemanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.folders = {
@@ -66,7 +73,9 @@ function Cloudresourcemanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -86,7 +95,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.delete
         * @desc Requests deletion of a Folder. The Folder is moved into the
@@ -104,7 +113,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -124,7 +135,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.get
         * @desc Retrieves a Folder identified by the supplied resource name.
@@ -140,7 +151,8 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -160,7 +172,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.getIamPolicy
         * @desc Gets the access control policy for a Folder. The returned policy
@@ -178,7 +190,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -199,7 +213,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.list
         * @desc Lists the Folders that are direct descendants of supplied parent
@@ -220,7 +234,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -240,7 +256,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.move
         * @desc Moves a Folder under a new resource parent. Returns an Operation
@@ -267,7 +283,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    move(params, options, callback) {
+    move(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -288,7 +306,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.patch
         * @desc Updates a Folder, changing its display_name. Changes to the
@@ -314,7 +332,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -334,7 +354,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.search
         * @desc Search for folders that match specific filter criteria. Search
@@ -351,7 +371,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -372,7 +394,7 @@ function Cloudresourcemanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.setIamPolicy
         * @desc Sets the access control policy on a Folder, replacing any
@@ -390,7 +412,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -411,7 +435,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.testIamPermissions
         * @desc Returns permissions that a caller has on the specified Folder.
@@ -428,7 +452,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -449,7 +475,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudresourcemanager.folders.undelete
         * @desc Cancels the deletion request for a Folder. This method may only
@@ -469,7 +495,9 @@ function Cloudresourcemanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    undelete(params, options, callback) {
+    undelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -490,7 +518,7 @@ function Cloudresourcemanager(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/cloudshell/v1.ts
+++ b/src/apis/cloudshell/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Shell API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudshell
  */
-function Cloudshell(options) {
+function Cloudshell(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -57,7 +64,9 @@ function Cloudshell(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -77,7 +86,7 @@ function Cloudshell(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudshell.operations.delete
         * @desc Deletes a long-running operation. This method indicates that the
@@ -93,7 +102,9 @@ function Cloudshell(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -112,7 +123,7 @@ function Cloudshell(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudshell.operations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -127,7 +138,8 @@ function Cloudshell(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -146,7 +158,7 @@ function Cloudshell(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * cloudshell.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -170,7 +182,9 @@ function Cloudshell(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -189,7 +203,7 @@ function Cloudshell(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/cloudshell/v1alpha1.ts
+++ b/src/apis/cloudshell/v1alpha1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Shell API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1alpha1
  * @param {object=} options Options for Cloudshell
  */
-function Cloudshell(options) {
+function Cloudshell(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.users = {
@@ -50,7 +57,8 @@ function Cloudshell(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -70,7 +78,7 @@ function Cloudshell(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudshell.users.environments.patch
           * @desc Updates an existing environment.
@@ -85,7 +93,9 @@ function Cloudshell(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -105,7 +115,7 @@ function Cloudshell(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudshell.users.environments.start
           * @desc Starts an existing environment, allowing clients to connect to
@@ -125,7 +135,9 @@ function Cloudshell(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      start(params, options, callback) {
+      start(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -145,7 +157,7 @@ function Cloudshell(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       publicKeys: {
         /**
@@ -164,7 +176,9 @@ function Cloudshell(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -185,7 +199,7 @@ function Cloudshell(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudshell.users.environments.publicKeys.delete
             * @desc Removes a public SSH key from an environment. Clients will
@@ -200,7 +214,9 @@ function Cloudshell(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -221,7 +237,7 @@ function Cloudshell(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/cloudtasks/v2beta2.ts
+++ b/src/apis/cloudtasks/v2beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Tasks API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta2
  * @param {object=} options Options for Cloudtasks
  */
-function Cloudtasks(options) {
+function Cloudtasks(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -103,7 +110,8 @@ function Cloudtasks(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -123,7 +131,7 @@ function Cloudtasks(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudtasks.projects.locations.list
           * @desc Lists information about the supported locations for this
@@ -208,7 +216,9 @@ function Cloudtasks(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -228,7 +238,7 @@ function Cloudtasks(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       queues: {
         /**
@@ -311,7 +321,9 @@ function Cloudtasks(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -332,7 +344,7 @@ function Cloudtasks(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.delete
             * @desc Deletes a queue.  This command will delete the queue even if
@@ -404,7 +416,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -425,7 +439,7 @@ function Cloudtasks(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.get
             * @desc Gets a queue.
@@ -493,7 +507,8 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -514,7 +529,7 @@ function Cloudtasks(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.getIamPolicy
             * @desc Gets the access control policy for a Queue. Returns an empty
@@ -591,7 +606,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getIamPolicy(params, options, callback) {
+        getIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -612,7 +629,7 @@ function Cloudtasks(options) {
             pathParams: ['resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.list
             * @desc Lists queues.  Queues are returned in lexicographical order.
@@ -698,7 +715,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -719,7 +738,7 @@ function Cloudtasks(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.patch
             * @desc Updates a queue.  This method creates the queue if it does
@@ -815,7 +834,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -836,7 +857,7 @@ function Cloudtasks(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.pause
             * @desc Pauses the queue.  If a queue is paused then the system will
@@ -912,7 +933,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        pause(params, options, callback) {
+        pause(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -933,7 +956,7 @@ function Cloudtasks(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.purge
             * @desc Purges a queue by deleting all of its tasks.  All tasks
@@ -1010,7 +1033,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        purge(params, options, callback) {
+        purge(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1031,7 +1056,7 @@ function Cloudtasks(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.resume
             * @desc Resume a queue.  This method resumes a queue after it has
@@ -1111,7 +1136,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resume(params, options, callback) {
+        resume(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1132,7 +1159,7 @@ function Cloudtasks(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.setIamPolicy
             * @desc Sets the access control policy for a Queue. Replaces any
@@ -1210,7 +1237,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setIamPolicy(params, options, callback) {
+        setIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1231,7 +1260,7 @@ function Cloudtasks(options) {
             pathParams: ['resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * cloudtasks.projects.locations.queues.testIamPermissions
             * @desc Returns permissions that a caller has on a Queue. If the
@@ -1309,7 +1338,9 @@ function Cloudtasks(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1330,7 +1361,7 @@ function Cloudtasks(options) {
             pathParams: ['resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         tasks: {
           /**
@@ -1413,7 +1444,9 @@ function Cloudtasks(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          acknowledge(params, options, callback) {
+          acknowledge(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1434,7 +1467,7 @@ function Cloudtasks(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.cancelLease
               * @desc Cancel a pull task's lease.  The worker can use this
@@ -1511,7 +1544,9 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          cancelLease(params, options, callback) {
+          cancelLease(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1532,7 +1567,7 @@ function Cloudtasks(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.create
               * @desc Creates a task and adds it to a queue.  To add multiple
@@ -1617,7 +1652,9 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1638,7 +1675,7 @@ function Cloudtasks(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.delete
               * @desc Deletes a task.  A task can be deleted if it is scheduled
@@ -1706,7 +1743,9 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1727,7 +1766,7 @@ function Cloudtasks(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.get
               * @desc Gets a task.
@@ -1797,7 +1836,8 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1818,7 +1858,7 @@ function Cloudtasks(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.lease
               * @desc Leases tasks from a pull queue for lease_duration.  This
@@ -1841,7 +1881,9 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          lease(params, options, callback) {
+          lease(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1862,7 +1904,7 @@ function Cloudtasks(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.list
               * @desc Lists the tasks in a queue.  By default, only the BASIC
@@ -1955,7 +1997,9 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1976,7 +2020,7 @@ function Cloudtasks(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.renewLease
               * @desc Renew the current lease of a pull task.  The worker can
@@ -2053,7 +2097,9 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          renewLease(params, options, callback) {
+          renewLease(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2074,7 +2120,7 @@ function Cloudtasks(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * cloudtasks.projects.locations.queues.tasks.run
               * @desc Forces a task to run now.  This command is meant to be
@@ -2164,7 +2210,8 @@ function Cloudtasks(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          run(params, options, callback) {
+          run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2185,7 +2232,7 @@ function Cloudtasks(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }

--- a/src/apis/cloudtrace/v1.ts
+++ b/src/apis/cloudtrace/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Stackdriver Trace API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Cloudtrace
  */
-function Cloudtrace(options) {
+function Cloudtrace(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -110,7 +117,9 @@ function Cloudtrace(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    patchTraces(params, options, callback) {
+    patchTraces(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -130,7 +139,7 @@ function Cloudtrace(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     traces: {
       /**
@@ -202,7 +211,8 @@ function Cloudtrace(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -222,7 +232,7 @@ function Cloudtrace(options) {
           pathParams: ['projectId', 'traceId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * cloudtrace.projects.traces.list
           * @desc Returns of a list of traces that match the specified filter
@@ -309,7 +319,9 @@ function Cloudtrace(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -329,7 +341,7 @@ function Cloudtrace(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/cloudtrace/v2.ts
+++ b/src/apis/cloudtrace/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Stackdriver Trace API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Cloudtrace
  */
-function Cloudtrace(options) {
+function Cloudtrace(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -52,7 +59,9 @@ function Cloudtrace(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      batchWrite(params, options, callback) {
+      batchWrite(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -72,7 +81,7 @@ function Cloudtrace(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       spans: {
         /**
@@ -88,7 +97,9 @@ function Cloudtrace(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        createSpan(params, options, callback) {
+        createSpan(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -108,7 +119,7 @@ function Cloudtrace(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/clouduseraccounts/alpha.ts
+++ b/src/apis/clouduseraccounts/alpha.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud User Accounts API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation alpha
  * @param {object=} options Options for Clouduseraccounts
  */
-function Clouduseraccounts(options) {
+function Clouduseraccounts(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.globalAccountsOperations = {
@@ -49,7 +56,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.get
         * @desc Retrieves the specified operation resource.
@@ -85,7 +94,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +117,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.list
         * @desc Retrieves the list of operation resources contained within the
@@ -125,7 +135,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +159,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -166,7 +178,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addMember(params, options, callback) {
+    addMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -188,7 +202,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.delete
         * @desc Deletes the specified Group resource.
@@ -202,7 +216,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -224,7 +240,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.get
         * @desc Returns the specified Group resource.
@@ -238,7 +254,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -260,7 +277,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -275,7 +292,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -297,7 +316,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.insert
         * @desc Creates a Group resource in the specified project using the data
@@ -312,7 +331,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -333,7 +354,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.list
         * @desc Retrieves the list of groups contained within the specified
@@ -351,7 +372,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -372,7 +395,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.removeMember
         * @desc Removes users from the specified group.
@@ -387,7 +410,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeMember(params, options, callback) {
+    removeMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -409,7 +434,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -425,7 +450,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -447,7 +474,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -462,7 +489,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -484,7 +513,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -506,7 +535,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getAuthorizedKeysView(params, options, callback) {
+    getAuthorizedKeysView(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -528,7 +559,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.linux.getLinuxAccountViews
         * @desc Retrieves a list of user accounts for an instance within a
@@ -548,7 +579,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getLinuxAccountViews(params, options, callback) {
+    getLinuxAccountViews(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -570,7 +603,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -590,7 +623,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addPublicKey(params, options, callback) {
+    addPublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -612,7 +647,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.delete
         * @desc Deletes the specified User resource.
@@ -626,7 +661,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -648,7 +685,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.get
         * @desc Returns the specified User resource.
@@ -662,7 +699,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -684,7 +722,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -699,7 +737,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -721,7 +761,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.insert
         * @desc Creates a User resource in the specified project using the data
@@ -736,7 +776,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -757,7 +799,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.list
         * @desc Retrieves a list of users contained within the specified
@@ -775,7 +817,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -796,7 +840,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.removePublicKey
         * @desc Removes the specified public key from the user.
@@ -811,7 +855,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removePublicKey(params, options, callback) {
+    removePublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -833,7 +879,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -849,7 +895,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -871,7 +919,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -886,7 +934,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -908,7 +958,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/clouduseraccounts/beta.ts
+++ b/src/apis/clouduseraccounts/beta.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud User Accounts API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation beta
  * @param {object=} options Options for Clouduseraccounts
  */
-function Clouduseraccounts(options) {
+function Clouduseraccounts(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.globalAccountsOperations = {
@@ -100,7 +107,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -122,7 +131,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.get
         * @desc Retrieves the specified operation resource.
@@ -190,7 +199,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -212,7 +222,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.list
         * @desc Retrieves the list of operation resources contained within the
@@ -298,7 +308,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -320,7 +332,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -399,7 +411,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addMember(params, options, callback) {
+    addMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -421,7 +435,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.delete
         * @desc Deletes the specified Group resource.
@@ -491,7 +505,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -513,7 +529,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.get
         * @desc Returns the specified Group resource.
@@ -583,7 +599,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -605,7 +622,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.insert
         * @desc Creates a Group resource in the specified project using the data
@@ -677,7 +694,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -698,7 +717,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.list
         * @desc Retrieves the list of groups contained within the specified
@@ -782,7 +801,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -803,7 +824,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.removeMember
         * @desc Removes users from the specified group.
@@ -876,7 +897,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeMember(params, options, callback) {
+    removeMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -898,7 +921,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -980,7 +1003,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getAuthorizedKeysView(params, options, callback) {
+    getAuthorizedKeysView(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1002,7 +1027,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.linux.getLinuxAccountViews
         * @desc Retrieves a list of user accounts for an instance within a
@@ -1079,7 +1104,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getLinuxAccountViews(params, options, callback) {
+    getLinuxAccountViews(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1101,7 +1128,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1181,7 +1208,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addPublicKey(params, options, callback) {
+    addPublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1203,7 +1232,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.delete
         * @desc Deletes the specified User resource.
@@ -1273,7 +1302,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1295,7 +1326,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.get
         * @desc Returns the specified User resource.
@@ -1365,7 +1396,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1387,7 +1419,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.insert
         * @desc Creates a User resource in the specified project using the data
@@ -1459,7 +1491,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1480,7 +1514,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.list
         * @desc Retrieves a list of users contained within the specified
@@ -1564,7 +1598,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1585,7 +1621,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.removePublicKey
         * @desc Removes the specified public key from the user.
@@ -1659,7 +1695,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removePublicKey(params, options, callback) {
+    removePublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1681,7 +1719,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/clouduseraccounts/vm_alpha.ts
+++ b/src/apis/clouduseraccounts/vm_alpha.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud User Accounts API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation vm_alpha
  * @param {object=} options Options for Clouduseraccounts
  */
-function Clouduseraccounts(options) {
+function Clouduseraccounts(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.globalAccountsOperations = {
@@ -49,7 +56,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.get
         * @desc Retrieves the specified operation resource.
@@ -85,7 +94,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +117,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.list
         * @desc Retrieves the list of operation resources contained within the
@@ -125,7 +135,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +159,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -166,7 +178,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addMember(params, options, callback) {
+    addMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -188,7 +202,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.delete
         * @desc Deletes the specified Group resource.
@@ -202,7 +216,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -224,7 +240,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.get
         * @desc Returns the specified Group resource.
@@ -238,7 +254,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -260,7 +277,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -275,7 +292,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -297,7 +316,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.insert
         * @desc Creates a Group resource in the specified project using the data
@@ -312,7 +331,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -334,7 +355,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.list
         * @desc Retrieves the list of groups contained within the specified
@@ -352,7 +373,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -374,7 +397,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.removeMember
         * @desc Removes users from the specified group.
@@ -389,7 +412,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeMember(params, options, callback) {
+    removeMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -411,7 +436,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -427,7 +452,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -449,7 +476,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -464,7 +491,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -486,7 +515,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -508,7 +537,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getAuthorizedKeysView(params, options, callback) {
+    getAuthorizedKeysView(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -530,7 +561,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.linux.getLinuxAccountViews
         * @desc Retrieves a list of user accounts for an instance within a
@@ -550,7 +581,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getLinuxAccountViews(params, options, callback) {
+    getLinuxAccountViews(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -572,7 +605,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -592,7 +625,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addPublicKey(params, options, callback) {
+    addPublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -614,7 +649,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.delete
         * @desc Deletes the specified User resource.
@@ -628,7 +663,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -650,7 +687,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.get
         * @desc Returns the specified User resource.
@@ -664,7 +701,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -686,7 +724,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -701,7 +739,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -723,7 +763,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.insert
         * @desc Creates a User resource in the specified project using the data
@@ -738,7 +778,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -760,7 +802,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.list
         * @desc Retrieves a list of users contained within the specified
@@ -778,7 +820,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -800,7 +844,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.removePublicKey
         * @desc Removes the specified public key from the user.
@@ -815,7 +859,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removePublicKey(params, options, callback) {
+    removePublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -837,7 +883,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -853,7 +899,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -875,7 +923,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -890,7 +938,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -912,7 +962,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/clouduseraccounts/vm_beta.ts
+++ b/src/apis/clouduseraccounts/vm_beta.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud User Accounts API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation vm_beta
  * @param {object=} options Options for Clouduseraccounts
  */
-function Clouduseraccounts(options) {
+function Clouduseraccounts(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.globalAccountsOperations = {
@@ -49,7 +56,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.get
         * @desc Retrieves the specified operation resource.
@@ -85,7 +94,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +117,7 @@ function Clouduseraccounts(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.globalAccountsOperations.list
         * @desc Retrieves the list of operation resources contained within the
@@ -125,7 +135,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +159,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -166,7 +178,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addMember(params, options, callback) {
+    addMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -188,7 +202,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.delete
         * @desc Deletes the specified Group resource.
@@ -202,7 +216,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -224,7 +240,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.get
         * @desc Returns the specified Group resource.
@@ -238,7 +254,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -260,7 +277,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.insert
         * @desc Creates a Group resource in the specified project using the data
@@ -275,7 +292,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -297,7 +316,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.list
         * @desc Retrieves the list of groups contained within the specified
@@ -315,7 +334,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -337,7 +358,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.groups.removeMember
         * @desc Removes users from the specified group.
@@ -352,7 +373,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeMember(params, options, callback) {
+    removeMember(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -374,7 +397,7 @@ function Clouduseraccounts(options) {
         pathParams: ['groupName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -396,7 +419,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getAuthorizedKeysView(params, options, callback) {
+    getAuthorizedKeysView(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -418,7 +443,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.linux.getLinuxAccountViews
         * @desc Retrieves a list of user accounts for an instance within a
@@ -438,7 +463,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getLinuxAccountViews(params, options, callback) {
+    getLinuxAccountViews(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -460,7 +487,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -480,7 +507,9 @@ function Clouduseraccounts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addPublicKey(params, options, callback) {
+    addPublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -502,7 +531,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.delete
         * @desc Deletes the specified User resource.
@@ -516,7 +545,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -538,7 +569,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.get
         * @desc Returns the specified User resource.
@@ -552,7 +583,8 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -574,7 +606,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.insert
         * @desc Creates a User resource in the specified project using the data
@@ -589,7 +621,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -611,7 +645,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.list
         * @desc Retrieves a list of users contained within the specified
@@ -629,7 +663,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -651,7 +687,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * clouduseraccounts.users.removePublicKey
         * @desc Removes the specified public key from the user.
@@ -666,7 +702,9 @@ function Clouduseraccounts(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removePublicKey(params, options, callback) {
+    removePublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -688,7 +726,7 @@ function Clouduseraccounts(options) {
         pathParams: ['project', 'user'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/compute/alpha.ts
+++ b/src/apis/compute/alpha.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Compute Engine API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation alpha
  * @param {object=} options Options for Compute
  */
-function Compute(options) {
+function Compute(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.acceleratorTypes = {
@@ -51,7 +58,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -73,7 +82,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.acceleratorTypes.get
         * @desc Returns the specified accelerator type. Get a list of available
@@ -89,7 +98,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -111,7 +121,7 @@ function Compute(options) {
         pathParams: ['acceleratorType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.acceleratorTypes.list
         * @desc Retrieves a list of accelerator types available to the specified
@@ -130,7 +140,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -152,7 +164,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -173,7 +185,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -194,7 +208,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.delete
         * @desc Deletes the specified address resource.
@@ -210,7 +224,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -232,7 +248,7 @@ function Compute(options) {
         pathParams: ['address', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.get
         * @desc Returns the specified address resource.
@@ -247,7 +263,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -269,7 +286,7 @@ function Compute(options) {
         pathParams: ['address', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.insert
         * @desc Creates an address resource in the specified project using the
@@ -286,7 +303,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -308,7 +327,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.list
         * @desc Retrieves a list of addresses contained within the specified
@@ -327,7 +346,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -349,7 +370,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.setLabels
         * @desc Sets the labels on an Address. To learn more about labels, read
@@ -367,7 +388,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -389,7 +412,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -405,7 +428,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -427,7 +452,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -448,7 +473,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -469,7 +496,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.delete
         * @desc Deletes the specified autoscaler.
@@ -485,7 +512,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -507,7 +536,7 @@ function Compute(options) {
         pathParams: ['autoscaler', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.get
         * @desc Returns the specified autoscaler resource. Get a list of
@@ -523,7 +552,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -545,7 +575,7 @@ function Compute(options) {
         pathParams: ['autoscaler', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.insert
         * @desc Creates an autoscaler in the specified project using the data
@@ -562,7 +592,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -584,7 +616,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.list
         * @desc Retrieves a list of autoscalers contained within the specified
@@ -603,7 +635,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -625,7 +659,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.patch
         * @desc Updates an autoscaler in the specified project using the data
@@ -644,7 +678,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -666,7 +702,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -682,7 +718,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -704,7 +742,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.update
         * @desc Updates an autoscaler in the specified project using the data
@@ -722,7 +760,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -744,7 +784,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -764,7 +804,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addSignedUrlKey(params, options, callback) {
+    addSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -786,7 +828,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.delete
         * @desc Deletes the specified BackendBucket resource.
@@ -801,7 +843,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -823,7 +867,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.deleteSignedUrlKey
         * @desc Deletes the given Signed URL Key from the backend bucket.
@@ -839,7 +883,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteSignedUrlKey(params, options, callback) {
+    deleteSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -861,7 +907,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.get
         * @desc Returns the specified BackendBucket resource. Get a list of
@@ -876,7 +922,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -898,7 +945,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -913,7 +960,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -935,7 +984,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.insert
         * @desc Creates a BackendBucket resource in the specified project using
@@ -951,7 +1000,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -972,7 +1023,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.list
         * @desc Retrieves the list of BackendBucket resources available to the
@@ -990,7 +1041,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1011,7 +1064,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.patch
         * @desc Updates the specified BackendBucket resource with the data
@@ -1029,7 +1082,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1051,7 +1106,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -1067,7 +1122,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1089,7 +1146,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -1104,7 +1161,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1126,7 +1185,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.update
         * @desc Updates the specified BackendBucket resource with the data
@@ -1143,7 +1202,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1165,7 +1226,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1185,7 +1246,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addSignedUrlKey(params, options, callback) {
+    addSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1207,7 +1270,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.aggregatedList
         * @desc Retrieves the list of all BackendService resources, regional and
@@ -1225,7 +1288,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1247,7 +1312,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.delete
         * @desc Deletes the specified BackendService resource.
@@ -1262,7 +1327,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1284,7 +1351,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.deleteSignedUrlKey
         * @desc Deletes the given Signed URL Key from the specified backend
@@ -1301,7 +1368,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteSignedUrlKey(params, options, callback) {
+    deleteSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1323,7 +1392,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.get
         * @desc Returns the specified BackendService resource. Get a list of
@@ -1338,7 +1407,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1360,7 +1430,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.getHealth
         * @desc Gets the most recent health check results for this
@@ -1376,7 +1446,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1398,7 +1470,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.insert
         * @desc Creates a BackendService resource in the specified project using
@@ -1416,7 +1488,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1437,7 +1511,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.list
         * @desc Retrieves the list of BackendService resources available to the
@@ -1455,7 +1529,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1476,7 +1552,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.patch
         * @desc Patches the specified BackendService resource with the data
@@ -1496,7 +1572,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1518,7 +1596,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.setSecurityPolicy
         * @desc Sets the security policy for the specified backend service.
@@ -1534,7 +1612,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSecurityPolicy(params, options, callback) {
+    setSecurityPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1556,7 +1636,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -1571,7 +1651,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1593,7 +1675,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.update
         * @desc Updates the specified BackendService resource with the data
@@ -1612,7 +1694,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1634,7 +1718,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1653,7 +1737,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1675,7 +1761,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1697,7 +1783,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        aggregatedList(params, options, callback) {
+        aggregatedList(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1718,7 +1806,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.createSnapshot
             * @desc Creates a snapshot of a specified persistent disk.
@@ -1736,7 +1824,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        createSnapshot(params, options, callback) {
+        createSnapshot(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1758,7 +1848,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.delete
             * @desc Deletes the specified persistent disk. Deleting a disk
@@ -1777,7 +1867,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1799,7 +1891,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.get
             * @desc Returns a specified persistent disk. Get a list of available
@@ -1815,7 +1907,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1837,7 +1930,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.getIamPolicy
             * @desc Gets the access control policy for a resource. May be empty
@@ -1853,7 +1946,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getIamPolicy(params, options, callback) {
+        getIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1875,7 +1970,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.insert
             * @desc Creates a persistent disk in the specified project using the
@@ -1896,7 +1991,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1917,7 +2014,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.list
             * @desc Retrieves a list of persistent disks contained within the
@@ -1936,7 +2033,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1957,7 +2056,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.resize
             * @desc Resizes the specified persistent disk. You can only increase
@@ -1975,7 +2074,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resize(params, options, callback) {
+        resize(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1997,7 +2098,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.setIamPolicy
             * @desc Sets the access control policy on the specified resource.
@@ -2014,7 +2115,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setIamPolicy(params, options, callback) {
+        setIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2036,7 +2139,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.setLabels
             * @desc Sets the labels on a disk. To learn more about labels, read
@@ -2054,7 +2157,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2076,7 +2181,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -2093,7 +2198,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2115,7 +2222,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -2136,7 +2243,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2157,7 +2266,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.diskTypes.get
         * @desc Returns the specified disk type. Get a list of available disk
@@ -2173,7 +2282,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2195,7 +2305,7 @@ function Compute(options) {
         pathParams: ['diskType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.diskTypes.list
         * @desc Retrieves a list of disk types available to the specified
@@ -2214,7 +2324,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2235,7 +2347,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2255,7 +2367,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2277,7 +2391,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.get
             * @desc Returns the specified firewall.
@@ -2291,7 +2405,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2313,7 +2428,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.insert
             * @desc Creates a firewall rule in the specified project using the
@@ -2329,7 +2444,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2350,7 +2467,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.list
             * @desc Retrieves the list of firewall rules available to the
@@ -2368,7 +2485,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2389,7 +2508,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.patch
             * @desc Updates the specified firewall rule with the data included
@@ -2407,7 +2526,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2429,7 +2550,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -2445,7 +2566,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2467,7 +2590,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.update
             * @desc Updates the specified firewall rule with the data included
@@ -2486,7 +2609,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2508,7 +2633,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -2529,7 +2654,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2551,7 +2678,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.delete
         * @desc Deletes the specified ForwardingRule resource.
@@ -2567,7 +2694,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2589,7 +2718,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.get
         * @desc Returns the specified ForwardingRule resource.
@@ -2604,7 +2733,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2626,7 +2756,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.insert
         * @desc Creates a ForwardingRule resource in the specified project and
@@ -2643,7 +2773,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2665,7 +2797,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.list
         * @desc Retrieves a list of ForwardingRule resources available to the
@@ -2684,7 +2816,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2706,7 +2840,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.patch
         * @desc Updates the specified forwarding rule with the data included in
@@ -2726,7 +2860,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2748,7 +2884,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.setLabels
         * @desc Sets the labels on the specified resource. To learn more about
@@ -2766,7 +2902,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2788,7 +2926,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.setTarget
         * @desc Changes target URL for forwarding rule. The new target should be
@@ -2806,7 +2944,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTarget(params, options, callback) {
+    setTarget(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2828,7 +2968,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -2844,7 +2984,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2866,7 +3008,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2885,7 +3027,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2907,7 +3051,7 @@ function Compute(options) {
         pathParams: ['address', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.get
         * @desc Returns the specified address resource. Get a list of available
@@ -2922,7 +3066,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2944,7 +3089,7 @@ function Compute(options) {
         pathParams: ['address', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.insert
         * @desc Creates an address resource in the specified project using the
@@ -2960,7 +3105,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2981,7 +3128,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.list
         * @desc Retrieves a list of global addresses.
@@ -2998,7 +3145,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3019,7 +3168,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.setLabels
         * @desc Sets the labels on a GlobalAddress. To learn more about labels,
@@ -3035,7 +3184,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3057,7 +3208,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -3072,7 +3223,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3094,7 +3247,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3114,7 +3267,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3136,7 +3291,7 @@ function Compute(options) {
             pathParams: ['forwardingRule', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.globalForwardingRules.get
             * @desc Returns the specified GlobalForwardingRule resource. Get a
@@ -3151,7 +3306,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3173,7 +3329,7 @@ function Compute(options) {
             pathParams: ['forwardingRule', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.globalForwardingRules.insert
             * @desc Creates a GlobalForwardingRule resource in the specified
@@ -3189,7 +3345,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3211,7 +3369,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.globalForwardingRules.list
             * @desc Retrieves a list of GlobalForwardingRule resources available
@@ -3229,7 +3387,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3251,7 +3411,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.globalForwardingRules.patch
             * @desc Updates the specified forwarding rule with the data included
@@ -3270,7 +3430,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3292,7 +3454,7 @@ function Compute(options) {
             pathParams: ['forwardingRule', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.globalForwardingRules.setLabels
             * @desc Sets the labels on the specified resource. To learn more
@@ -3308,7 +3470,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3330,7 +3494,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.globalForwardingRules.setTarget
             * @desc Changes target URL for the GlobalForwardingRule resource.
@@ -3347,7 +3511,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setTarget(params, options, callback) {
+        setTarget(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3369,7 +3535,7 @@ function Compute(options) {
             pathParams: ['forwardingRule', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.globalForwardingRules.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -3385,7 +3551,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3407,7 +3575,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -3428,7 +3596,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3449,7 +3619,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.delete
         * @desc Deletes the specified Operations resource.
@@ -3463,7 +3633,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3485,7 +3657,7 @@ function Compute(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.get
         * @desc Retrieves the specified Operations resource. Get a list of
@@ -3500,7 +3672,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3522,7 +3695,7 @@ function Compute(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -3540,7 +3713,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3561,7 +3736,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3580,7 +3755,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3602,7 +3779,7 @@ function Compute(options) {
         pathParams: ['healthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.healthChecks.get
         * @desc Returns the specified HealthCheck resource. Get a list of
@@ -3617,7 +3794,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3639,7 +3817,7 @@ function Compute(options) {
         pathParams: ['healthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.healthChecks.insert
         * @desc Creates a HealthCheck resource in the specified project using
@@ -3655,7 +3833,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3676,7 +3856,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.healthChecks.list
         * @desc Retrieves the list of HealthCheck resources available to the
@@ -3694,7 +3874,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3715,7 +3897,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.healthChecks.patch
         * @desc Updates a HealthCheck resource in the specified project using
@@ -3733,7 +3915,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3755,7 +3939,7 @@ function Compute(options) {
         pathParams: ['healthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.healthChecks.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -3770,7 +3954,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3792,7 +3978,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.healthChecks.update
         * @desc Updates a HealthCheck resource in the specified project using
@@ -3809,7 +3995,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3831,7 +4019,7 @@ function Compute(options) {
         pathParams: ['healthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3852,7 +4040,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3873,7 +4063,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hosts.delete
         * @desc Deletes the specified Host resource.
@@ -3889,7 +4079,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3911,7 +4103,7 @@ function Compute(options) {
         pathParams: ['host', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hosts.get
         * @desc Returns the specified host. Get a list of available hosts by
@@ -3927,7 +4119,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3949,7 +4142,7 @@ function Compute(options) {
         pathParams: ['host', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hosts.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -3965,7 +4158,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3987,7 +4182,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hosts.insert
         * @desc Creates a host resource in the specified project using the data
@@ -4004,7 +4199,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4025,7 +4222,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hosts.list
         * @desc Retrieves a list of hosts available to the specified project.
@@ -4043,7 +4240,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4064,7 +4263,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hosts.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -4081,7 +4280,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4103,7 +4304,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hosts.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -4119,7 +4320,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4141,7 +4344,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4162,7 +4365,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4183,7 +4388,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hostTypes.get
         * @desc Returns the specified host type. Get a list of available host
@@ -4199,7 +4404,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4221,7 +4427,7 @@ function Compute(options) {
         pathParams: ['hostType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.hostTypes.list
         * @desc Retrieves a list of host types available to the specified
@@ -4240,7 +4446,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4261,7 +4469,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4281,7 +4489,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4303,7 +4513,7 @@ function Compute(options) {
             pathParams: ['httpHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpHealthChecks.get
             * @desc Returns the specified HttpHealthCheck resource. Get a list
@@ -4318,7 +4528,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4340,7 +4551,7 @@ function Compute(options) {
             pathParams: ['httpHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpHealthChecks.insert
             * @desc Creates a HttpHealthCheck resource in the specified project
@@ -4356,7 +4567,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4378,7 +4591,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpHealthChecks.list
             * @desc Retrieves the list of HttpHealthCheck resources available to
@@ -4396,7 +4609,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4418,7 +4633,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpHealthChecks.patch
             * @desc Updates a HttpHealthCheck resource in the specified project
@@ -4437,7 +4652,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4459,7 +4676,7 @@ function Compute(options) {
             pathParams: ['httpHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpHealthChecks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -4475,7 +4692,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4497,7 +4716,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpHealthChecks.update
             * @desc Updates a HttpHealthCheck resource in the specified project
@@ -4514,7 +4733,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4536,7 +4757,7 @@ function Compute(options) {
             pathParams: ['httpHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -4556,7 +4777,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4578,7 +4801,7 @@ function Compute(options) {
             pathParams: ['httpsHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpsHealthChecks.get
             * @desc Returns the specified HttpsHealthCheck resource. Get a list
@@ -4593,7 +4816,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4615,7 +4839,7 @@ function Compute(options) {
             pathParams: ['httpsHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpsHealthChecks.insert
             * @desc Creates a HttpsHealthCheck resource in the specified project
@@ -4631,7 +4855,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4653,7 +4879,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpsHealthChecks.list
             * @desc Retrieves the list of HttpsHealthCheck resources available
@@ -4671,7 +4897,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4693,7 +4921,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpsHealthChecks.patch
             * @desc Updates a HttpsHealthCheck resource in the specified project
@@ -4712,7 +4940,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4734,7 +4964,7 @@ function Compute(options) {
             pathParams: ['httpsHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpsHealthChecks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -4750,7 +4980,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4772,7 +5004,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.httpsHealthChecks.update
             * @desc Updates a HttpsHealthCheck resource in the specified project
@@ -4789,7 +5021,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4811,7 +5045,7 @@ function Compute(options) {
             pathParams: ['httpsHealthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -4831,7 +5065,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4853,7 +5089,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.deprecate
             * @desc Sets the deprecation status of an image.  If an empty
@@ -4870,7 +5106,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        deprecate(params, options, callback) {
+        deprecate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4892,7 +5130,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.get
             * @desc Returns the specified image. Get a list of available images
@@ -4907,7 +5145,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4929,7 +5168,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.getFromFamily
             * @desc Returns the latest image that is part of an image family and
@@ -4944,7 +5183,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getFromFamily(params, options, callback) {
+        getFromFamily(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4966,7 +5207,7 @@ function Compute(options) {
             pathParams: ['family', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.getIamPolicy
             * @desc Gets the access control policy for a resource. May be empty
@@ -4981,7 +5222,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getIamPolicy(params, options, callback) {
+        getIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5003,7 +5246,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.insert
             * @desc Creates an image in the specified project using the data
@@ -5020,7 +5263,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5041,7 +5286,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.list
             * @desc Retrieves the list of custom images available to the
@@ -5064,7 +5309,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5085,7 +5332,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.setIamPolicy
             * @desc Sets the access control policy on the specified resource.
@@ -5101,7 +5348,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setIamPolicy(params, options, callback) {
+        setIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5123,7 +5372,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.setLabels
             * @desc Sets the labels on an image. To learn more about labels,
@@ -5139,7 +5388,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5161,7 +5412,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -5177,7 +5428,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5199,7 +5452,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -5232,7 +5485,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    abandonInstances(params, options, callback) {
+    abandonInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5254,7 +5509,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.aggregatedList
         * @desc Retrieves the list of managed instance groups and groups them by
@@ -5272,7 +5527,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5294,7 +5551,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.applyUpdatesToInstances
         * @desc Apply changes to selected instances on the managed instance
@@ -5312,7 +5569,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    applyUpdatesToInstances(params, options, callback) {
+    applyUpdatesToInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5334,7 +5593,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.delete
         * @desc Deletes the specified managed instance group and all of the
@@ -5353,7 +5612,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5375,7 +5636,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.deleteInstances
         * @desc Schedules a group action to delete the specified instances in
@@ -5403,7 +5664,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteInstances(params, options, callback) {
+    deleteInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5425,7 +5688,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.deletePerInstanceConfigs
         * @desc Delete selected per-instance configs for the managed instance
@@ -5442,7 +5705,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deletePerInstanceConfigs(params, options, callback) {
+    deletePerInstanceConfigs(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5464,7 +5729,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.get
         * @desc Returns all of the details about the specified managed instance
@@ -5481,7 +5746,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5503,7 +5769,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.insert
         * @desc Creates a managed instance group using the information that you
@@ -5527,7 +5793,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5549,7 +5817,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.list
         * @desc Retrieves a list of managed instance groups that are contained
@@ -5568,7 +5836,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5590,7 +5860,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.listManagedInstances
         * @desc Lists all of the instances in the managed instance group. Each
@@ -5614,7 +5884,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listManagedInstances(params, options, callback) {
+    listManagedInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5636,7 +5908,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.listPerInstanceConfigs
         * @desc Lists all of the per-instance configs defined for the managed
@@ -5656,7 +5928,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listPerInstanceConfigs(params, options, callback) {
+    listPerInstanceConfigs(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5678,7 +5952,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.patch
         * @desc Updates a managed instance group using the information that you
@@ -5701,7 +5975,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5723,7 +5999,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.recreateInstances
         * @desc Schedules a group action to recreate the specified instances in
@@ -5750,7 +6026,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    recreateInstances(params, options, callback) {
+    recreateInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5772,7 +6050,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.resize
         * @desc Resizes the managed instance group. If you increase the size,
@@ -5798,7 +6076,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resize(params, options, callback) {
+    resize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5820,7 +6100,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.resizeAdvanced
         * @desc Resizes the managed instance group with advanced configuration
@@ -5848,7 +6128,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resizeAdvanced(params, options, callback) {
+    resizeAdvanced(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5870,7 +6152,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.setAutoHealingPolicies
         * @desc Modifies the autohealing policies.
@@ -5887,7 +6169,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setAutoHealingPolicies(params, options, callback) {
+    setAutoHealingPolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5909,7 +6193,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.setInstanceTemplate
         * @desc Specifies the instance template to use when creating new
@@ -5928,7 +6212,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setInstanceTemplate(params, options, callback) {
+    setInstanceTemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5950,7 +6236,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.setTargetPools
         * @desc Modifies the target pools to which all instances in this managed
@@ -5973,7 +6259,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTargetPools(params, options, callback) {
+    setTargetPools(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5995,7 +6283,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -6011,7 +6299,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6033,7 +6323,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.update
         * @desc Updates a managed instance group using the information that you
@@ -6054,7 +6344,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6076,7 +6368,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroupManagers.updatePerInstanceConfigs
         * @desc Insert or patch (for the ones that already exist) per-instance
@@ -6096,7 +6388,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updatePerInstanceConfigs(params, options, callback) {
+    updatePerInstanceConfigs(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6118,7 +6412,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6141,7 +6435,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addInstances(params, options, callback) {
+    addInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6163,7 +6459,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.aggregatedList
         * @desc Retrieves the list of instance groups and sorts them by zone.
@@ -6180,7 +6476,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6202,7 +6500,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.delete
         * @desc Deletes the specified instance group. The instances in the group
@@ -6220,7 +6518,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6242,7 +6542,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.get
         * @desc Returns the specified instance group. Get a list of available
@@ -6258,7 +6558,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6280,7 +6581,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.insert
         * @desc Creates an instance group in the specified project using the
@@ -6297,7 +6598,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6319,7 +6622,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.list
         * @desc Retrieves the list of instance groups that are located in the
@@ -6338,7 +6641,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6360,7 +6665,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.listInstances
         * @desc Lists the instances in the specified instance group.
@@ -6380,7 +6685,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listInstances(params, options, callback) {
+    listInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6402,7 +6709,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.removeInstances
         * @desc Removes one or more instances from the specified instance group,
@@ -6423,7 +6730,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeInstances(params, options, callback) {
+    removeInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6445,7 +6754,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.setNamedPorts
         * @desc Sets the named ports for the specified instance group.
@@ -6462,7 +6771,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setNamedPorts(params, options, callback) {
+    setNamedPorts(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6484,7 +6795,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -6500,7 +6811,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6522,7 +6835,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6544,7 +6857,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addAccessConfig(params, options, callback) {
+    addAccessConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6566,7 +6881,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.addMaintenancePolicies
         * @desc Adds existing maintenance policies to an instance. You can only
@@ -6585,7 +6900,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    addMaintenancePolicies(params, options, callback) {
+    addMaintenancePolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6607,7 +6924,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.aggregatedList
         * @desc Retrieves aggregated list of instances.
@@ -6624,7 +6941,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6645,7 +6964,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.attachDisk
         * @desc Attaches an existing Disk resource to an instance. You must
@@ -6666,7 +6985,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    attachDisk(params, options, callback) {
+    attachDisk(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6688,7 +7009,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.delete
         * @desc Deletes the specified Instance resource. For more information,
@@ -6705,7 +7026,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6727,7 +7050,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.deleteAccessConfig
         * @desc Deletes an access config from an instance's network interface.
@@ -6745,7 +7068,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteAccessConfig(params, options, callback) {
+    deleteAccessConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6768,7 +7093,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.detachDisk
         * @desc Detaches a disk from an instance.
@@ -6785,7 +7110,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    detachDisk(params, options, callback) {
+    detachDisk(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6807,7 +7134,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.get
         * @desc Returns the specified Instance resource. Get a list of available
@@ -6823,7 +7150,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6845,7 +7173,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.getGuestAttributes
         * @desc Returns the specified guest attributes entry.
@@ -6861,7 +7189,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getGuestAttributes(params, options, callback) {
+    getGuestAttributes(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6883,7 +7213,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -6899,7 +7229,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6921,7 +7253,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.getSerialPortOutput
         * @desc Returns the specified instance's serial port output.
@@ -6938,7 +7270,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getSerialPortOutput(params, options, callback) {
+    getSerialPortOutput(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6960,7 +7294,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.insert
         * @desc Creates an instance resource in the specified project using the
@@ -6978,7 +7312,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6999,7 +7335,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.list
         * @desc Retrieves the list of instances contained within the specified
@@ -7018,7 +7354,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7039,7 +7377,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.listReferrers
         * @desc Retrieves the list of referrers to instances contained within
@@ -7059,7 +7397,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listReferrers(params, options, callback) {
+    listReferrers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7081,7 +7421,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.removeMaintenancePolicies
         * @desc Removes maintenance policies from an instance.
@@ -7098,7 +7438,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeMaintenancePolicies(params, options, callback) {
+    removeMaintenancePolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7120,7 +7462,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.reset
         * @desc Performs a reset on the instance. For more information, see
@@ -7137,7 +7479,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reset(params, options, callback) {
+    reset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7159,7 +7503,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.resume
         * @desc Resumes an instance that was suspended using the
@@ -7177,7 +7521,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resume(params, options, callback) {
+    resume(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7199,7 +7545,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setDeletionProtection
         * @desc Sets deletion protection on the instance.
@@ -7216,7 +7562,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setDeletionProtection(params, options, callback) {
+    setDeletionProtection(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7238,7 +7586,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setDiskAutoDelete
         * @desc Sets the auto-delete flag for a disk attached to an instance.
@@ -7256,7 +7604,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setDiskAutoDelete(params, options, callback) {
+    setDiskAutoDelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7279,7 +7629,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -7296,7 +7646,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7318,7 +7670,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setLabels
         * @desc Sets labels on an instance. To learn more about labels, read the
@@ -7336,7 +7688,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7358,7 +7712,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setMachineResources
         * @desc Changes the number and/or type of accelerator for a stopped
@@ -7376,7 +7730,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setMachineResources(params, options, callback) {
+    setMachineResources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7398,7 +7754,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setMachineType
         * @desc Changes the machine type for a stopped instance to the machine
@@ -7416,7 +7772,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setMachineType(params, options, callback) {
+    setMachineType(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7438,7 +7796,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setMetadata
         * @desc Sets metadata for the specified instance to the data included in
@@ -7456,7 +7814,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setMetadata(params, options, callback) {
+    setMetadata(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7478,7 +7838,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setMinCpuPlatform
         * @desc Changes the minimum CPU platform that this instance should use.
@@ -7497,7 +7857,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setMinCpuPlatform(params, options, callback) {
+    setMinCpuPlatform(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7519,7 +7881,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setScheduling
         * @desc Sets an instance's scheduling options.
@@ -7536,7 +7898,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setScheduling(params, options, callback) {
+    setScheduling(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7558,7 +7922,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setServiceAccount
         * @desc Sets the service account on the instance. For more information,
@@ -7576,7 +7940,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setServiceAccount(params, options, callback) {
+    setServiceAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7598,7 +7964,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.setTags
         * @desc Sets tags for the specified instance to the data included in the
@@ -7616,7 +7982,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTags(params, options, callback) {
+    setTags(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7638,7 +8006,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.simulateMaintenanceEvent
         * @desc Simulates a maintenance event on the instance.
@@ -7653,7 +8021,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    simulateMaintenanceEvent(params, options, callback) {
+    simulateMaintenanceEvent(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7675,7 +8045,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.start
         * @desc Starts an instance that was stopped using the using the
@@ -7693,7 +8063,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    start(params, options, callback) {
+    start(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7715,7 +8087,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.startWithEncryptionKey
         * @desc Starts an instance that was stopped using the using the
@@ -7734,7 +8106,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    startWithEncryptionKey(params, options, callback) {
+    startWithEncryptionKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7756,7 +8130,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.stop
         * @desc Stops a running instance, shutting it down cleanly, and allows
@@ -7778,7 +8152,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7800,7 +8176,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.suspend
         * @desc This method suspends a running instance, saving its state to
@@ -7822,7 +8198,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    suspend(params, options, callback) {
+    suspend(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7844,7 +8222,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -7860,7 +8238,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7882,7 +8262,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.updateAccessConfig
         * @desc Updates the specified access config from an instance's network
@@ -7903,7 +8283,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateAccessConfig(params, options, callback) {
+    updateAccessConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7925,7 +8307,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.updateNetworkInterface
         * @desc Updates an instance's network interface. This method follows
@@ -7944,7 +8326,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateNetworkInterface(params, options, callback) {
+    updateNetworkInterface(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7966,7 +8350,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instances.updateShieldedVmConfig
         * @desc Updates the Shielded VM config for an instance. This method
@@ -7985,7 +8369,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateShieldedVmConfig(params, options, callback) {
+    updateShieldedVmConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8007,7 +8393,7 @@ function Compute(options) {
         pathParams: ['instance', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8028,7 +8414,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8050,7 +8438,7 @@ function Compute(options) {
         pathParams: ['instanceTemplate', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.get
         * @desc Returns the specified instance template. Get a list of available
@@ -8065,7 +8453,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8087,7 +8476,7 @@ function Compute(options) {
         pathParams: ['instanceTemplate', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.insert
         * @desc Creates an instance template in the specified project using the
@@ -8106,7 +8495,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8128,7 +8519,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.list
         * @desc Retrieves a list of instance templates that are contained within
@@ -8146,7 +8537,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8168,7 +8561,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -8183,7 +8576,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8205,7 +8600,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8226,7 +8621,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8248,7 +8645,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.delete
         * @desc Deletes the specified interconnect attachment.
@@ -8264,7 +8661,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8286,7 +8685,7 @@ function Compute(options) {
         pathParams: ['interconnectAttachment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.get
         * @desc Returns the specified interconnect attachment.
@@ -8301,7 +8700,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8323,7 +8723,7 @@ function Compute(options) {
         pathParams: ['interconnectAttachment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -8339,7 +8739,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8361,7 +8763,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.insert
         * @desc Creates an InterconnectAttachment in the specified project using
@@ -8378,7 +8780,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8400,7 +8804,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.list
         * @desc Retrieves the list of interconnect attachments contained within
@@ -8419,7 +8823,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8441,7 +8847,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.patch
         * @desc Updates the specified interconnect attachment with the data
@@ -8460,7 +8866,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8482,7 +8890,7 @@ function Compute(options) {
         pathParams: ['interconnectAttachment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -8499,7 +8907,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8521,7 +8931,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.setLabels
         * @desc Sets the labels on an InterconnectAttachment. To learn more
@@ -8539,7 +8949,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8561,7 +8973,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -8577,7 +8989,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8599,7 +9013,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8618,7 +9032,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8640,7 +9055,7 @@ function Compute(options) {
         pathParams: ['interconnectLocation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectLocations.list
         * @desc Retrieves the list of interconnect locations available to the
@@ -8658,7 +9073,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8680,7 +9097,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectLocations.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -8695,7 +9112,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8717,7 +9136,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8737,7 +9156,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8759,7 +9180,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.get
             * @desc Returns the specified interconnect. Get a list of available
@@ -8774,7 +9195,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8796,7 +9218,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.getIamPolicy
             * @desc Gets the access control policy for a resource. May be empty
@@ -8811,7 +9233,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getIamPolicy(params, options, callback) {
+        getIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8833,7 +9257,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.insert
             * @desc Creates a Interconnect in the specified project using the
@@ -8849,7 +9273,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8871,7 +9297,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.list
             * @desc Retrieves the list of interconnect available to the
@@ -8889,7 +9315,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8911,7 +9339,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.patch
             * @desc Updates the specified interconnect with the data included in
@@ -8929,7 +9357,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8951,7 +9381,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.setIamPolicy
             * @desc Sets the access control policy on the specified resource.
@@ -8967,7 +9397,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setIamPolicy(params, options, callback) {
+        setIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8989,7 +9421,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.setLabels
             * @desc Sets the labels on an Interconnect. To learn more about
@@ -9005,7 +9437,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9027,7 +9461,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -9043,7 +9477,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9065,7 +9501,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -9084,7 +9520,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9106,7 +9543,7 @@ function Compute(options) {
         pathParams: ['licenseCode', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenseCodes.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -9121,7 +9558,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9143,7 +9582,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenseCodes.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -9159,7 +9598,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9181,7 +9622,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenseCodes.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -9196,7 +9637,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9218,7 +9661,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -9237,7 +9680,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9259,7 +9704,7 @@ function Compute(options) {
         pathParams: ['license', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.get
         * @desc Returns the specified License resource.
@@ -9273,7 +9718,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9295,7 +9741,7 @@ function Compute(options) {
         pathParams: ['license', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -9310,7 +9756,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9332,7 +9780,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.insert
         * @desc Create a License resource in the specified project.
@@ -9347,7 +9795,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9368,7 +9818,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.list
         * @desc Retrieves the list of licenses available in the specified
@@ -9390,7 +9840,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9411,7 +9863,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -9427,7 +9879,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9449,7 +9903,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -9464,7 +9918,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9486,7 +9942,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -9507,7 +9963,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9528,7 +9986,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.machineTypes.get
         * @desc Returns the specified machine type. Get a list of available
@@ -9544,7 +10002,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9566,7 +10025,7 @@ function Compute(options) {
         pathParams: ['machineType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.machineTypes.list
         * @desc Retrieves a list of machine types available to the specified
@@ -9585,7 +10044,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9607,7 +10068,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -9628,7 +10089,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9650,7 +10113,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.maintenancePolicies.delete
         * @desc Deletes the specified maintenance policy.
@@ -9666,7 +10129,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9688,7 +10153,7 @@ function Compute(options) {
         pathParams: ['maintenancePolicy', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.maintenancePolicies.get
         * @desc Retrieves all information of the specified maintenance policy.
@@ -9703,7 +10168,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9725,7 +10191,7 @@ function Compute(options) {
         pathParams: ['maintenancePolicy', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.maintenancePolicies.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -9741,7 +10207,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9763,7 +10231,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.maintenancePolicies.insert
         * @desc Creates a new maintenance policy.
@@ -9779,7 +10247,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9801,7 +10271,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.maintenancePolicies.list
         * @desc List all the maintenance policies that have been configured for
@@ -9820,7 +10290,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9842,7 +10314,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.maintenancePolicies.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -9859,7 +10331,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9881,7 +10355,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.maintenancePolicies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -9897,7 +10371,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9919,7 +10395,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -9941,7 +10417,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9963,7 +10441,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.attachNetworkEndpoints
         * @desc Attach a list of network endpoints to the specified network
@@ -9981,7 +10459,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    attachNetworkEndpoints(params, options, callback) {
+    attachNetworkEndpoints(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10003,7 +10483,7 @@ function Compute(options) {
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.delete
         * @desc Deletes the specified network endpoint group. The network
@@ -10022,7 +10502,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10044,7 +10526,7 @@ function Compute(options) {
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.detachNetworkEndpoints
         * @desc Detach a list of network endpoints from the specified network
@@ -10062,7 +10544,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    detachNetworkEndpoints(params, options, callback) {
+    detachNetworkEndpoints(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10084,7 +10568,7 @@ function Compute(options) {
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.get
         * @desc Returns the specified network endpoint group. Get a list of
@@ -10100,7 +10584,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10122,7 +10607,7 @@ function Compute(options) {
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.insert
         * @desc Creates a network endpoint group in the specified project using
@@ -10139,7 +10624,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10161,7 +10648,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.list
         * @desc Retrieves the list of network endpoint groups that are located
@@ -10180,7 +10667,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10202,7 +10691,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.listNetworkEndpoints
         * @desc List the network endpoints in the specified network endpoint
@@ -10223,7 +10712,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listNetworkEndpoints(params, options, callback) {
+    listNetworkEndpoints(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10245,7 +10736,7 @@ function Compute(options) {
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.networkEndpointGroups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -10261,7 +10752,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10283,7 +10776,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -10304,7 +10797,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        addPeering(params, options, callback) {
+        addPeering(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10326,7 +10821,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.delete
             * @desc Deletes the specified network.
@@ -10341,7 +10836,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10363,7 +10860,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.get
             * @desc Returns the specified network. Get a list of available
@@ -10378,7 +10875,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10400,7 +10898,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.insert
             * @desc Creates a network in the specified project using the data
@@ -10416,7 +10914,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10437,7 +10937,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.list
             * @desc Retrieves the list of networks available to the specified
@@ -10455,7 +10955,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10476,7 +10978,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.listIpOwners
             * @desc List the internal IP owners in the specified network.
@@ -10499,7 +11001,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listIpOwners(params, options, callback) {
+        listIpOwners(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10521,7 +11025,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.patch
             * @desc Patches the specified network with the data included in the
@@ -10539,7 +11043,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10561,7 +11067,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.removePeering
             * @desc Removes a peering from the specified network.
@@ -10577,7 +11083,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        removePeering(params, options, callback) {
+        removePeering(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10599,7 +11107,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.switchToCustomMode
             * @desc Switches the network mode from auto subnet mode to custom
@@ -10615,7 +11123,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        switchToCustomMode(params, options, callback) {
+        switchToCustomMode(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10637,7 +11147,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -10653,7 +11163,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10675,7 +11187,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -10695,7 +11207,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10717,7 +11231,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.nodeGroups.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -10734,7 +11248,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10756,7 +11272,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.nodeGroups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -10772,7 +11288,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10794,7 +11312,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -10814,7 +11332,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10836,7 +11356,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.nodeTemplates.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -10853,7 +11373,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10875,7 +11397,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.nodeTemplates.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -10891,7 +11413,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10913,7 +11437,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -10931,7 +11455,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    disableXpnHost(params, options, callback) {
+    disableXpnHost(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10952,7 +11478,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.disableXpnResource
         * @desc Disable a serivce resource (a.k.a service project) associated
@@ -10968,7 +11494,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    disableXpnResource(params, options, callback) {
+    disableXpnResource(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10989,7 +11517,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.enableXpnHost
         * @desc Enable this project as a shared VPC host project.
@@ -11003,7 +11531,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    enableXpnHost(params, options, callback) {
+    enableXpnHost(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11023,7 +11553,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.enableXpnResource
         * @desc Enable service resource (a.k.a service project) for a host
@@ -11040,7 +11570,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    enableXpnResource(params, options, callback) {
+    enableXpnResource(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11061,7 +11593,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.get
         * @desc Returns the specified Project resource.
@@ -11074,7 +11606,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11094,7 +11627,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.getXpnHost
         * @desc Get the shared VPC host project that this project links to. May
@@ -11108,7 +11641,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getXpnHost(params, options, callback) {
+    getXpnHost(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11128,7 +11663,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.getXpnResources
         * @desc Get service resources (a.k.a service project) associated with
@@ -11146,7 +11681,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getXpnResources(params, options, callback) {
+    getXpnResources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11167,7 +11704,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.listXpnHosts
         * @desc List all shared VPC host projects visible to the user in an
@@ -11186,7 +11723,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listXpnHosts(params, options, callback) {
+    listXpnHosts(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11206,7 +11745,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.moveDisk
         * @desc Moves a persistent disk from one zone to another.
@@ -11221,7 +11760,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    moveDisk(params, options, callback) {
+    moveDisk(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11241,7 +11782,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.moveInstance
         * @desc Moves an instance and its attached persistent disks from one
@@ -11257,7 +11798,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    moveInstance(params, options, callback) {
+    moveInstance(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11277,7 +11820,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.setCommonInstanceMetadata
         * @desc Sets metadata common to all instances within the specified
@@ -11293,7 +11836,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setCommonInstanceMetadata(params, options, callback) {
+    setCommonInstanceMetadata(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11315,7 +11860,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.setDefaultNetworkTier
         * @desc Sets the default network tier of the project. The default
@@ -11332,7 +11877,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setDefaultNetworkTier(params, options, callback) {
+    setDefaultNetworkTier(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11353,7 +11900,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.setDefaultServiceAccount
         * @desc Sets the default service account of the project. The default
@@ -11370,7 +11917,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setDefaultServiceAccount(params, options, callback) {
+    setDefaultServiceAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11392,7 +11941,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.projects.setUsageExportBucket
         * @desc Enables the usage export feature and sets the usage export
@@ -11409,7 +11958,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setUsageExportBucket(params, options, callback) {
+    setUsageExportBucket(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11430,7 +11981,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11451,7 +12002,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11473,7 +12026,7 @@ function Compute(options) {
             pathParams: ['autoscaler', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.get
             * @desc Returns the specified autoscaler.
@@ -11488,7 +12041,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11510,7 +12064,7 @@ function Compute(options) {
             pathParams: ['autoscaler', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.insert
             * @desc Creates an autoscaler in the specified project using the
@@ -11527,7 +12081,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11549,7 +12105,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.list
             * @desc Retrieves a list of autoscalers contained within the
@@ -11568,7 +12124,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11590,7 +12148,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.patch
             * @desc Updates an autoscaler in the specified project using the
@@ -11609,7 +12167,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11631,7 +12191,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -11648,7 +12208,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11670,7 +12232,7 @@ function Compute(options) {
             pathParams: ['project', 'region', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.update
             * @desc Updates an autoscaler in the specified project using the
@@ -11688,7 +12250,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11710,7 +12274,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -11730,7 +12294,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11752,7 +12318,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.get
         * @desc Returns the specified regional BackendService resource.
@@ -11767,7 +12333,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11789,7 +12356,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.getHealth
         * @desc Gets the most recent health check results for this regional
@@ -11806,7 +12373,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11828,7 +12397,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.insert
         * @desc Creates a regional BackendService resource in the specified
@@ -11848,7 +12417,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11870,7 +12441,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.list
         * @desc Retrieves the list of regional BackendService resources
@@ -11889,7 +12460,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11911,7 +12484,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.patch
         * @desc Updates the specified regional BackendService resource with the
@@ -11933,7 +12506,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11955,7 +12530,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -11971,7 +12546,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11993,7 +12570,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.update
         * @desc Updates the specified regional BackendService resource with the
@@ -12013,7 +12590,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12035,7 +12614,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -12056,7 +12635,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12077,7 +12658,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.get
         * @desc Returns the specified commitment resource. Get a list of
@@ -12093,7 +12674,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12115,7 +12697,7 @@ function Compute(options) {
         pathParams: ['commitment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.insert
         * @desc Creates a commitment in the specified project using the data
@@ -12132,7 +12714,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12154,7 +12738,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.list
         * @desc Retrieves a list of commitments contained within the specified
@@ -12173,7 +12757,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12195,7 +12781,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -12211,7 +12797,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12233,7 +12821,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -12256,7 +12844,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        createSnapshot(params, options, callback) {
+        createSnapshot(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12278,7 +12868,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionDisks.delete
             * @desc Deletes the specified regional persistent disk. Deleting a
@@ -12298,7 +12888,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12320,7 +12912,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionDisks.get
             * @desc Returns a specified regional persistent disk.
@@ -12335,7 +12927,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12357,7 +12950,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionDisks.insert
             * @desc Creates a persistent regional disk in the specified project
@@ -12375,7 +12968,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12397,7 +12992,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionDisks.list
             * @desc Retrieves the list of persistent disks contained within the
@@ -12416,7 +13011,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12438,7 +13035,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionDisks.resize
             * @desc Resizes the specified regional persistent disk.
@@ -12455,7 +13052,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resize(params, options, callback) {
+        resize(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12477,7 +13076,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionDisks.setLabels
             * @desc Sets the labels on the target regional disk.
@@ -12494,7 +13093,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12516,7 +13117,7 @@ function Compute(options) {
             pathParams: ['project', 'region', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionDisks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -12533,7 +13134,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12555,7 +13158,7 @@ function Compute(options) {
             pathParams: ['project', 'region', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -12575,7 +13178,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12597,7 +13201,7 @@ function Compute(options) {
         pathParams: ['diskType', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionDiskTypes.list
         * @desc Retrieves a list of regional disk types available to the
@@ -12616,7 +13220,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12638,7 +13244,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -12671,7 +13277,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    abandonInstances(params, options, callback) {
+    abandonInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12693,7 +13301,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.applyUpdatesToInstances
         * @desc Apply updates to selected instances the managed instance group.
@@ -12709,7 +13317,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    applyUpdatesToInstances(params, options, callback) {
+    applyUpdatesToInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12731,7 +13341,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.delete
         * @desc Deletes the specified managed instance group and all of the
@@ -12748,7 +13358,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12770,7 +13382,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.deleteInstances
         * @desc Schedules a group action to delete the specified instances in
@@ -12798,7 +13410,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteInstances(params, options, callback) {
+    deleteInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12820,7 +13434,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.deletePerInstanceConfigs
         * @desc Delete selected per-instance configs for the managed instance
@@ -12837,7 +13451,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deletePerInstanceConfigs(params, options, callback) {
+    deletePerInstanceConfigs(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12859,7 +13475,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.get
         * @desc Returns all of the details about the specified managed instance
@@ -12875,7 +13491,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12897,7 +13514,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.insert
         * @desc Creates a managed instance group using the information that you
@@ -12920,7 +13537,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12942,7 +13561,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.list
         * @desc Retrieves the list of managed instance groups that are contained
@@ -12961,7 +13580,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12983,7 +13604,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.listManagedInstances
         * @desc Lists the instances in the managed instance group and instances
@@ -13004,7 +13625,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listManagedInstances(params, options, callback) {
+    listManagedInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13026,7 +13649,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.listPerInstanceConfigs
         * @desc Lists all of the per-instance configs defined for the managed
@@ -13046,7 +13669,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listPerInstanceConfigs(params, options, callback) {
+    listPerInstanceConfigs(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13068,7 +13693,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.patch
         * @desc Updates a managed instance group using the information that you
@@ -13091,7 +13716,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13113,7 +13740,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.recreateInstances
         * @desc Schedules a group action to recreate the specified instances in
@@ -13140,7 +13767,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    recreateInstances(params, options, callback) {
+    recreateInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13162,7 +13791,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.resize
         * @desc Changes the intended size for the managed instance group. If you
@@ -13189,7 +13818,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resize(params, options, callback) {
+    resize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13211,7 +13842,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setAutoHealingPolicies
         * @desc Modifies the autohealing policy for the instances in this
@@ -13229,7 +13860,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setAutoHealingPolicies(params, options, callback) {
+    setAutoHealingPolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13251,7 +13884,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setInstanceTemplate
         * @desc Sets the instance template to use when creating new instances or
@@ -13270,7 +13903,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setInstanceTemplate(params, options, callback) {
+    setInstanceTemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13292,7 +13927,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setTargetPools
         * @desc Modifies the target pools to which all new instances in this
@@ -13310,7 +13945,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTargetPools(params, options, callback) {
+    setTargetPools(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13332,7 +13969,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -13348,7 +13985,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13370,7 +14009,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.update
         * @desc Updates a managed instance group using the information that you
@@ -13391,7 +14030,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13413,7 +14054,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.updatePerInstanceConfigs
         * @desc Insert or patch (for the ones that already exist) per-instance
@@ -13432,7 +14073,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updatePerInstanceConfigs(params, options, callback) {
+    updatePerInstanceConfigs(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13454,7 +14097,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13473,7 +14116,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13495,7 +14139,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.list
         * @desc Retrieves the list of instance group resources contained within
@@ -13514,7 +14158,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13536,7 +14182,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.listInstances
         * @desc Lists the instances in the specified instance group and displays
@@ -13559,7 +14205,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listInstances(params, options, callback) {
+    listInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13581,7 +14229,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.setNamedPorts
         * @desc Sets the named ports for the specified regional instance group.
@@ -13598,7 +14246,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setNamedPorts(params, options, callback) {
+    setNamedPorts(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13620,7 +14270,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -13636,7 +14286,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13658,7 +14310,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13677,7 +14329,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13699,7 +14353,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionOperations.get
         * @desc Retrieves the specified region-specific Operations resource.
@@ -13714,7 +14368,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13736,7 +14391,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -13755,7 +14410,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13777,7 +14434,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13796,7 +14453,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13817,7 +14475,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regions.list
         * @desc Retrieves the list of region resources available to the
@@ -13835,7 +14493,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13855,7 +14515,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13876,7 +14536,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13897,7 +14559,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.delete
         * @desc Deletes the specified Router resource.
@@ -13913,7 +14575,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13935,7 +14599,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.get
         * @desc Returns the specified Router resource. Get a list of available
@@ -13951,7 +14615,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13973,7 +14638,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.getRouterStatus
         * @desc Retrieves runtime information of the specified router.
@@ -13988,7 +14653,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getRouterStatus(params, options, callback) {
+    getRouterStatus(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14010,7 +14677,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.insert
         * @desc Creates a Router resource in the specified project and region
@@ -14027,7 +14694,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14049,7 +14718,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.list
         * @desc Retrieves a list of Router resources available to the specified
@@ -14068,7 +14737,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14090,7 +14761,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.patch
         * @desc Patches the specified Router resource with the data included in
@@ -14109,7 +14780,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14131,7 +14804,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.preview
         * @desc Preview fields auto-generated during router create and update
@@ -14148,7 +14821,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    preview(params, options, callback) {
+    preview(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14170,7 +14845,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -14186,7 +14861,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14208,7 +14885,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.update
         * @desc Updates the specified Router resource with the data included in
@@ -14226,7 +14903,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14248,7 +14927,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14267,7 +14946,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14288,7 +14969,7 @@ function Compute(options) {
         pathParams: ['project', 'route'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.get
         * @desc Returns the specified Route resource. Get a list of available
@@ -14303,7 +14984,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14324,7 +15006,7 @@ function Compute(options) {
         pathParams: ['project', 'route'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.insert
         * @desc Creates a Route resource in the specified project using the data
@@ -14340,7 +15022,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14360,7 +15044,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.list
         * @desc Retrieves the list of Route resources available to the specified
@@ -14378,7 +15062,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14398,7 +15084,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -14413,7 +15099,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14435,7 +15123,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14455,7 +15143,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addRule(params, options, callback) {
+    addRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14477,7 +15167,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.delete
         * @desc Deletes the specified policy.
@@ -14492,7 +15182,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14514,7 +15206,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.get
         * @desc List all of the ordered rules present in a single specified
@@ -14529,7 +15221,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14551,7 +15244,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.getRule
         * @desc Gets a rule at the specified priority.
@@ -14566,7 +15259,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getRule(params, options, callback) {
+    getRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14588,7 +15283,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.insert
         * @desc Creates a new policy in the specified project using the data
@@ -14604,7 +15299,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14625,7 +15322,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.list
         * @desc List all the policies that have been configured for the
@@ -14643,7 +15340,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14664,7 +15363,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.patch
         * @desc Patches the specified policy with the data included in the
@@ -14681,7 +15380,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14703,7 +15404,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.patchRule
         * @desc Patches a rule at the specified priority.
@@ -14720,7 +15421,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patchRule(params, options, callback) {
+    patchRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14742,7 +15445,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.removeRule
         * @desc Deletes a rule at the specified priority.
@@ -14757,7 +15460,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeRule(params, options, callback) {
+    removeRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14779,7 +15484,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -14794,7 +15499,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14816,7 +15523,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14839,7 +15546,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14861,7 +15570,7 @@ function Compute(options) {
         pathParams: ['project', 'snapshot'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.get
         * @desc Returns the specified Snapshot resource. Get a list of available
@@ -14876,7 +15585,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14898,7 +15608,7 @@ function Compute(options) {
         pathParams: ['project', 'snapshot'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -14913,7 +15623,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14935,7 +15647,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.list
         * @desc Retrieves the list of Snapshot resources contained within the
@@ -14953,7 +15665,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14974,7 +15688,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -14990,7 +15704,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15012,7 +15728,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.setLabels
         * @desc Sets the labels on a snapshot. To learn more about labels, read
@@ -15028,7 +15744,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15050,7 +15768,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -15065,7 +15783,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15087,7 +15807,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -15106,7 +15826,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15128,7 +15850,7 @@ function Compute(options) {
         pathParams: ['project', 'sslCertificate'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.get
         * @desc Returns the specified SslCertificate resource. Get a list of
@@ -15143,7 +15865,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15165,7 +15888,7 @@ function Compute(options) {
         pathParams: ['project', 'sslCertificate'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.insert
         * @desc Creates a SslCertificate resource in the specified project using
@@ -15181,7 +15904,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15202,7 +15927,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.list
         * @desc Retrieves the list of SslCertificate resources available to the
@@ -15220,7 +15945,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15241,7 +15968,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -15256,7 +15983,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15278,7 +16007,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -15299,7 +16028,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15321,7 +16052,7 @@ function Compute(options) {
         pathParams: ['project', 'sslPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.get
         * @desc List all of the ordered rules present in a single specified
@@ -15336,7 +16067,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15358,7 +16090,7 @@ function Compute(options) {
         pathParams: ['project', 'sslPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.insert
         * @desc Returns the specified SSL policy resource. Get a list of
@@ -15374,7 +16106,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15395,7 +16129,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.list
         * @desc List all the SSL policies that have been configured for the
@@ -15413,7 +16147,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15434,7 +16170,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.listAvailableFeatures
         * @desc Lists all features that can be specified in the SSL policy when
@@ -15452,7 +16188,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listAvailableFeatures(params, options, callback) {
+    listAvailableFeatures(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15474,7 +16212,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.patch
         * @desc Patches the specified SSL policy with the data included in the
@@ -15491,7 +16229,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15513,7 +16253,7 @@ function Compute(options) {
         pathParams: ['project', 'sslPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -15528,7 +16268,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15550,7 +16292,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -15571,7 +16313,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15592,7 +16336,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.delete
         * @desc Deletes the specified subnetwork.
@@ -15608,7 +16352,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15630,7 +16376,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.expandIpCidrRange
         * @desc Expands the IP CIDR range of the subnetwork to a specified
@@ -15648,7 +16394,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    expandIpCidrRange(params, options, callback) {
+    expandIpCidrRange(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15670,7 +16418,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.get
         * @desc Returns the specified subnetwork. Get a list of available
@@ -15686,7 +16434,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15708,7 +16457,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -15724,7 +16473,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15746,7 +16497,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.insert
         * @desc Creates a subnetwork in the specified project using the data
@@ -15763,7 +16514,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15785,7 +16538,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.list
         * @desc Retrieves a list of subnetworks available to the specified
@@ -15804,7 +16557,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15826,7 +16581,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.listUsable
         * @desc Retrieves an aggregated list of usable subnetworks.
@@ -15843,7 +16598,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listUsable(params, options, callback) {
+    listUsable(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15865,7 +16622,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.patch
         * @desc Patches the specified subnetwork with the data included in the
@@ -15886,7 +16643,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15908,7 +16667,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -15925,7 +16684,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15947,7 +16708,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.setPrivateIpGoogleAccess
         * @desc Set whether VMs in this subnet can access Google services
@@ -15965,7 +16726,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setPrivateIpGoogleAccess(params, options, callback) {
+    setPrivateIpGoogleAccess(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15987,7 +16750,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -16003,7 +16766,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16025,7 +16790,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -16045,7 +16810,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16067,7 +16834,7 @@ function Compute(options) {
             pathParams: ['project', 'targetHttpProxy'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.targetHttpProxies.get
             * @desc Returns the specified TargetHttpProxy resource. Get a list
@@ -16082,7 +16849,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16104,7 +16872,7 @@ function Compute(options) {
             pathParams: ['project', 'targetHttpProxy'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.targetHttpProxies.insert
             * @desc Creates a TargetHttpProxy resource in the specified project
@@ -16120,7 +16888,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16142,7 +16912,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.targetHttpProxies.list
             * @desc Retrieves the list of TargetHttpProxy resources available to
@@ -16160,7 +16930,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16182,7 +16954,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.targetHttpProxies.setUrlMap
             * @desc Changes the URL map for TargetHttpProxy.
@@ -16198,7 +16970,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setUrlMap(params, options, callback) {
+        setUrlMap(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16220,7 +16994,7 @@ function Compute(options) {
             pathParams: ['project', 'targetHttpProxy'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.targetHttpProxies.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -16236,7 +17010,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16258,7 +17034,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -16277,7 +17053,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16299,7 +17077,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.get
         * @desc Returns the specified TargetHttpsProxy resource. Get a list of
@@ -16314,7 +17092,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16336,7 +17115,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.insert
         * @desc Creates a TargetHttpsProxy resource in the specified project
@@ -16352,7 +17131,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16374,7 +17155,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.list
         * @desc Retrieves the list of TargetHttpsProxy resources available to
@@ -16392,7 +17173,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16414,7 +17197,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setQuicOverride
         * @desc Sets the QUIC override policy for TargetHttpsProxy.
@@ -16430,7 +17213,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setQuicOverride(params, options, callback) {
+    setQuicOverride(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16452,7 +17237,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setSslCertificates
         * @desc Replaces SslCertificates for TargetHttpsProxy.
@@ -16468,7 +17253,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslCertificates(params, options, callback) {
+    setSslCertificates(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16490,7 +17277,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setSslPolicy
         * @desc Sets the SSL policy for TargetHttpsProxy. The SSL policy
@@ -16509,7 +17296,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslPolicy(params, options, callback) {
+    setSslPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16531,7 +17320,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setUrlMap
         * @desc Changes the URL map for TargetHttpsProxy.
@@ -16547,7 +17336,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setUrlMap(params, options, callback) {
+    setUrlMap(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16569,7 +17360,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -16584,7 +17375,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16606,7 +17399,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -16627,7 +17420,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16649,7 +17444,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.delete
         * @desc Deletes the specified TargetInstance resource.
@@ -16665,7 +17460,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16687,7 +17484,7 @@ function Compute(options) {
         pathParams: ['project', 'targetInstance', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.get
         * @desc Returns the specified TargetInstance resource. Get a list of
@@ -16703,7 +17500,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16725,7 +17523,7 @@ function Compute(options) {
         pathParams: ['project', 'targetInstance', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.insert
         * @desc Creates a TargetInstance resource in the specified project and
@@ -16742,7 +17540,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16764,7 +17564,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.list
         * @desc Retrieves a list of TargetInstance resources available to the
@@ -16783,7 +17583,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16805,7 +17607,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -16821,7 +17623,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16843,7 +17647,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -16864,7 +17668,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addHealthCheck(params, options, callback) {
+    addHealthCheck(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16886,7 +17692,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.addInstance
         * @desc Adds an instance to a target pool.
@@ -16903,7 +17709,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    addInstance(params, options, callback) {
+    addInstance(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16925,7 +17733,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.aggregatedList
         * @desc Retrieves an aggregated list of target pools.
@@ -16942,7 +17750,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16963,7 +17773,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.delete
         * @desc Deletes the specified target pool.
@@ -16979,7 +17789,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17001,7 +17813,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.get
         * @desc Returns the specified target pool. Get a list of available
@@ -17017,7 +17829,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17039,7 +17852,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.getHealth
         * @desc Gets the most recent health check results for each IP for the
@@ -17056,7 +17869,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17078,7 +17893,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.insert
         * @desc Creates a target pool in the specified project and region using
@@ -17095,7 +17910,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17117,7 +17934,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.list
         * @desc Retrieves a list of target pools available to the specified
@@ -17136,7 +17953,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17158,7 +17977,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.removeHealthCheck
         * @desc Removes health check URL from a target pool.
@@ -17175,7 +17994,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeHealthCheck(params, options, callback) {
+    removeHealthCheck(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17197,7 +18018,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.removeInstance
         * @desc Removes instance URL from a target pool.
@@ -17214,7 +18035,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeInstance(params, options, callback) {
+    removeInstance(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17236,7 +18059,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.setBackup
         * @desc Changes a backup target pool's configurations.
@@ -17254,7 +18077,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackup(params, options, callback) {
+    setBackup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17276,7 +18101,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -17292,7 +18117,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17314,7 +18141,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17333,7 +18160,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17355,7 +18184,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.get
         * @desc Returns the specified TargetSslProxy resource. Get a list of
@@ -17370,7 +18199,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17392,7 +18222,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.insert
         * @desc Creates a TargetSslProxy resource in the specified project using
@@ -17408,7 +18238,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17429,7 +18261,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.list
         * @desc Retrieves the list of TargetSslProxy resources available to the
@@ -17447,7 +18279,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17468,7 +18302,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setBackendService
         * @desc Changes the BackendService for TargetSslProxy.
@@ -17484,7 +18318,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackendService(params, options, callback) {
+    setBackendService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17506,7 +18342,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setProxyHeader
         * @desc Changes the ProxyHeaderType for TargetSslProxy.
@@ -17522,7 +18358,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setProxyHeader(params, options, callback) {
+    setProxyHeader(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17544,7 +18382,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setSslCertificates
         * @desc Changes SslCertificates for TargetSslProxy.
@@ -17560,7 +18398,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslCertificates(params, options, callback) {
+    setSslCertificates(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17582,7 +18422,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setSslPolicy
         * @desc Sets the SSL policy for TargetSslProxy. The SSL policy specifies
@@ -17601,7 +18441,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslPolicy(params, options, callback) {
+    setSslPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17623,7 +18465,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -17638,7 +18480,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17660,7 +18504,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17679,7 +18523,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17701,7 +18547,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.get
         * @desc Returns the specified TargetTcpProxy resource. Get a list of
@@ -17716,7 +18562,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17738,7 +18585,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.insert
         * @desc Creates a TargetTcpProxy resource in the specified project using
@@ -17754,7 +18601,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17775,7 +18624,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.list
         * @desc Retrieves the list of TargetTcpProxy resources available to the
@@ -17793,7 +18642,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17814,7 +18665,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.setBackendService
         * @desc Changes the BackendService for TargetTcpProxy.
@@ -17830,7 +18681,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackendService(params, options, callback) {
+    setBackendService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17852,7 +18705,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.setProxyHeader
         * @desc Changes the ProxyHeaderType for TargetTcpProxy.
@@ -17868,7 +18721,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setProxyHeader(params, options, callback) {
+    setProxyHeader(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17890,7 +18745,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -17905,7 +18760,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17927,7 +18784,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17948,7 +18805,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17970,7 +18829,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.delete
         * @desc Deletes the specified target VPN gateway.
@@ -17986,7 +18845,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18008,7 +18869,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetVpnGateway'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.get
         * @desc Returns the specified target VPN gateway. Get a list of
@@ -18024,7 +18885,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18046,7 +18908,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetVpnGateway'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.insert
         * @desc Creates a target VPN gateway in the specified project and region
@@ -18063,7 +18925,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18085,7 +18949,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.list
         * @desc Retrieves a list of target VPN gateways available to the
@@ -18104,7 +18968,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18126,7 +18992,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.setLabels
         * @desc Sets the labels on a TargetVpnGateway. To learn more about
@@ -18144,7 +19010,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18166,7 +19034,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -18182,7 +19050,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18204,7 +19074,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18223,7 +19093,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18244,7 +19116,7 @@ function Compute(options) {
         pathParams: ['project', 'urlMap'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.get
         * @desc Returns the specified UrlMap resource. Get a list of available
@@ -18259,7 +19131,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18280,7 +19153,7 @@ function Compute(options) {
         pathParams: ['project', 'urlMap'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.insert
         * @desc Creates a UrlMap resource in the specified project using the
@@ -18296,7 +19169,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18317,7 +19192,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.invalidateCache
         * @desc Initiates a cache invalidation operation, invalidating the
@@ -18334,7 +19209,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    invalidateCache(params, options, callback) {
+    invalidateCache(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18356,7 +19233,7 @@ function Compute(options) {
         pathParams: ['project', 'urlMap'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.list
         * @desc Retrieves the list of UrlMap resources available to the
@@ -18374,7 +19251,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18395,7 +19274,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.patch
         * @desc Patches the specified UrlMap resource with the data included in
@@ -18413,7 +19292,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18434,7 +19315,7 @@ function Compute(options) {
         pathParams: ['project', 'urlMap'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -18449,7 +19330,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18471,7 +19354,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.update
         * @desc Updates the specified UrlMap resource with the data included in
@@ -18488,7 +19371,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18509,7 +19394,7 @@ function Compute(options) {
         pathParams: ['project', 'urlMap'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.urlMaps.validate
         * @desc Runs static validation for the UrlMap. In particular, the tests
@@ -18526,7 +19411,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    validate(params, options, callback) {
+    validate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18548,7 +19435,7 @@ function Compute(options) {
         pathParams: ['project', 'urlMap'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18569,7 +19456,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18590,7 +19479,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.delete
         * @desc Deletes the specified VpnTunnel resource.
@@ -18606,7 +19495,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18628,7 +19519,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'vpnTunnel'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.get
         * @desc Returns the specified VpnTunnel resource. Get a list of
@@ -18644,7 +19535,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18666,7 +19558,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'vpnTunnel'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.insert
         * @desc Creates a VpnTunnel resource in the specified project and region
@@ -18683,7 +19575,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18705,7 +19599,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.list
         * @desc Retrieves a list of VpnTunnel resources contained in the
@@ -18724,7 +19618,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18746,7 +19642,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.setLabels
         * @desc Sets the labels on a VpnTunnel. To learn more about labels, read
@@ -18764,7 +19660,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18786,7 +19684,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -18802,7 +19700,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18824,7 +19724,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18843,7 +19743,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18865,7 +19767,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zoneOperations.get
         * @desc Retrieves the specified zone-specific Operations resource.
@@ -18880,7 +19782,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18902,7 +19805,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zoneOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -18921,7 +19824,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18942,7 +19847,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18961,7 +19866,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18981,7 +19887,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zones.list
         * @desc Retrieves the list of Zone resources available to the specified
@@ -18999,7 +19905,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19019,7 +19927,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/compute/beta.ts
+++ b/src/apis/compute/beta.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Compute Engine API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation beta
  * @param {object=} options Options for Compute
  */
-function Compute(options) {
+function Compute(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.acceleratorTypes = {
@@ -118,7 +125,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +149,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.acceleratorTypes.get
         * @desc Returns the specified accelerator type. Get a list of available
@@ -216,7 +225,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -238,7 +248,7 @@ function Compute(options) {
         pathParams: ['acceleratorType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.acceleratorTypes.list
         * @desc Retrieves a list of accelerator types available to the specified
@@ -326,7 +336,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -348,7 +360,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -436,7 +448,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -457,7 +471,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.delete
         * @desc Deletes the specified address resource.
@@ -532,7 +546,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -554,7 +570,7 @@ function Compute(options) {
         pathParams: ['address', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.get
         * @desc Returns the specified address resource.
@@ -628,7 +644,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -650,7 +667,7 @@ function Compute(options) {
         pathParams: ['address', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.insert
         * @desc Creates an address resource in the specified project using the
@@ -727,7 +744,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -749,7 +768,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.list
         * @desc Retrieves a list of addresses contained within the specified
@@ -837,7 +856,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -859,7 +880,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.setLabels
         * @desc Sets the labels on an Address. To learn more about labels, read
@@ -940,7 +961,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -962,7 +985,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -1039,7 +1062,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1061,7 +1086,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1149,7 +1174,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1170,7 +1197,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.delete
         * @desc Deletes the specified autoscaler.
@@ -1245,7 +1272,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1267,7 +1296,7 @@ function Compute(options) {
         pathParams: ['autoscaler', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.get
         * @desc Returns the specified autoscaler resource. Get a list of
@@ -1342,7 +1371,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1364,7 +1394,7 @@ function Compute(options) {
         pathParams: ['autoscaler', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.insert
         * @desc Creates an autoscaler in the specified project using the data
@@ -1441,7 +1471,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1462,7 +1494,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.list
         * @desc Retrieves a list of autoscalers contained within the specified
@@ -1550,7 +1582,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1571,7 +1605,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.patch
         * @desc Updates an autoscaler in the specified project using the data
@@ -1652,7 +1686,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1673,7 +1709,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -1750,7 +1786,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1772,7 +1810,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.update
         * @desc Updates an autoscaler in the specified project using the data
@@ -1852,7 +1890,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1873,7 +1913,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1893,7 +1933,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addSignedUrlKey(params, options, callback) {
+    addSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1915,7 +1957,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.delete
         * @desc Deletes the specified BackendBucket resource.
@@ -1987,7 +2029,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2009,7 +2053,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.deleteSignedUrlKey
         * @desc Deletes the given Signed URL Key from the backend bucket.
@@ -2025,7 +2069,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteSignedUrlKey(params, options, callback) {
+    deleteSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2047,7 +2093,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.get
         * @desc Returns the specified BackendBucket resource. Get a list of
@@ -2119,7 +2165,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2141,7 +2188,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.insert
         * @desc Creates a BackendBucket resource in the specified project using
@@ -2214,7 +2261,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2235,7 +2284,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.list
         * @desc Retrieves the list of BackendBucket resources available to the
@@ -2319,7 +2368,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2340,7 +2391,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.patch
         * @desc Updates the specified BackendBucket resource with the data
@@ -2421,7 +2472,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2443,7 +2496,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendBuckets.update
         * @desc Updates the specified BackendBucket resource with the data
@@ -2523,7 +2576,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2545,7 +2600,7 @@ function Compute(options) {
         pathParams: ['backendBucket', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2565,7 +2620,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addSignedUrlKey(params, options, callback) {
+    addSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2587,7 +2644,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.aggregatedList
         * @desc Retrieves the list of all BackendService resources, regional and
@@ -2672,7 +2729,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2694,7 +2753,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.delete
         * @desc Deletes the specified BackendService resource.
@@ -2766,7 +2825,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2788,7 +2849,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.deleteSignedUrlKey
         * @desc Deletes the given Signed URL Key from the specified backend
@@ -2805,7 +2866,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteSignedUrlKey(params, options, callback) {
+    deleteSignedUrlKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2827,7 +2890,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.get
         * @desc Returns the specified BackendService resource. Get a list of
@@ -2899,7 +2962,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2921,7 +2985,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.getHealth
         * @desc Gets the most recent health check results for this
@@ -2997,7 +3061,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3019,7 +3085,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.insert
         * @desc Creates a BackendService resource in the specified project using
@@ -3094,7 +3160,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3115,7 +3183,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.list
         * @desc Retrieves the list of BackendService resources available to the
@@ -3199,7 +3267,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3220,7 +3290,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.patch
         * @desc Patches the specified BackendService resource with the data
@@ -3303,7 +3373,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3325,7 +3397,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.setSecurityPolicy
         * @desc Sets the security policy for the specified backend service.
@@ -3402,7 +3474,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSecurityPolicy(params, options, callback) {
+    setSecurityPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3424,7 +3498,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -3497,7 +3571,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3519,7 +3595,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.update
         * @desc Updates the specified BackendService resource with the data
@@ -3601,7 +3677,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3623,7 +3701,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3712,7 +3790,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        aggregatedList(params, options, callback) {
+        aggregatedList(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3733,7 +3813,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.createSnapshot
             * @desc Creates a snapshot of a specified persistent disk.
@@ -3814,7 +3894,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        createSnapshot(params, options, callback) {
+        createSnapshot(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3836,7 +3918,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.delete
             * @desc Deletes the specified persistent disk. Deleting a disk
@@ -3914,7 +3996,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3936,7 +4020,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.get
             * @desc Returns a specified persistent disk. Get a list of available
@@ -4011,7 +4095,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4033,7 +4118,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.insert
             * @desc Creates a persistent disk in the specified project using the
@@ -4114,7 +4199,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4135,7 +4222,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.list
             * @desc Retrieves a list of persistent disks contained within the
@@ -4223,7 +4310,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4244,7 +4333,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.resize
             * @desc Resizes the specified persistent disk. You can only increase
@@ -4325,7 +4414,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resize(params, options, callback) {
+        resize(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4347,7 +4438,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.setLabels
             * @desc Sets the labels on a disk. To learn more about labels, read
@@ -4428,7 +4519,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4450,7 +4543,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -4528,7 +4621,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4550,7 +4645,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -4638,7 +4733,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4659,7 +4756,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.diskTypes.get
         * @desc Returns the specified disk type. Get a list of available disk
@@ -4734,7 +4831,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4756,7 +4854,7 @@ function Compute(options) {
         pathParams: ['diskType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.diskTypes.list
         * @desc Retrieves a list of disk types available to the specified
@@ -4844,7 +4942,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4865,7 +4965,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4941,7 +5041,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4963,7 +5065,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.get
             * @desc Returns the specified firewall.
@@ -5033,7 +5135,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5055,7 +5158,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.insert
             * @desc Creates a firewall rule in the specified project using the
@@ -5128,7 +5231,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5149,7 +5254,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.list
             * @desc Retrieves the list of firewall rules available to the
@@ -5233,7 +5338,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5254,7 +5361,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.patch
             * @desc Updates the specified firewall rule with the data included
@@ -5334,7 +5441,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5356,7 +5465,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -5430,7 +5539,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5452,7 +5563,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.firewalls.update
             * @desc Updates the specified firewall rule with the data included
@@ -5533,7 +5644,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -5555,7 +5668,7 @@ function Compute(options) {
             pathParams: ['firewall', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -5643,7 +5756,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5665,7 +5780,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.delete
         * @desc Deletes the specified ForwardingRule resource.
@@ -5741,7 +5856,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5763,7 +5880,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.get
         * @desc Returns the specified ForwardingRule resource.
@@ -5838,7 +5955,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5860,7 +5978,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.insert
         * @desc Creates a ForwardingRule resource in the specified project and
@@ -5937,7 +6055,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5959,7 +6079,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.list
         * @desc Retrieves a list of ForwardingRule resources available to the
@@ -6047,7 +6167,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6069,7 +6191,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.setLabels
         * @desc Sets the labels on the specified resource. To learn more about
@@ -6150,7 +6272,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6172,7 +6296,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.setTarget
         * @desc Changes target URL for forwarding rule. The new target should be
@@ -6254,7 +6378,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTarget(params, options, callback) {
+    setTarget(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6276,7 +6402,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -6353,7 +6479,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6375,7 +6503,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6450,7 +6578,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6472,7 +6602,7 @@ function Compute(options) {
         pathParams: ['address', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.get
         * @desc Returns the specified address resource. Get a list of available
@@ -6543,7 +6673,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6565,7 +6696,7 @@ function Compute(options) {
         pathParams: ['address', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.insert
         * @desc Creates an address resource in the specified project using the
@@ -6638,7 +6769,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6659,7 +6792,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.list
         * @desc Retrieves a list of global addresses.
@@ -6742,7 +6875,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6763,7 +6898,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.setLabels
         * @desc Sets the labels on a GlobalAddress. To learn more about labels,
@@ -6839,7 +6974,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6861,7 +6998,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -6934,7 +7071,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6956,7 +7095,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7032,7 +7171,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7054,7 +7195,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.get
         * @desc Returns the specified GlobalForwardingRule resource. Get a list
@@ -7126,7 +7267,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7148,7 +7290,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.insert
         * @desc Creates a GlobalForwardingRule resource in the specified project
@@ -7219,7 +7361,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7240,7 +7384,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.list
         * @desc Retrieves a list of GlobalForwardingRule resources available to
@@ -7324,7 +7468,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7345,7 +7491,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.setLabels
         * @desc Sets the labels on the specified resource. To learn more about
@@ -7419,7 +7565,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7441,7 +7589,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.setTarget
         * @desc Changes target URL for the GlobalForwardingRule resource. The
@@ -7517,7 +7665,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTarget(params, options, callback) {
+    setTarget(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7539,7 +7689,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -7612,7 +7762,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7634,7 +7786,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7722,7 +7874,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7743,7 +7897,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.delete
         * @desc Deletes the specified Operations resource.
@@ -7810,7 +7964,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7832,7 +7988,7 @@ function Compute(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.get
         * @desc Retrieves the specified Operations resource. Get a list of
@@ -7903,7 +8059,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7925,7 +8082,7 @@ function Compute(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -8009,7 +8166,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8030,7 +8189,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8107,7 +8266,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8129,7 +8290,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.get
             * @desc Returns the specified HealthCheck resource. Get a list of
@@ -8201,7 +8362,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8223,7 +8385,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.insert
             * @desc Creates a HealthCheck resource in the specified project
@@ -8296,7 +8458,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8317,7 +8481,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.list
             * @desc Retrieves the list of HealthCheck resources available to the
@@ -8401,7 +8565,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8422,7 +8588,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.patch
             * @desc Updates a HealthCheck resource in the specified project
@@ -8504,7 +8670,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8526,7 +8694,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -8600,7 +8768,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8622,7 +8792,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.update
             * @desc Updates a HealthCheck resource in the specified project
@@ -8702,7 +8872,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8724,7 +8896,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -8800,7 +8972,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8822,7 +8996,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.get
         * @desc Returns the specified HttpHealthCheck resource. Get a list of
@@ -8894,7 +9068,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8916,7 +9091,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.insert
         * @desc Creates a HttpHealthCheck resource in the specified project
@@ -8989,7 +9164,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9010,7 +9187,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.list
         * @desc Retrieves the list of HttpHealthCheck resources available to the
@@ -9094,7 +9271,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9115,7 +9294,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.patch
         * @desc Updates a HttpHealthCheck resource in the specified project
@@ -9196,7 +9375,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9218,7 +9399,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -9291,7 +9472,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9313,7 +9496,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.update
         * @desc Updates a HttpHealthCheck resource in the specified project
@@ -9393,7 +9576,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9415,7 +9600,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -9491,7 +9676,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9513,7 +9700,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.get
         * @desc Returns the specified HttpsHealthCheck resource. Get a list of
@@ -9585,7 +9772,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9607,7 +9795,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.insert
         * @desc Creates a HttpsHealthCheck resource in the specified project
@@ -9680,7 +9868,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9701,7 +9891,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.list
         * @desc Retrieves the list of HttpsHealthCheck resources available to
@@ -9785,7 +9975,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9806,7 +9998,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.patch
         * @desc Updates a HttpsHealthCheck resource in the specified project
@@ -9887,7 +10079,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9909,7 +10103,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -9982,7 +10176,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10004,7 +10200,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.update
         * @desc Updates a HttpsHealthCheck resource in the specified project
@@ -10084,7 +10280,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10106,7 +10304,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -10182,7 +10380,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10204,7 +10404,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.deprecate
             * @desc Sets the deprecation status of an image.  If an empty
@@ -10281,7 +10481,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        deprecate(params, options, callback) {
+        deprecate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10303,7 +10505,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.get
             * @desc Returns the specified image. Get a list of available images
@@ -10374,7 +10576,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10396,7 +10599,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.getFromFamily
             * @desc Returns the latest image that is part of an image family and
@@ -10467,7 +10670,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getFromFamily(params, options, callback) {
+        getFromFamily(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10489,7 +10694,7 @@ function Compute(options) {
             pathParams: ['family', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.insert
             * @desc Creates an image in the specified project using the data
@@ -10563,7 +10768,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10584,7 +10791,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.list
             * @desc Retrieves the list of custom images available to the
@@ -10673,7 +10880,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10694,7 +10903,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.setLabels
             * @desc Sets the labels on an image. To learn more about labels,
@@ -10770,7 +10979,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10792,7 +11003,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -10866,7 +11077,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10888,7 +11101,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -10984,7 +11197,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        abandonInstances(params, options, callback) {
+        abandonInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11006,7 +11221,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.aggregatedList
             * @desc Retrieves the list of managed instance groups and groups
@@ -11093,7 +11308,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        aggregatedList(params, options, callback) {
+        aggregatedList(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11115,7 +11332,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.delete
             * @desc Deletes the specified managed instance group and all of the
@@ -11192,7 +11409,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11214,7 +11433,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.deleteInstances
             * @desc Schedules a group action to delete the specified instances
@@ -11304,7 +11523,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        deleteInstances(params, options, callback) {
+        deleteInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11326,7 +11547,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.get
             * @desc Returns all of the details about the specified managed
@@ -11401,7 +11622,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11423,7 +11645,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.insert
             * @desc Creates a managed instance group using the information that
@@ -11507,7 +11729,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11529,7 +11753,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.list
             * @desc Retrieves a list of managed instance groups that are
@@ -11617,7 +11841,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11639,7 +11865,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.listManagedInstances
             * @desc Lists all of the instances in the managed instance group.
@@ -11740,7 +11966,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listManagedInstances(params, options, callback) {
+        listManagedInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11762,7 +11990,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.patch
             * @desc Updates a managed instance group using the information that
@@ -11850,7 +12078,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11872,7 +12102,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.recreateInstances
             * @desc Schedules a group action to recreate the specified instances
@@ -11961,7 +12191,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        recreateInstances(params, options, callback) {
+        recreateInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11983,7 +12215,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.resize
             * @desc Resizes the managed instance group. If you increase the
@@ -12075,7 +12307,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resize(params, options, callback) {
+        resize(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12097,7 +12331,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.resizeAdvanced
             * @desc Resizes the managed instance group with advanced
@@ -12188,7 +12422,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resizeAdvanced(params, options, callback) {
+        resizeAdvanced(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12210,7 +12446,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.setAutoHealingPolicies
             * @desc Modifies the autohealing policies.
@@ -12289,7 +12525,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setAutoHealingPolicies(params, options, callback) {
+        setAutoHealingPolicies(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12311,7 +12549,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.setInstanceTemplate
             * @desc Specifies the instance template to use when creating new
@@ -12392,7 +12630,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setInstanceTemplate(params, options, callback) {
+        setInstanceTemplate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12414,7 +12654,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.setTargetPools
             * @desc Modifies the target pools to which all instances in this
@@ -12499,7 +12739,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setTargetPools(params, options, callback) {
+        setTargetPools(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12521,7 +12763,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -12599,7 +12841,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12621,7 +12865,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.update
             * @desc Updates a managed instance group using the information that
@@ -12707,7 +12951,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12729,7 +12975,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -12816,7 +13062,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addInstances(params, options, callback) {
+    addInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12838,7 +13086,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.aggregatedList
         * @desc Retrieves the list of instance groups and sorts them by zone.
@@ -12922,7 +13170,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12944,7 +13194,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.delete
         * @desc Deletes the specified instance group. The instances in the group
@@ -13022,7 +13272,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13044,7 +13296,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.get
         * @desc Returns the specified instance group. Get a list of available
@@ -13120,7 +13372,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13142,7 +13395,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.insert
         * @desc Creates an instance group in the specified project using the
@@ -13219,7 +13472,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13241,7 +13496,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.list
         * @desc Retrieves the list of instance groups that are located in the
@@ -13329,7 +13584,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13351,7 +13608,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.listInstances
         * @desc Lists the instances in the specified instance group.
@@ -13448,7 +13705,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listInstances(params, options, callback) {
+    listInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13470,7 +13729,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.removeInstances
         * @desc Removes one or more instances from the specified instance group,
@@ -13553,7 +13812,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeInstances(params, options, callback) {
+    removeInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13575,7 +13836,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.setNamedPorts
         * @desc Sets the named ports for the specified instance group.
@@ -13654,7 +13915,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setNamedPorts(params, options, callback) {
+    setNamedPorts(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13676,7 +13939,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -13753,7 +14016,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13775,7 +14040,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13862,7 +14127,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        addAccessConfig(params, options, callback) {
+        addAccessConfig(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13884,7 +14151,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.aggregatedList
             * @desc Retrieves aggregated list of instances.
@@ -13968,7 +14235,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        aggregatedList(params, options, callback) {
+        aggregatedList(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13989,7 +14258,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.attachDisk
             * @desc Attaches an existing Disk resource to an instance. You must
@@ -14072,7 +14341,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        attachDisk(params, options, callback) {
+        attachDisk(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14094,7 +14365,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.delete
             * @desc Deletes the specified Instance resource. For more
@@ -14170,7 +14441,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14192,7 +14465,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.deleteAccessConfig
             * @desc Deletes an access config from an instance's network
@@ -14274,7 +14547,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        deleteAccessConfig(params, options, callback) {
+        deleteAccessConfig(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14298,7 +14573,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.detachDisk
             * @desc Detaches a disk from an instance.
@@ -14377,7 +14652,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        detachDisk(params, options, callback) {
+        detachDisk(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14399,7 +14676,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.get
             * @desc Returns the specified Instance resource. Get a list of
@@ -14474,7 +14751,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14496,7 +14774,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.getSerialPortOutput
             * @desc Returns the specified instance's serial port output.
@@ -14570,7 +14848,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getSerialPortOutput(params, options, callback) {
+        getSerialPortOutput(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14592,7 +14872,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.insert
             * @desc Creates an instance resource in the specified project using
@@ -14670,7 +14950,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14692,7 +14974,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.list
             * @desc Retrieves the list of instances contained within the
@@ -14780,7 +15062,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14802,7 +15086,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.listReferrers
             * @desc Retrieves the list of referrers to instances contained
@@ -14896,7 +15180,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listReferrers(params, options, callback) {
+        listReferrers(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -14918,7 +15204,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.reset
             * @desc Performs a reset on the instance. For more information, see
@@ -14994,7 +15280,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        reset(params, options, callback) {
+        reset(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15016,7 +15304,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setDeletionProtection
             * @desc Sets deletion protection on the instance.
@@ -15090,7 +15378,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setDeletionProtection(params, options, callback) {
+        setDeletionProtection(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15112,7 +15402,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setDiskAutoDelete
             * @desc Sets the auto-delete flag for a disk attached to an
@@ -15194,7 +15484,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setDiskAutoDelete(params, options, callback) {
+        setDiskAutoDelete(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15217,7 +15509,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setLabels
             * @desc Sets labels on an instance. To learn more about labels, read
@@ -15298,7 +15590,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15320,7 +15614,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMachineResources
             * @desc Changes the number and/or type of accelerator for a stopped
@@ -15399,7 +15693,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMachineResources(params, options, callback) {
+        setMachineResources(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15421,7 +15717,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMachineType
             * @desc Changes the machine type for a stopped instance to the
@@ -15500,7 +15796,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMachineType(params, options, callback) {
+        setMachineType(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15522,7 +15820,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMetadata
             * @desc Sets metadata for the specified instance to the data
@@ -15603,7 +15901,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMetadata(params, options, callback) {
+        setMetadata(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15625,7 +15925,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMinCpuPlatform
             * @desc Changes the minimum CPU platform that this instance should
@@ -15705,7 +16005,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMinCpuPlatform(params, options, callback) {
+        setMinCpuPlatform(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15727,7 +16029,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setScheduling
             * @desc Sets an instance's scheduling options.
@@ -15805,7 +16107,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setScheduling(params, options, callback) {
+        setScheduling(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15827,7 +16131,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setServiceAccount
             * @desc Sets the service account on the instance. For more
@@ -15907,7 +16211,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setServiceAccount(params, options, callback) {
+        setServiceAccount(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15929,7 +16235,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setTags
             * @desc Sets tags for the specified instance to the data included in
@@ -16010,7 +16316,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setTags(params, options, callback) {
+        setTags(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16032,7 +16340,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.start
             * @desc Starts an instance that was stopped using the using the
@@ -16109,7 +16417,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        start(params, options, callback) {
+        start(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16131,7 +16441,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.startWithEncryptionKey
             * @desc Starts an instance that was stopped using the using the
@@ -16211,7 +16521,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        startWithEncryptionKey(params, options, callback) {
+        startWithEncryptionKey(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16233,7 +16545,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.stop
             * @desc Stops a running instance, shutting it down cleanly, and
@@ -16313,7 +16625,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        stop(params, options, callback) {
+        stop(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16335,7 +16649,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -16413,7 +16727,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16435,7 +16751,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.updateAccessConfig
             * @desc Updates the specified access config from an instance's
@@ -16521,7 +16837,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        updateAccessConfig(params, options, callback) {
+        updateAccessConfig(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16543,7 +16861,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.updateNetworkInterface
             * @desc Updates an instance's network interface. This method follows
@@ -16628,7 +16946,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        updateNetworkInterface(params, options, callback) {
+        updateNetworkInterface(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16650,7 +16970,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -16728,7 +17048,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16750,7 +17072,7 @@ function Compute(options) {
         pathParams: ['instanceTemplate', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.get
         * @desc Returns the specified instance template. Get a list of available
@@ -16822,7 +17144,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16844,7 +17167,7 @@ function Compute(options) {
         pathParams: ['instanceTemplate', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.insert
         * @desc Creates an instance template in the specified project using the
@@ -16920,7 +17243,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16941,7 +17266,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.list
         * @desc Retrieves a list of instance templates that are contained within
@@ -17025,7 +17350,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17046,7 +17373,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -17119,7 +17446,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17141,7 +17470,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17230,7 +17559,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17252,7 +17583,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.delete
         * @desc Deletes the specified interconnect attachment.
@@ -17326,7 +17657,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17348,7 +17681,7 @@ function Compute(options) {
         pathParams: ['interconnectAttachment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.get
         * @desc Returns the specified interconnect attachment.
@@ -17421,7 +17754,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17443,7 +17777,7 @@ function Compute(options) {
         pathParams: ['interconnectAttachment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.insert
         * @desc Creates an InterconnectAttachment in the specified project using
@@ -17518,7 +17852,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17540,7 +17876,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.list
         * @desc Retrieves the list of interconnect attachments contained within
@@ -17628,7 +17964,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17650,7 +17988,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.setLabels
         * @desc Sets the labels on an InterconnectAttachment. To learn more
@@ -17668,7 +18006,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17690,7 +18030,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -17767,7 +18107,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17789,7 +18131,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17865,7 +18207,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17887,7 +18230,7 @@ function Compute(options) {
         pathParams: ['interconnectLocation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectLocations.list
         * @desc Retrieves the list of interconnect locations available to the
@@ -17971,7 +18314,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17993,7 +18338,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18070,7 +18415,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18092,7 +18439,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.get
             * @desc Returns the specified interconnect. Get a list of available
@@ -18164,7 +18511,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18186,7 +18534,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.insert
             * @desc Creates a Interconnect in the specified project using the
@@ -18259,7 +18607,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18280,7 +18630,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.list
             * @desc Retrieves the list of interconnect available to the
@@ -18364,7 +18714,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18385,7 +18737,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.patch
             * @desc Updates the specified interconnect with the data included in
@@ -18466,7 +18818,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18488,7 +18842,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.setLabels
             * @desc Sets the labels on an Interconnect. To learn more about
@@ -18504,7 +18858,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18526,7 +18882,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -18600,7 +18956,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18622,7 +18980,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -18641,7 +18999,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18663,7 +19022,7 @@ function Compute(options) {
         pathParams: ['licenseCode', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18682,7 +19041,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18704,7 +19065,7 @@ function Compute(options) {
         pathParams: ['license', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.get
         * @desc Returns the specified License resource.
@@ -18774,7 +19135,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18796,7 +19158,7 @@ function Compute(options) {
         pathParams: ['license', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.insert
         * @desc Create a License resource in the specified project.
@@ -18811,7 +19173,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18832,7 +19196,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.licenses.list
         * @desc Retrieves the list of licenses available in the specified
@@ -18854,7 +19218,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18875,7 +19241,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18963,7 +19329,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18984,7 +19352,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.machineTypes.get
         * @desc Returns the specified machine type. Get a list of available
@@ -19060,7 +19428,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19082,7 +19451,7 @@ function Compute(options) {
         pathParams: ['machineType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.machineTypes.list
         * @desc Retrieves a list of machine types available to the specified
@@ -19170,7 +19539,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19192,7 +19563,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -19273,7 +19644,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        addPeering(params, options, callback) {
+        addPeering(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19295,7 +19668,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.delete
             * @desc Deletes the specified network.
@@ -19366,7 +19739,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19388,7 +19763,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.get
             * @desc Returns the specified network. Get a list of available
@@ -19459,7 +19834,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19481,7 +19857,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.insert
             * @desc Creates a network in the specified project using the data
@@ -19554,7 +19930,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19575,7 +19953,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.list
             * @desc Retrieves the list of networks available to the specified
@@ -19659,7 +20037,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19680,7 +20060,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.patch
             * @desc Patches the specified network with the data included in the
@@ -19760,7 +20140,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19782,7 +20164,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.removePeering
             * @desc Removes a peering from the specified network.
@@ -19856,7 +20238,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        removePeering(params, options, callback) {
+        removePeering(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19878,7 +20262,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.switchToCustomMode
             * @desc Switches the network mode from auto subnet mode to custom
@@ -19948,7 +20332,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        switchToCustomMode(params, options, callback) {
+        switchToCustomMode(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -19970,7 +20356,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -20044,7 +20430,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20066,7 +20454,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -20138,7 +20526,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        disableXpnHost(params, options, callback) {
+        disableXpnHost(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20159,7 +20549,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.disableXpnResource
             * @desc Disable a serivce resource (a.k.a service project)
@@ -20230,7 +20620,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        disableXpnResource(params, options, callback) {
+        disableXpnResource(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20251,7 +20643,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.enableXpnHost
             * @desc Enable this project as a shared VPC host project.
@@ -20316,7 +20708,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        enableXpnHost(params, options, callback) {
+        enableXpnHost(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20337,7 +20731,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.enableXpnResource
             * @desc Enable service resource (a.k.a service project) for a host
@@ -20409,7 +20803,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        enableXpnResource(params, options, callback) {
+        enableXpnResource(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20430,7 +20826,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.get
             * @desc Returns the specified Project resource.
@@ -20496,7 +20892,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20516,7 +20913,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.getXpnHost
             * @desc Get the shared VPC host project that this project links to.
@@ -20583,7 +20980,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getXpnHost(params, options, callback) {
+        getXpnHost(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20603,7 +21002,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.getXpnResources
             * @desc Get service resources (a.k.a service project) associated
@@ -20688,7 +21087,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getXpnResources(params, options, callback) {
+        getXpnResources(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20709,7 +21110,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.listXpnHosts
             * @desc List all shared VPC host projects visible to the user in an
@@ -20798,7 +21199,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listXpnHosts(params, options, callback) {
+        listXpnHosts(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20819,7 +21222,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.moveDisk
             * @desc Moves a persistent disk from one zone to another.
@@ -20891,7 +21294,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        moveDisk(params, options, callback) {
+        moveDisk(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -20911,7 +21316,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.moveInstance
             * @desc Moves an instance and its attached persistent disks from one
@@ -20984,7 +21389,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        moveInstance(params, options, callback) {
+        moveInstance(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21005,7 +21412,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.setCommonInstanceMetadata
             * @desc Sets metadata common to all instances within the specified
@@ -21076,7 +21483,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setCommonInstanceMetadata(params, options, callback) {
+        setCommonInstanceMetadata(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21098,7 +21507,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.setDefaultNetworkTier
             * @desc Sets the default network tier of the project. The default
@@ -21115,7 +21524,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setDefaultNetworkTier(params, options, callback) {
+        setDefaultNetworkTier(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21137,7 +21548,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.setUsageExportBucket
             * @desc Enables the usage export feature and sets the usage export
@@ -21209,7 +21620,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setUsageExportBucket(params, options, callback) {
+        setUsageExportBucket(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21230,7 +21643,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -21310,7 +21723,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21332,7 +21747,7 @@ function Compute(options) {
             pathParams: ['autoscaler', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.get
             * @desc Returns the specified autoscaler.
@@ -21407,7 +21822,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21429,7 +21845,7 @@ function Compute(options) {
             pathParams: ['autoscaler', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.insert
             * @desc Creates an autoscaler in the specified project using the
@@ -21504,7 +21920,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21526,7 +21944,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.list
             * @desc Retrieves a list of autoscalers contained within the
@@ -21614,7 +22032,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21636,7 +22056,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.patch
             * @desc Updates an autoscaler in the specified project using the
@@ -21715,7 +22135,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21737,7 +22159,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -21815,7 +22237,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21837,7 +22261,7 @@ function Compute(options) {
             pathParams: ['project', 'region', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.update
             * @desc Updates an autoscaler in the specified project using the
@@ -21915,7 +22339,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -21937,7 +22363,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -22017,7 +22443,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22039,7 +22467,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.get
         * @desc Returns the specified regional BackendService resource.
@@ -22114,7 +22542,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22136,7 +22565,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.getHealth
         * @desc Gets the most recent health check results for this regional
@@ -22214,7 +22643,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22236,7 +22667,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.insert
         * @desc Creates a regional BackendService resource in the specified
@@ -22314,7 +22745,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22336,7 +22769,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.list
         * @desc Retrieves the list of regional BackendService resources
@@ -22424,7 +22857,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22446,7 +22881,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.patch
         * @desc Updates the specified regional BackendService resource with the
@@ -22532,7 +22967,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22554,7 +22991,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -22631,7 +23068,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22653,7 +23092,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.update
         * @desc Updates the specified regional BackendService resource with the
@@ -22737,7 +23176,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22759,7 +23200,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -22847,7 +23288,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22868,7 +23311,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.get
         * @desc Returns the specified commitment resource. Get a list of
@@ -22943,7 +23386,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22965,7 +23409,7 @@ function Compute(options) {
         pathParams: ['commitment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.insert
         * @desc Creates a commitment in the specified project using the data
@@ -23042,7 +23486,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23064,7 +23510,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.list
         * @desc Retrieves a list of commitments contained within the specified
@@ -23152,7 +23598,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23174,7 +23622,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -23269,7 +23717,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    abandonInstances(params, options, callback) {
+    abandonInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23291,7 +23741,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.delete
         * @desc Deletes the specified managed instance group and all of the
@@ -23366,7 +23816,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23388,7 +23840,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.deleteInstances
         * @desc Schedules a group action to delete the specified instances in
@@ -23478,7 +23930,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteInstances(params, options, callback) {
+    deleteInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23500,7 +23954,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.get
         * @desc Returns all of the details about the specified managed instance
@@ -23574,7 +24028,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23596,7 +24051,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.insert
         * @desc Creates a managed instance group using the information that you
@@ -23677,7 +24132,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23699,7 +24156,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.list
         * @desc Retrieves the list of managed instance groups that are contained
@@ -23787,7 +24244,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23809,7 +24268,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.listManagedInstances
         * @desc Lists the instances in the managed instance group and instances
@@ -23906,7 +24365,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listManagedInstances(params, options, callback) {
+    listManagedInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23928,7 +24389,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.patch
         * @desc Updates a managed instance group using the information that you
@@ -24015,7 +24476,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24037,7 +24500,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.recreateInstances
         * @desc Schedules a group action to recreate the specified instances in
@@ -24126,7 +24589,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    recreateInstances(params, options, callback) {
+    recreateInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24148,7 +24613,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.resize
         * @desc Changes the intended size for the managed instance group. If you
@@ -24236,7 +24701,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resize(params, options, callback) {
+    resize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24258,7 +24725,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setAutoHealingPolicies
         * @desc Modifies the autohealing policy for the instances in this
@@ -24338,7 +24805,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setAutoHealingPolicies(params, options, callback) {
+    setAutoHealingPolicies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24360,7 +24829,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setInstanceTemplate
         * @desc Sets the instance template to use when creating new instances or
@@ -24441,7 +24910,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setInstanceTemplate(params, options, callback) {
+    setInstanceTemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24463,7 +24934,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setTargetPools
         * @desc Modifies the target pools to which all new instances in this
@@ -24543,7 +25014,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTargetPools(params, options, callback) {
+    setTargetPools(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24565,7 +25038,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -24642,7 +25115,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24664,7 +25139,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.update
         * @desc Updates a managed instance group using the information that you
@@ -24749,7 +25224,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24771,7 +25248,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -24850,7 +25327,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24872,7 +25350,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.list
         * @desc Retrieves the list of instance group resources contained within
@@ -24960,7 +25438,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24982,7 +25462,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.listInstances
         * @desc Lists the instances in the specified instance group and displays
@@ -25082,7 +25562,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listInstances(params, options, callback) {
+    listInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25104,7 +25586,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.setNamedPorts
         * @desc Sets the named ports for the specified regional instance group.
@@ -25183,7 +25665,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setNamedPorts(params, options, callback) {
+    setNamedPorts(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25205,7 +25689,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -25282,7 +25766,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25304,7 +25790,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -25379,7 +25865,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25401,7 +25889,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionOperations.get
         * @desc Retrieves the specified region-specific Operations resource.
@@ -25475,7 +25963,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25497,7 +25986,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -25585,7 +26074,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25607,7 +26098,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -25682,7 +26173,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25703,7 +26195,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regions.list
         * @desc Retrieves the list of region resources available to the
@@ -25787,7 +26279,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25807,7 +26301,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -25895,7 +26389,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25916,7 +26412,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.delete
         * @desc Deletes the specified Router resource.
@@ -25991,7 +26487,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26013,7 +26511,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.get
         * @desc Returns the specified Router resource. Get a list of available
@@ -26088,7 +26586,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26110,7 +26609,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.getRouterStatus
         * @desc Retrieves runtime information of the specified router.
@@ -26184,7 +26683,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getRouterStatus(params, options, callback) {
+    getRouterStatus(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26206,7 +26707,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.insert
         * @desc Creates a Router resource in the specified project and region
@@ -26283,7 +26784,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26304,7 +26807,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.list
         * @desc Retrieves a list of Router resources available to the specified
@@ -26392,7 +26895,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26413,7 +26918,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.patch
         * @desc Patches the specified Router resource with the data included in
@@ -26497,7 +27002,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26519,7 +27026,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.preview
         * @desc Preview fields auto-generated during router create and update
@@ -26599,7 +27106,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    preview(params, options, callback) {
+    preview(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26621,7 +27130,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -26698,7 +27207,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26720,7 +27231,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.update
         * @desc Updates the specified Router resource with the data included in
@@ -26803,7 +27314,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26825,7 +27338,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -26900,7 +27413,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26921,7 +27436,7 @@ function Compute(options) {
         pathParams: ['project', 'route'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.get
         * @desc Returns the specified Route resource. Get a list of available
@@ -26992,7 +27507,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27013,7 +27529,7 @@ function Compute(options) {
         pathParams: ['project', 'route'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.insert
         * @desc Creates a Route resource in the specified project using the data
@@ -27086,7 +27602,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27106,7 +27624,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.list
         * @desc Retrieves the list of Route resources available to the specified
@@ -27190,7 +27708,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27210,7 +27730,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -27285,7 +27805,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27307,7 +27829,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -27326,7 +27848,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addRule(params, options, callback) {
+    addRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27348,7 +27872,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.delete
         * @desc Deletes the specified policy.
@@ -27420,7 +27944,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27442,7 +27968,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.get
         * @desc List all of the ordered rules present in a single specified
@@ -27514,7 +28040,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27536,7 +28063,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.getRule
         * @desc Gets a rule at the specified priority.
@@ -27551,7 +28078,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getRule(params, options, callback) {
+    getRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27573,7 +28102,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.insert
         * @desc Creates a new policy in the specified project using the data
@@ -27646,7 +28175,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27667,7 +28198,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.list
         * @desc List all the policies that have been configured for the
@@ -27751,7 +28282,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27772,7 +28305,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.patch
         * @desc Patches the specified policy with the data included in the
@@ -27852,7 +28385,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27874,7 +28409,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.patchRule
         * @desc Patches a rule at the specified priority.
@@ -27890,7 +28425,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patchRule(params, options, callback) {
+    patchRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27912,7 +28449,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.removeRule
         * @desc Deletes a rule at the specified priority.
@@ -27927,7 +28464,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeRule(params, options, callback) {
+    removeRule(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27949,7 +28488,7 @@ function Compute(options) {
         pathParams: ['project', 'securityPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.securityPolicies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -28022,7 +28561,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28044,7 +28585,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -28123,7 +28664,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28145,7 +28688,7 @@ function Compute(options) {
         pathParams: ['project', 'snapshot'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.get
         * @desc Returns the specified Snapshot resource. Get a list of available
@@ -28216,7 +28759,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28238,7 +28782,7 @@ function Compute(options) {
         pathParams: ['project', 'snapshot'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.list
         * @desc Retrieves the list of Snapshot resources contained within the
@@ -28322,7 +28866,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28343,7 +28889,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.setLabels
         * @desc Sets the labels on a snapshot. To learn more about labels, read
@@ -28419,7 +28965,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28441,7 +28989,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -28514,7 +29062,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28536,7 +29086,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -28612,7 +29162,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28634,7 +29186,7 @@ function Compute(options) {
         pathParams: ['project', 'sslCertificate'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.get
         * @desc Returns the specified SslCertificate resource. Get a list of
@@ -28706,7 +29258,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28728,7 +29281,7 @@ function Compute(options) {
         pathParams: ['project', 'sslCertificate'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.insert
         * @desc Creates a SslCertificate resource in the specified project using
@@ -28801,7 +29354,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28822,7 +29377,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.list
         * @desc Retrieves the list of SslCertificate resources available to the
@@ -28906,7 +29461,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28927,7 +29484,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -29000,7 +29557,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29022,7 +29581,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -29043,7 +29602,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29065,7 +29626,7 @@ function Compute(options) {
         pathParams: ['project', 'sslPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.get
         * @desc List all of the ordered rules present in a single specified
@@ -29080,7 +29641,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29102,7 +29664,7 @@ function Compute(options) {
         pathParams: ['project', 'sslPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.insert
         * @desc Returns the specified SSL policy resource. Get a list of
@@ -29118,7 +29680,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29139,7 +29703,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.list
         * @desc List all the SSL policies that have been configured for the
@@ -29157,7 +29721,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29178,7 +29744,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.listAvailableFeatures
         * @desc Lists all features that can be specified in the SSL policy when
@@ -29196,7 +29762,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listAvailableFeatures(params, options, callback) {
+    listAvailableFeatures(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29218,7 +29786,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.patch
         * @desc Patches the specified SSL policy with the data included in the
@@ -29235,7 +29803,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29257,7 +29827,7 @@ function Compute(options) {
         pathParams: ['project', 'sslPolicy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslPolicies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -29272,7 +29842,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29294,7 +29866,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -29382,7 +29954,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29403,7 +29977,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.delete
         * @desc Deletes the specified subnetwork.
@@ -29478,7 +30052,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29500,7 +30076,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.expandIpCidrRange
         * @desc Expands the IP CIDR range of the subnetwork to a specified
@@ -29579,7 +30155,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    expandIpCidrRange(params, options, callback) {
+    expandIpCidrRange(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29601,7 +30179,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.get
         * @desc Returns the specified subnetwork. Get a list of available
@@ -29676,7 +30254,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29698,7 +30277,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -29773,7 +30352,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29795,7 +30376,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.insert
         * @desc Creates a subnetwork in the specified project using the data
@@ -29872,7 +30453,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29894,7 +30477,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.list
         * @desc Retrieves a list of subnetworks available to the specified
@@ -29982,7 +30565,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30004,7 +30589,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.patch
         * @desc Patches the specified subnetwork with the data included in the
@@ -30090,7 +30675,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30112,7 +30699,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -30192,7 +30779,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30214,7 +30803,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.setPrivateIpGoogleAccess
         * @desc Set whether VMs in this subnet can access Google services
@@ -30293,7 +30882,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setPrivateIpGoogleAccess(params, options, callback) {
+    setPrivateIpGoogleAccess(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30315,7 +30906,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -30392,7 +30983,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30414,7 +31007,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -30490,7 +31083,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30512,7 +31107,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.get
         * @desc Returns the specified TargetHttpProxy resource. Get a list of
@@ -30584,7 +31179,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30606,7 +31202,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.insert
         * @desc Creates a TargetHttpProxy resource in the specified project
@@ -30679,7 +31275,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30700,7 +31298,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.list
         * @desc Retrieves the list of TargetHttpProxy resources available to the
@@ -30784,7 +31382,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30805,7 +31405,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.setUrlMap
         * @desc Changes the URL map for TargetHttpProxy.
@@ -30880,7 +31480,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setUrlMap(params, options, callback) {
+    setUrlMap(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30902,7 +31504,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -30975,7 +31577,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30997,7 +31601,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -31073,7 +31677,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31095,7 +31701,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.get
         * @desc Returns the specified TargetHttpsProxy resource. Get a list of
@@ -31167,7 +31773,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31189,7 +31796,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.insert
         * @desc Creates a TargetHttpsProxy resource in the specified project
@@ -31262,7 +31869,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31284,7 +31893,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.list
         * @desc Retrieves the list of TargetHttpsProxy resources available to
@@ -31368,7 +31977,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31390,7 +32001,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setQuicOverride
         * @desc Sets the QUIC override policy for TargetHttpsProxy.
@@ -31406,7 +32017,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setQuicOverride(params, options, callback) {
+    setQuicOverride(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31428,7 +32041,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setSslCertificates
         * @desc Replaces SslCertificates for TargetHttpsProxy.
@@ -31503,7 +32116,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslCertificates(params, options, callback) {
+    setSslCertificates(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31525,7 +32140,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setSslPolicy
         * @desc Sets the SSL policy for TargetHttpsProxy. The SSL policy
@@ -31544,7 +32159,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslPolicy(params, options, callback) {
+    setSslPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31566,7 +32183,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setUrlMap
         * @desc Changes the URL map for TargetHttpsProxy.
@@ -31641,7 +32258,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setUrlMap(params, options, callback) {
+    setUrlMap(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31663,7 +32282,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -31736,7 +32355,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31758,7 +32379,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -31846,7 +32467,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31868,7 +32491,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.delete
         * @desc Deletes the specified TargetInstance resource.
@@ -31944,7 +32567,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -31966,7 +32591,7 @@ function Compute(options) {
         pathParams: ['project', 'targetInstance', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.get
         * @desc Returns the specified TargetInstance resource. Get a list of
@@ -32042,7 +32667,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32064,7 +32690,7 @@ function Compute(options) {
         pathParams: ['project', 'targetInstance', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.insert
         * @desc Creates a TargetInstance resource in the specified project and
@@ -32141,7 +32767,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32163,7 +32791,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.list
         * @desc Retrieves a list of TargetInstance resources available to the
@@ -32251,7 +32879,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32273,7 +32903,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -32350,7 +32980,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32372,7 +33004,7 @@ function Compute(options) {
         pathParams: ['project', 'resource', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -32456,7 +33088,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addHealthCheck(params, options, callback) {
+    addHealthCheck(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32478,7 +33112,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.addInstance
         * @desc Adds an instance to a target pool.
@@ -32558,7 +33192,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    addInstance(params, options, callback) {
+    addInstance(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32580,7 +33216,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.aggregatedList
         * @desc Retrieves an aggregated list of target pools.
@@ -32664,7 +33300,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32685,7 +33323,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.delete
         * @desc Deletes the specified target pool.
@@ -32760,7 +33398,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32782,7 +33422,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.get
         * @desc Returns the specified target pool. Get a list of available
@@ -32857,7 +33497,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32879,7 +33520,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.getHealth
         * @desc Gets the most recent health check results for each IP for the
@@ -32960,7 +33601,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -32982,7 +33625,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.insert
         * @desc Creates a target pool in the specified project and region using
@@ -33059,7 +33702,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33081,7 +33726,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.list
         * @desc Retrieves a list of target pools available to the specified
@@ -33169,7 +33814,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33191,7 +33838,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.removeHealthCheck
         * @desc Removes health check URL from a target pool.
@@ -33269,7 +33916,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeHealthCheck(params, options, callback) {
+    removeHealthCheck(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33291,7 +33940,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.removeInstance
         * @desc Removes instance URL from a target pool.
@@ -33369,7 +34018,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeInstance(params, options, callback) {
+    removeInstance(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33391,7 +34042,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.setBackup
         * @desc Changes a backup target pool's configurations.
@@ -33472,7 +34123,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackup(params, options, callback) {
+    setBackup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33494,7 +34147,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -33571,7 +34224,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33593,7 +34248,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -33669,7 +34324,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33691,7 +34348,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.get
         * @desc Returns the specified TargetSslProxy resource. Get a list of
@@ -33763,7 +34420,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33785,7 +34443,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.insert
         * @desc Creates a TargetSslProxy resource in the specified project using
@@ -33858,7 +34516,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33879,7 +34539,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.list
         * @desc Retrieves the list of TargetSslProxy resources available to the
@@ -33963,7 +34623,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -33984,7 +34646,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setBackendService
         * @desc Changes the BackendService for TargetSslProxy.
@@ -34059,7 +34721,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackendService(params, options, callback) {
+    setBackendService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34081,7 +34745,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setProxyHeader
         * @desc Changes the ProxyHeaderType for TargetSslProxy.
@@ -34156,7 +34820,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setProxyHeader(params, options, callback) {
+    setProxyHeader(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34178,7 +34844,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setSslCertificates
         * @desc Changes SslCertificates for TargetSslProxy.
@@ -34253,7 +34919,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslCertificates(params, options, callback) {
+    setSslCertificates(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34275,7 +34943,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setSslPolicy
         * @desc Sets the SSL policy for TargetSslProxy. The SSL policy specifies
@@ -34294,7 +34962,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslPolicy(params, options, callback) {
+    setSslPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34316,7 +34986,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -34389,7 +35059,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34411,7 +35083,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -34487,7 +35159,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34509,7 +35183,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.get
         * @desc Returns the specified TargetTcpProxy resource. Get a list of
@@ -34581,7 +35255,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34603,7 +35278,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.insert
         * @desc Creates a TargetTcpProxy resource in the specified project using
@@ -34676,7 +35351,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34697,7 +35374,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.list
         * @desc Retrieves the list of TargetTcpProxy resources available to the
@@ -34781,7 +35458,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34802,7 +35481,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.setBackendService
         * @desc Changes the BackendService for TargetTcpProxy.
@@ -34877,7 +35556,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackendService(params, options, callback) {
+    setBackendService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34899,7 +35580,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.setProxyHeader
         * @desc Changes the ProxyHeaderType for TargetTcpProxy.
@@ -34974,7 +35655,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setProxyHeader(params, options, callback) {
+    setProxyHeader(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -34996,7 +35679,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -35084,7 +35767,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -35106,7 +35791,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.delete
         * @desc Deletes the specified target VPN gateway.
@@ -35182,7 +35867,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -35204,7 +35891,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetVpnGateway'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.get
         * @desc Returns the specified target VPN gateway. Get a list of
@@ -35280,7 +35967,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -35302,7 +35990,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetVpnGateway'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.insert
         * @desc Creates a target VPN gateway in the specified project and region
@@ -35379,7 +36067,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -35401,7 +36091,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.list
         * @desc Retrieves a list of target VPN gateways available to the
@@ -35489,7 +36179,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -35511,7 +36203,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.setLabels
         * @desc Sets the labels on a TargetVpnGateway. To learn more about
@@ -35529,7 +36221,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -35551,7 +36245,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -35628,7 +36322,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -35650,7 +36346,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -35726,7 +36422,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -35748,7 +36446,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.get
             * @desc Returns the specified UrlMap resource. Get a list of
@@ -35819,7 +36517,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -35841,7 +36540,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.insert
             * @desc Creates a UrlMap resource in the specified project using the
@@ -35914,7 +36613,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -35935,7 +36636,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.invalidateCache
             * @desc Initiates a cache invalidation operation, invalidating the
@@ -36010,7 +36711,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        invalidateCache(params, options, callback) {
+        invalidateCache(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -36032,7 +36735,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.list
             * @desc Retrieves the list of UrlMap resources available to the
@@ -36116,7 +36819,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -36137,7 +36842,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.patch
             * @desc Patches the specified UrlMap resource with the data included
@@ -36217,7 +36922,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -36239,7 +36946,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -36313,7 +37020,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -36335,7 +37044,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.update
             * @desc Updates the specified UrlMap resource with the data included
@@ -36414,7 +37123,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -36436,7 +37147,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.validate
             * @desc Runs static validation for the UrlMap. In particular, the
@@ -36513,7 +37224,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        validate(params, options, callback) {
+        validate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -36535,7 +37248,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -36623,7 +37336,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -36644,7 +37359,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.delete
         * @desc Deletes the specified VpnTunnel resource.
@@ -36719,7 +37434,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -36741,7 +37458,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'vpnTunnel'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.get
         * @desc Returns the specified VpnTunnel resource. Get a list of
@@ -36816,7 +37533,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -36838,7 +37556,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'vpnTunnel'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.insert
         * @desc Creates a VpnTunnel resource in the specified project and region
@@ -36915,7 +37633,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -36937,7 +37657,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.list
         * @desc Retrieves a list of VpnTunnel resources contained in the
@@ -37025,7 +37745,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37047,7 +37769,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.setLabels
         * @desc Sets the labels on a VpnTunnel. To learn more about labels, read
@@ -37065,7 +37787,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37087,7 +37811,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -37164,7 +37888,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37186,7 +37912,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -37261,7 +37987,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37283,7 +38011,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zoneOperations.get
         * @desc Retrieves the specified zone-specific Operations resource.
@@ -37357,7 +38085,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37379,7 +38108,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zoneOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -37467,7 +38196,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37488,7 +38219,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -37563,7 +38294,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37583,7 +38315,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zones.list
         * @desc Retrieves the list of Zone resources available to the specified
@@ -37667,7 +38399,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -37687,7 +38421,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/compute/v1.ts
+++ b/src/apis/compute/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Compute Engine API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Compute
  */
-function Compute(options) {
+function Compute(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.acceleratorTypes = {
@@ -118,7 +125,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +149,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.acceleratorTypes.get
         * @desc Returns the specified accelerator type. Get a list of available
@@ -216,7 +225,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -238,7 +248,7 @@ function Compute(options) {
         pathParams: ['acceleratorType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.acceleratorTypes.list
         * @desc Retrieves a list of accelerator types available to the specified
@@ -326,7 +336,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -348,7 +360,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -436,7 +448,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -457,7 +471,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.delete
         * @desc Deletes the specified address resource.
@@ -532,7 +546,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -554,7 +570,7 @@ function Compute(options) {
         pathParams: ['address', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.get
         * @desc Returns the specified address resource.
@@ -628,7 +644,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -650,7 +667,7 @@ function Compute(options) {
         pathParams: ['address', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.insert
         * @desc Creates an address resource in the specified project using the
@@ -727,7 +744,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -748,7 +767,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.addresses.list
         * @desc Retrieves a list of addresses contained within the specified
@@ -836,7 +855,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -857,7 +878,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -945,7 +966,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -966,7 +989,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.delete
         * @desc Deletes the specified autoscaler.
@@ -1041,7 +1064,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1063,7 +1088,7 @@ function Compute(options) {
         pathParams: ['autoscaler', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.get
         * @desc Returns the specified autoscaler resource. Get a list of
@@ -1138,7 +1163,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1160,7 +1186,7 @@ function Compute(options) {
         pathParams: ['autoscaler', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.insert
         * @desc Creates an autoscaler in the specified project using the data
@@ -1237,7 +1263,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1258,7 +1286,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.list
         * @desc Retrieves a list of autoscalers contained within the specified
@@ -1346,7 +1374,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1367,7 +1397,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.patch
         * @desc Updates an autoscaler in the specified project using the data
@@ -1448,7 +1478,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1469,7 +1501,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.autoscalers.update
         * @desc Updates an autoscaler in the specified project using the data
@@ -1549,7 +1581,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1570,7 +1604,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1647,7 +1681,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1669,7 +1705,7 @@ function Compute(options) {
             pathParams: ['backendBucket', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.backendBuckets.get
             * @desc Returns the specified BackendBucket resource. Get a list of
@@ -1741,7 +1777,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1763,7 +1800,7 @@ function Compute(options) {
             pathParams: ['backendBucket', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.backendBuckets.insert
             * @desc Creates a BackendBucket resource in the specified project
@@ -1836,7 +1873,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1857,7 +1896,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.backendBuckets.list
             * @desc Retrieves the list of BackendBucket resources available to
@@ -1941,7 +1980,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1962,7 +2003,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.backendBuckets.patch
             * @desc Updates the specified BackendBucket resource with the data
@@ -2043,7 +2084,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2065,7 +2108,7 @@ function Compute(options) {
             pathParams: ['backendBucket', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.backendBuckets.update
             * @desc Updates the specified BackendBucket resource with the data
@@ -2145,7 +2188,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2167,7 +2212,7 @@ function Compute(options) {
             pathParams: ['backendBucket', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -2256,7 +2301,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2277,7 +2324,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.delete
         * @desc Deletes the specified BackendService resource.
@@ -2349,7 +2396,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2371,7 +2420,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.get
         * @desc Returns the specified BackendService resource. Get a list of
@@ -2443,7 +2492,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2465,7 +2515,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.getHealth
         * @desc Gets the most recent health check results for this
@@ -2541,7 +2591,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2563,7 +2615,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.insert
         * @desc Creates a BackendService resource in the specified project using
@@ -2638,7 +2690,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2659,7 +2713,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.list
         * @desc Retrieves the list of BackendService resources available to the
@@ -2743,7 +2797,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2764,7 +2820,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.patch
         * @desc Patches the specified BackendService resource with the data
@@ -2847,7 +2903,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2869,7 +2927,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.backendServices.update
         * @desc Updates the specified BackendService resource with the data
@@ -2951,7 +3009,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2973,7 +3033,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3062,7 +3122,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        aggregatedList(params, options, callback) {
+        aggregatedList(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3083,7 +3145,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.createSnapshot
             * @desc Creates a snapshot of a specified persistent disk.
@@ -3164,7 +3226,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        createSnapshot(params, options, callback) {
+        createSnapshot(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3186,7 +3250,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.delete
             * @desc Deletes the specified persistent disk. Deleting a disk
@@ -3264,7 +3328,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3286,7 +3352,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.get
             * @desc Returns a specified persistent disk. Get a list of available
@@ -3361,7 +3427,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3383,7 +3450,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.insert
             * @desc Creates a persistent disk in the specified project using the
@@ -3464,7 +3531,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3485,7 +3554,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.list
             * @desc Retrieves a list of persistent disks contained within the
@@ -3573,7 +3642,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3594,7 +3665,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.resize
             * @desc Resizes the specified persistent disk. You can only increase
@@ -3675,7 +3746,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resize(params, options, callback) {
+        resize(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3697,7 +3770,7 @@ function Compute(options) {
             pathParams: ['disk', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.disks.setLabels
             * @desc Sets the labels on a disk. To learn more about labels, read
@@ -3778,7 +3851,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3800,7 +3875,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -3888,7 +3963,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3909,7 +3986,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.diskTypes.get
         * @desc Returns the specified disk type. Get a list of available disk
@@ -3984,7 +4061,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4006,7 +4084,7 @@ function Compute(options) {
         pathParams: ['diskType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.diskTypes.list
         * @desc Retrieves a list of disk types available to the specified
@@ -4094,7 +4172,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4115,7 +4195,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4190,7 +4270,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4212,7 +4294,7 @@ function Compute(options) {
         pathParams: ['firewall', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.firewalls.get
         * @desc Returns the specified firewall.
@@ -4282,7 +4364,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4304,7 +4387,7 @@ function Compute(options) {
         pathParams: ['firewall', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.firewalls.insert
         * @desc Creates a firewall rule in the specified project using the data
@@ -4377,7 +4460,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4397,7 +4482,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.firewalls.list
         * @desc Retrieves the list of firewall rules available to the specified
@@ -4481,7 +4566,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4501,7 +4588,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.firewalls.patch
         * @desc Updates the specified firewall rule with the data included in
@@ -4581,7 +4668,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4603,7 +4692,7 @@ function Compute(options) {
         pathParams: ['firewall', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.firewalls.update
         * @desc Updates the specified firewall rule with the data included in
@@ -4684,7 +4773,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4706,7 +4797,7 @@ function Compute(options) {
         pathParams: ['firewall', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4794,7 +4885,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4815,7 +4908,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.delete
         * @desc Deletes the specified ForwardingRule resource.
@@ -4891,7 +4984,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4913,7 +5008,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.get
         * @desc Returns the specified ForwardingRule resource.
@@ -4988,7 +5083,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5010,7 +5106,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.insert
         * @desc Creates a ForwardingRule resource in the specified project and
@@ -5087,7 +5183,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5109,7 +5207,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.list
         * @desc Retrieves a list of ForwardingRule resources available to the
@@ -5197,7 +5295,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5219,7 +5319,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.forwardingRules.setTarget
         * @desc Changes target URL for forwarding rule. The new target should be
@@ -5301,7 +5401,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTarget(params, options, callback) {
+    setTarget(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5323,7 +5425,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5398,7 +5500,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5419,7 +5523,7 @@ function Compute(options) {
         pathParams: ['address', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.get
         * @desc Returns the specified address resource. Get a list of available
@@ -5490,7 +5594,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5511,7 +5616,7 @@ function Compute(options) {
         pathParams: ['address', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.insert
         * @desc Creates an address resource in the specified project using the
@@ -5584,7 +5689,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5604,7 +5711,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalAddresses.list
         * @desc Retrieves a list of global addresses.
@@ -5687,7 +5794,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5707,7 +5816,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5783,7 +5892,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5805,7 +5916,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.get
         * @desc Returns the specified GlobalForwardingRule resource. Get a list
@@ -5877,7 +5988,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5899,7 +6011,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.insert
         * @desc Creates a GlobalForwardingRule resource in the specified project
@@ -5970,7 +6082,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5991,7 +6105,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.list
         * @desc Retrieves a list of GlobalForwardingRule resources available to
@@ -6075,7 +6189,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6096,7 +6212,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalForwardingRules.setTarget
         * @desc Changes target URL for the GlobalForwardingRule resource. The
@@ -6172,7 +6288,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTarget(params, options, callback) {
+    setTarget(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6194,7 +6312,7 @@ function Compute(options) {
         pathParams: ['forwardingRule', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6282,7 +6400,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6303,7 +6423,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.delete
         * @desc Deletes the specified Operations resource.
@@ -6370,7 +6490,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6392,7 +6514,7 @@ function Compute(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.get
         * @desc Retrieves the specified Operations resource. Get a list of
@@ -6463,7 +6585,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6485,7 +6608,7 @@ function Compute(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.globalOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -6569,7 +6692,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6590,7 +6715,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6667,7 +6792,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -6689,7 +6816,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.get
             * @desc Returns the specified HealthCheck resource. Get a list of
@@ -6761,7 +6888,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -6783,7 +6911,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.insert
             * @desc Creates a HealthCheck resource in the specified project
@@ -6856,7 +6984,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -6877,7 +7007,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.list
             * @desc Retrieves the list of HealthCheck resources available to the
@@ -6961,7 +7091,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -6982,7 +7114,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.patch
             * @desc Updates a HealthCheck resource in the specified project
@@ -7064,7 +7196,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -7086,7 +7220,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.healthChecks.update
             * @desc Updates a HealthCheck resource in the specified project
@@ -7166,7 +7300,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -7188,7 +7324,7 @@ function Compute(options) {
             pathParams: ['healthCheck', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -7264,7 +7400,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7286,7 +7424,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.get
         * @desc Returns the specified HttpHealthCheck resource. Get a list of
@@ -7358,7 +7496,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7380,7 +7519,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.insert
         * @desc Creates a HttpHealthCheck resource in the specified project
@@ -7453,7 +7592,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7474,7 +7615,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.list
         * @desc Retrieves the list of HttpHealthCheck resources available to the
@@ -7558,7 +7699,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7579,7 +7722,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.patch
         * @desc Updates a HttpHealthCheck resource in the specified project
@@ -7660,7 +7803,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7682,7 +7827,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpHealthChecks.update
         * @desc Updates a HttpHealthCheck resource in the specified project
@@ -7762,7 +7907,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7784,7 +7931,7 @@ function Compute(options) {
         pathParams: ['httpHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7860,7 +8007,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7882,7 +8031,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.get
         * @desc Returns the specified HttpsHealthCheck resource. Get a list of
@@ -7954,7 +8103,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7976,7 +8126,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.insert
         * @desc Creates a HttpsHealthCheck resource in the specified project
@@ -8049,7 +8199,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8070,7 +8222,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.list
         * @desc Retrieves the list of HttpsHealthCheck resources available to
@@ -8154,7 +8306,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8175,7 +8329,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.patch
         * @desc Updates a HttpsHealthCheck resource in the specified project
@@ -8256,7 +8410,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8278,7 +8434,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.httpsHealthChecks.update
         * @desc Updates a HttpsHealthCheck resource in the specified project
@@ -8358,7 +8514,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8380,7 +8538,7 @@ function Compute(options) {
         pathParams: ['httpsHealthCheck', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8456,7 +8614,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8477,7 +8637,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.deprecate
             * @desc Sets the deprecation status of an image.  If an empty
@@ -8554,7 +8714,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        deprecate(params, options, callback) {
+        deprecate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8576,7 +8738,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.get
             * @desc Returns the specified image. Get a list of available images
@@ -8647,7 +8809,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8668,7 +8831,7 @@ function Compute(options) {
             pathParams: ['image', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.getFromFamily
             * @desc Returns the latest image that is part of an image family and
@@ -8739,7 +8902,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getFromFamily(params, options, callback) {
+        getFromFamily(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8761,7 +8926,7 @@ function Compute(options) {
             pathParams: ['family', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.insert
             * @desc Creates an image in the specified project using the data
@@ -8835,7 +9000,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8856,7 +9023,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.list
             * @desc Retrieves the list of custom images available to the
@@ -8945,7 +9112,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -8966,7 +9135,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.images.setLabels
             * @desc Sets the labels on an image. To learn more about labels,
@@ -9042,7 +9211,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9064,7 +9235,7 @@ function Compute(options) {
             pathParams: ['project', 'resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -9160,7 +9331,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        abandonInstances(params, options, callback) {
+        abandonInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9182,7 +9355,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.aggregatedList
             * @desc Retrieves the list of managed instance groups and groups
@@ -9269,7 +9442,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        aggregatedList(params, options, callback) {
+        aggregatedList(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9291,7 +9466,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.delete
             * @desc Deletes the specified managed instance group and all of the
@@ -9368,7 +9543,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9390,7 +9567,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.deleteInstances
             * @desc Schedules a group action to delete the specified instances
@@ -9480,7 +9657,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        deleteInstances(params, options, callback) {
+        deleteInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9502,7 +9681,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.get
             * @desc Returns all of the details about the specified managed
@@ -9577,7 +9756,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9599,7 +9779,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.insert
             * @desc Creates a managed instance group using the information that
@@ -9683,7 +9863,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9705,7 +9887,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.list
             * @desc Retrieves a list of managed instance groups that are
@@ -9793,7 +9975,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9815,7 +9999,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.listManagedInstances
             * @desc Lists all of the instances in the managed instance group.
@@ -9897,7 +10081,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listManagedInstances(params, options, callback) {
+        listManagedInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -9919,7 +10105,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.recreateInstances
             * @desc Schedules a group action to recreate the specified instances
@@ -10008,7 +10194,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        recreateInstances(params, options, callback) {
+        recreateInstances(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10030,7 +10218,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.resize
             * @desc Resizes the managed instance group. If you increase the
@@ -10122,7 +10310,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resize(params, options, callback) {
+        resize(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10144,7 +10334,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.setInstanceTemplate
             * @desc Specifies the instance template to use when creating new
@@ -10225,7 +10415,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setInstanceTemplate(params, options, callback) {
+        setInstanceTemplate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10247,7 +10439,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instanceGroupManagers.setTargetPools
             * @desc Modifies the target pools to which all instances in this
@@ -10332,7 +10524,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setTargetPools(params, options, callback) {
+        setTargetPools(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -10354,7 +10548,7 @@ function Compute(options) {
             pathParams: ['instanceGroupManager', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -10441,7 +10635,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addInstances(params, options, callback) {
+    addInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10463,7 +10659,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.aggregatedList
         * @desc Retrieves the list of instance groups and sorts them by zone.
@@ -10547,7 +10743,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10568,7 +10766,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.delete
         * @desc Deletes the specified instance group. The instances in the group
@@ -10646,7 +10844,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10668,7 +10868,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.get
         * @desc Returns the specified instance group. Get a list of available
@@ -10744,7 +10944,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10766,7 +10967,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.insert
         * @desc Creates an instance group in the specified project using the
@@ -10843,7 +11044,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10865,7 +11068,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.list
         * @desc Retrieves the list of instance groups that are located in the
@@ -10953,7 +11156,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10975,7 +11180,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.listInstances
         * @desc Lists the instances in the specified instance group.
@@ -11072,7 +11277,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listInstances(params, options, callback) {
+    listInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11094,7 +11301,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.removeInstances
         * @desc Removes one or more instances from the specified instance group,
@@ -11177,7 +11384,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeInstances(params, options, callback) {
+    removeInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11199,7 +11408,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceGroups.setNamedPorts
         * @desc Sets the named ports for the specified instance group.
@@ -11278,7 +11487,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setNamedPorts(params, options, callback) {
+    setNamedPorts(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11300,7 +11511,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11387,7 +11598,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        addAccessConfig(params, options, callback) {
+        addAccessConfig(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11409,7 +11622,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.aggregatedList
             * @desc Retrieves aggregated list of instances.
@@ -11493,7 +11706,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        aggregatedList(params, options, callback) {
+        aggregatedList(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11514,7 +11729,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.attachDisk
             * @desc Attaches an existing Disk resource to an instance. You must
@@ -11597,7 +11812,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        attachDisk(params, options, callback) {
+        attachDisk(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11619,7 +11836,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.delete
             * @desc Deletes the specified Instance resource. For more
@@ -11695,7 +11912,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11717,7 +11936,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.deleteAccessConfig
             * @desc Deletes an access config from an instance's network
@@ -11799,7 +12018,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        deleteAccessConfig(params, options, callback) {
+        deleteAccessConfig(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11823,7 +12044,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.detachDisk
             * @desc Detaches a disk from an instance.
@@ -11902,7 +12123,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        detachDisk(params, options, callback) {
+        detachDisk(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -11924,7 +12147,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.get
             * @desc Returns the specified Instance resource. Get a list of
@@ -11999,7 +12222,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12021,7 +12245,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.getSerialPortOutput
             * @desc Returns the specified instance's serial port output.
@@ -12095,7 +12319,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getSerialPortOutput(params, options, callback) {
+        getSerialPortOutput(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12117,7 +12343,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.insert
             * @desc Creates an instance resource in the specified project using
@@ -12194,7 +12420,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12215,7 +12443,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.list
             * @desc Retrieves the list of instances contained within the
@@ -12303,7 +12531,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12324,7 +12554,7 @@ function Compute(options) {
             pathParams: ['project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.listReferrers
             * @desc Retrieves the list of referrers to instances contained
@@ -12344,7 +12574,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listReferrers(params, options, callback) {
+        listReferrers(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12366,7 +12598,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.reset
             * @desc Performs a reset on the instance. For more information, see
@@ -12442,7 +12674,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        reset(params, options, callback) {
+        reset(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12464,7 +12698,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setDeletionProtection
             * @desc Sets deletion protection on the instance.
@@ -12538,7 +12772,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setDeletionProtection(params, options, callback) {
+        setDeletionProtection(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12560,7 +12796,7 @@ function Compute(options) {
             pathParams: ['project', 'resource', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setDiskAutoDelete
             * @desc Sets the auto-delete flag for a disk attached to an
@@ -12642,7 +12878,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setDiskAutoDelete(params, options, callback) {
+        setDiskAutoDelete(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12665,7 +12903,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setLabels
             * @desc Sets labels on an instance. To learn more about labels, read
@@ -12746,7 +12984,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLabels(params, options, callback) {
+        setLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12768,7 +13008,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMachineResources
             * @desc Changes the number and/or type of accelerator for a stopped
@@ -12847,7 +13087,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMachineResources(params, options, callback) {
+        setMachineResources(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12869,7 +13111,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMachineType
             * @desc Changes the machine type for a stopped instance to the
@@ -12948,7 +13190,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMachineType(params, options, callback) {
+        setMachineType(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -12970,7 +13214,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMetadata
             * @desc Sets metadata for the specified instance to the data
@@ -13051,7 +13295,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMetadata(params, options, callback) {
+        setMetadata(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13073,7 +13319,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setMinCpuPlatform
             * @desc Changes the minimum CPU platform that this instance should
@@ -13153,7 +13399,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMinCpuPlatform(params, options, callback) {
+        setMinCpuPlatform(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13175,7 +13423,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setScheduling
             * @desc Sets an instance's scheduling options.
@@ -13253,7 +13501,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setScheduling(params, options, callback) {
+        setScheduling(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13275,7 +13525,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setServiceAccount
             * @desc Sets the service account on the instance. For more
@@ -13355,7 +13605,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setServiceAccount(params, options, callback) {
+        setServiceAccount(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13377,7 +13629,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.setTags
             * @desc Sets tags for the specified instance to the data included in
@@ -13458,7 +13710,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setTags(params, options, callback) {
+        setTags(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13480,7 +13734,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.start
             * @desc Starts an instance that was stopped using the using the
@@ -13557,7 +13811,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        start(params, options, callback) {
+        start(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13579,7 +13835,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.startWithEncryptionKey
             * @desc Starts an instance that was stopped using the using the
@@ -13659,7 +13915,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        startWithEncryptionKey(params, options, callback) {
+        startWithEncryptionKey(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13681,7 +13939,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.stop
             * @desc Stops a running instance, shutting it down cleanly, and
@@ -13761,7 +14019,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        stop(params, options, callback) {
+        stop(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13783,7 +14043,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.instances.updateAccessConfig
             * @desc Updates the specified access config from an instance's
@@ -13804,7 +14064,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        updateAccessConfig(params, options, callback) {
+        updateAccessConfig(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -13826,7 +14088,7 @@ function Compute(options) {
             pathParams: ['instance', 'project', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -13904,7 +14166,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13926,7 +14190,7 @@ function Compute(options) {
         pathParams: ['instanceTemplate', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.get
         * @desc Returns the specified instance template. Get a list of available
@@ -13998,7 +14262,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14020,7 +14285,7 @@ function Compute(options) {
         pathParams: ['instanceTemplate', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.insert
         * @desc Creates an instance template in the specified project using the
@@ -14096,7 +14361,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14117,7 +14384,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.instanceTemplates.list
         * @desc Retrieves a list of instance templates that are contained within
@@ -14201,7 +14468,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14222,7 +14491,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14311,7 +14580,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14333,7 +14604,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.delete
         * @desc Deletes the specified interconnect attachment.
@@ -14407,7 +14678,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14429,7 +14702,7 @@ function Compute(options) {
         pathParams: ['interconnectAttachment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.get
         * @desc Returns the specified interconnect attachment.
@@ -14502,7 +14775,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14524,7 +14798,7 @@ function Compute(options) {
         pathParams: ['interconnectAttachment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.insert
         * @desc Creates an InterconnectAttachment in the specified project using
@@ -14599,7 +14873,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14621,7 +14897,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectAttachments.list
         * @desc Retrieves the list of interconnect attachments contained within
@@ -14709,7 +14985,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14731,7 +15009,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14807,7 +15085,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14829,7 +15108,7 @@ function Compute(options) {
         pathParams: ['interconnectLocation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.interconnectLocations.list
         * @desc Retrieves the list of interconnect locations available to the
@@ -14913,7 +15192,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14935,7 +15216,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -15012,7 +15293,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15034,7 +15317,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.get
             * @desc Returns the specified interconnect. Get a list of available
@@ -15106,7 +15389,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15128,7 +15412,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.insert
             * @desc Creates a Interconnect in the specified project using the
@@ -15201,7 +15485,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15222,7 +15508,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.list
             * @desc Retrieves the list of interconnect available to the
@@ -15306,7 +15592,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15327,7 +15615,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.interconnects.patch
             * @desc Updates the specified interconnect with the data included in
@@ -15408,7 +15696,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15430,7 +15720,7 @@ function Compute(options) {
             pathParams: ['interconnect', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -15504,7 +15794,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15525,7 +15816,7 @@ function Compute(options) {
         pathParams: ['license', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -15613,7 +15904,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15634,7 +15927,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.machineTypes.get
         * @desc Returns the specified machine type. Get a list of available
@@ -15710,7 +16003,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15732,7 +16026,7 @@ function Compute(options) {
         pathParams: ['machineType', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.machineTypes.list
         * @desc Retrieves a list of machine types available to the specified
@@ -15820,7 +16114,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15841,7 +16137,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -15922,7 +16218,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        addPeering(params, options, callback) {
+        addPeering(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -15944,7 +16242,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.delete
             * @desc Deletes the specified network.
@@ -16015,7 +16313,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16037,7 +16337,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.get
             * @desc Returns the specified network. Get a list of available
@@ -16108,7 +16408,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16130,7 +16431,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.insert
             * @desc Creates a network in the specified project using the data
@@ -16203,7 +16504,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16224,7 +16527,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.list
             * @desc Retrieves the list of networks available to the specified
@@ -16308,7 +16611,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16329,7 +16634,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.patch
             * @desc Patches the specified network with the data included in the
@@ -16409,7 +16714,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16431,7 +16738,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.removePeering
             * @desc Removes a peering from the specified network.
@@ -16505,7 +16812,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        removePeering(params, options, callback) {
+        removePeering(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16527,7 +16836,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.networks.switchToCustomMode
             * @desc Switches the network mode from auto subnet mode to custom
@@ -16597,7 +16906,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        switchToCustomMode(params, options, callback) {
+        switchToCustomMode(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16619,7 +16930,7 @@ function Compute(options) {
             pathParams: ['network', 'project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -16691,7 +17002,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        disableXpnHost(params, options, callback) {
+        disableXpnHost(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16712,7 +17025,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.disableXpnResource
             * @desc Disable a serivce resource (a.k.a service project)
@@ -16783,7 +17096,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        disableXpnResource(params, options, callback) {
+        disableXpnResource(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16804,7 +17119,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.enableXpnHost
             * @desc Enable this project as a shared VPC host project.
@@ -16869,7 +17184,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        enableXpnHost(params, options, callback) {
+        enableXpnHost(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16890,7 +17207,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.enableXpnResource
             * @desc Enable service resource (a.k.a service project) for a host
@@ -16962,7 +17279,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        enableXpnResource(params, options, callback) {
+        enableXpnResource(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -16983,7 +17302,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.get
             * @desc Returns the specified Project resource.
@@ -17049,7 +17368,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17069,7 +17389,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.getXpnHost
             * @desc Get the shared VPC host project that this project links to.
@@ -17136,7 +17456,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getXpnHost(params, options, callback) {
+        getXpnHost(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17156,7 +17478,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.getXpnResources
             * @desc Get service resources (a.k.a service project) associated
@@ -17241,7 +17563,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getXpnResources(params, options, callback) {
+        getXpnResources(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17262,7 +17586,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.listXpnHosts
             * @desc List all shared VPC host projects visible to the user in an
@@ -17351,7 +17675,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listXpnHosts(params, options, callback) {
+        listXpnHosts(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17371,7 +17697,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.moveDisk
             * @desc Moves a persistent disk from one zone to another.
@@ -17443,7 +17769,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        moveDisk(params, options, callback) {
+        moveDisk(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17463,7 +17791,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.moveInstance
             * @desc Moves an instance and its attached persistent disks from one
@@ -17536,7 +17864,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        moveInstance(params, options, callback) {
+        moveInstance(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17556,7 +17886,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.setCommonInstanceMetadata
             * @desc Sets metadata common to all instances within the specified
@@ -17627,7 +17957,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setCommonInstanceMetadata(params, options, callback) {
+        setCommonInstanceMetadata(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17649,7 +17981,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.projects.setUsageExportBucket
             * @desc Enables the usage export feature and sets the usage export
@@ -17721,7 +18053,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setUsageExportBucket(params, options, callback) {
+        setUsageExportBucket(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17742,7 +18076,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -17822,7 +18156,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17844,7 +18180,7 @@ function Compute(options) {
             pathParams: ['autoscaler', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.get
             * @desc Returns the specified autoscaler.
@@ -17919,7 +18255,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -17941,7 +18278,7 @@ function Compute(options) {
             pathParams: ['autoscaler', 'project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.insert
             * @desc Creates an autoscaler in the specified project using the
@@ -18016,7 +18353,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18038,7 +18377,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.list
             * @desc Retrieves a list of autoscalers contained within the
@@ -18126,7 +18465,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18148,7 +18489,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.patch
             * @desc Updates an autoscaler in the specified project using the
@@ -18227,7 +18568,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18249,7 +18592,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.regionAutoscalers.update
             * @desc Updates an autoscaler in the specified project using the
@@ -18327,7 +18670,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -18349,7 +18694,7 @@ function Compute(options) {
             pathParams: ['project', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -18429,7 +18774,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18451,7 +18798,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.get
         * @desc Returns the specified regional BackendService resource.
@@ -18526,7 +18873,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18548,7 +18896,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.getHealth
         * @desc Gets the most recent health check results for this regional
@@ -18626,7 +18974,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18648,7 +18998,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.insert
         * @desc Creates a regional BackendService resource in the specified
@@ -18726,7 +19076,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18748,7 +19100,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.list
         * @desc Retrieves the list of regional BackendService resources
@@ -18836,7 +19188,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18858,7 +19212,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.patch
         * @desc Updates the specified regional BackendService resource with the
@@ -18944,7 +19298,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18966,7 +19322,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionBackendServices.update
         * @desc Updates the specified regional BackendService resource with the
@@ -19050,7 +19406,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19072,7 +19430,7 @@ function Compute(options) {
         pathParams: ['backendService', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -19160,7 +19518,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19181,7 +19541,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.get
         * @desc Returns the specified commitment resource. Get a list of
@@ -19256,7 +19616,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19278,7 +19639,7 @@ function Compute(options) {
         pathParams: ['commitment', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.insert
         * @desc Creates a commitment in the specified project using the data
@@ -19355,7 +19716,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19377,7 +19740,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionCommitments.list
         * @desc Retrieves a list of commitments contained within the specified
@@ -19465,7 +19828,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19487,7 +19852,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -19582,7 +19947,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    abandonInstances(params, options, callback) {
+    abandonInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19604,7 +19971,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.delete
         * @desc Deletes the specified managed instance group and all of the
@@ -19679,7 +20046,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19701,7 +20070,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.deleteInstances
         * @desc Schedules a group action to delete the specified instances in
@@ -19791,7 +20160,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteInstances(params, options, callback) {
+    deleteInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19813,7 +20184,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.get
         * @desc Returns all of the details about the specified managed instance
@@ -19887,7 +20258,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -19909,7 +20281,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.insert
         * @desc Creates a managed instance group using the information that you
@@ -19990,7 +20362,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20012,7 +20386,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.list
         * @desc Retrieves the list of managed instance groups that are contained
@@ -20100,7 +20474,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20122,7 +20498,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.listManagedInstances
         * @desc Lists the instances in the managed instance group and instances
@@ -20201,7 +20577,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listManagedInstances(params, options, callback) {
+    listManagedInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20223,7 +20601,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.recreateInstances
         * @desc Schedules a group action to recreate the specified instances in
@@ -20312,7 +20690,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    recreateInstances(params, options, callback) {
+    recreateInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20334,7 +20714,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.resize
         * @desc Changes the intended size for the managed instance group. If you
@@ -20422,7 +20802,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resize(params, options, callback) {
+    resize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20444,7 +20826,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setInstanceTemplate
         * @desc Sets the instance template to use when creating new instances or
@@ -20525,7 +20907,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setInstanceTemplate(params, options, callback) {
+    setInstanceTemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20547,7 +20931,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroupManagers.setTargetPools
         * @desc Modifies the target pools to which all new instances in this
@@ -20627,7 +21011,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTargetPools(params, options, callback) {
+    setTargetPools(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20649,7 +21035,7 @@ function Compute(options) {
         pathParams: ['instanceGroupManager', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -20728,7 +21114,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20750,7 +21137,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.list
         * @desc Retrieves the list of instance group resources contained within
@@ -20838,7 +21225,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20860,7 +21249,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.listInstances
         * @desc Lists the instances in the specified instance group and displays
@@ -20960,7 +21349,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listInstances(params, options, callback) {
+    listInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -20982,7 +21373,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionInstanceGroups.setNamedPorts
         * @desc Sets the named ports for the specified regional instance group.
@@ -21061,7 +21452,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setNamedPorts(params, options, callback) {
+    setNamedPorts(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21083,7 +21476,7 @@ function Compute(options) {
         pathParams: ['instanceGroup', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -21158,7 +21551,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21180,7 +21575,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionOperations.get
         * @desc Retrieves the specified region-specific Operations resource.
@@ -21254,7 +21649,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21276,7 +21672,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regionOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -21364,7 +21760,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21386,7 +21784,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -21461,7 +21859,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21481,7 +21880,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.regions.list
         * @desc Retrieves the list of region resources available to the
@@ -21565,7 +21964,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21585,7 +21986,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -21673,7 +22074,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21694,7 +22097,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.delete
         * @desc Deletes the specified Router resource.
@@ -21769,7 +22172,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21791,7 +22196,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.get
         * @desc Returns the specified Router resource. Get a list of available
@@ -21866,7 +22271,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21888,7 +22294,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.getRouterStatus
         * @desc Retrieves runtime information of the specified router.
@@ -21962,7 +22368,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getRouterStatus(params, options, callback) {
+    getRouterStatus(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -21984,7 +22392,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.insert
         * @desc Creates a Router resource in the specified project and region
@@ -22061,7 +22469,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22082,7 +22492,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.list
         * @desc Retrieves a list of Router resources available to the specified
@@ -22170,7 +22580,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22191,7 +22603,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.patch
         * @desc Patches the specified Router resource with the data included in
@@ -22275,7 +22687,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22297,7 +22711,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.preview
         * @desc Preview fields auto-generated during router create and update
@@ -22377,7 +22791,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    preview(params, options, callback) {
+    preview(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22399,7 +22815,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routers.update
         * @desc Updates the specified Router resource with the data included in
@@ -22482,7 +22898,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22504,7 +22922,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'router'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -22579,7 +22997,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22600,7 +23020,7 @@ function Compute(options) {
         pathParams: ['project', 'route'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.get
         * @desc Returns the specified Route resource. Get a list of available
@@ -22671,7 +23091,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22692,7 +23113,7 @@ function Compute(options) {
         pathParams: ['project', 'route'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.insert
         * @desc Creates a Route resource in the specified project using the data
@@ -22765,7 +23186,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22785,7 +23208,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.routes.list
         * @desc Retrieves the list of Route resources available to the specified
@@ -22869,7 +23292,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22889,7 +23314,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -22968,7 +23393,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -22990,7 +23417,7 @@ function Compute(options) {
         pathParams: ['project', 'snapshot'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.get
         * @desc Returns the specified Snapshot resource. Get a list of available
@@ -23061,7 +23488,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23083,7 +23511,7 @@ function Compute(options) {
         pathParams: ['project', 'snapshot'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.list
         * @desc Retrieves the list of Snapshot resources contained within the
@@ -23167,7 +23595,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23187,7 +23617,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.snapshots.setLabels
         * @desc Sets the labels on a snapshot. To learn more about labels, read
@@ -23263,7 +23693,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setLabels(params, options, callback) {
+    setLabels(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23285,7 +23717,7 @@ function Compute(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -23361,7 +23793,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23383,7 +23817,7 @@ function Compute(options) {
         pathParams: ['project', 'sslCertificate'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.get
         * @desc Returns the specified SslCertificate resource. Get a list of
@@ -23455,7 +23889,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23477,7 +23912,7 @@ function Compute(options) {
         pathParams: ['project', 'sslCertificate'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.insert
         * @desc Creates a SslCertificate resource in the specified project using
@@ -23550,7 +23985,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23571,7 +24008,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.sslCertificates.list
         * @desc Retrieves the list of SslCertificate resources available to the
@@ -23655,7 +24092,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23676,7 +24115,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -23764,7 +24203,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23785,7 +24226,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.delete
         * @desc Deletes the specified subnetwork.
@@ -23860,7 +24301,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23882,7 +24325,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.expandIpCidrRange
         * @desc Expands the IP CIDR range of the subnetwork to a specified
@@ -23961,7 +24404,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    expandIpCidrRange(params, options, callback) {
+    expandIpCidrRange(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -23983,7 +24428,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.get
         * @desc Returns the specified subnetwork. Get a list of available
@@ -24058,7 +24503,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24080,7 +24526,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.insert
         * @desc Creates a subnetwork in the specified project using the data
@@ -24157,7 +24603,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24179,7 +24627,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.list
         * @desc Retrieves a list of subnetworks available to the specified
@@ -24267,7 +24715,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24289,7 +24739,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.subnetworks.setPrivateIpGoogleAccess
         * @desc Set whether VMs in this subnet can access Google services
@@ -24368,7 +24818,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setPrivateIpGoogleAccess(params, options, callback) {
+    setPrivateIpGoogleAccess(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24390,7 +24842,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'subnetwork'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -24466,7 +24918,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24488,7 +24942,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.get
         * @desc Returns the specified TargetHttpProxy resource. Get a list of
@@ -24560,7 +25014,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24582,7 +25037,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.insert
         * @desc Creates a TargetHttpProxy resource in the specified project
@@ -24655,7 +25110,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24676,7 +25133,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.list
         * @desc Retrieves the list of TargetHttpProxy resources available to the
@@ -24760,7 +25217,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24781,7 +25240,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpProxies.setUrlMap
         * @desc Changes the URL map for TargetHttpProxy.
@@ -24856,7 +25315,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setUrlMap(params, options, callback) {
+    setUrlMap(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24878,7 +25339,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -24954,7 +25415,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -24976,7 +25439,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.get
         * @desc Returns the specified TargetHttpsProxy resource. Get a list of
@@ -25048,7 +25511,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25070,7 +25534,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.insert
         * @desc Creates a TargetHttpsProxy resource in the specified project
@@ -25143,7 +25607,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25164,7 +25630,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.list
         * @desc Retrieves the list of TargetHttpsProxy resources available to
@@ -25248,7 +25714,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25269,7 +25737,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setSslCertificates
         * @desc Replaces SslCertificates for TargetHttpsProxy.
@@ -25344,7 +25812,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslCertificates(params, options, callback) {
+    setSslCertificates(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25366,7 +25836,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetHttpsProxies.setUrlMap
         * @desc Changes the URL map for TargetHttpsProxy.
@@ -25441,7 +25911,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setUrlMap(params, options, callback) {
+    setUrlMap(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25463,7 +25935,7 @@ function Compute(options) {
         pathParams: ['project', 'targetHttpsProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -25551,7 +26023,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25572,7 +26046,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.delete
         * @desc Deletes the specified TargetInstance resource.
@@ -25648,7 +26122,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25670,7 +26146,7 @@ function Compute(options) {
         pathParams: ['project', 'targetInstance', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.get
         * @desc Returns the specified TargetInstance resource. Get a list of
@@ -25746,7 +26222,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25768,7 +26245,7 @@ function Compute(options) {
         pathParams: ['project', 'targetInstance', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.insert
         * @desc Creates a TargetInstance resource in the specified project and
@@ -25845,7 +26322,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25867,7 +26346,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetInstances.list
         * @desc Retrieves a list of TargetInstance resources available to the
@@ -25955,7 +26434,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -25977,7 +26458,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -26061,7 +26542,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addHealthCheck(params, options, callback) {
+    addHealthCheck(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26083,7 +26566,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.addInstance
         * @desc Adds an instance to a target pool.
@@ -26163,7 +26646,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    addInstance(params, options, callback) {
+    addInstance(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26185,7 +26670,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.aggregatedList
         * @desc Retrieves an aggregated list of target pools.
@@ -26269,7 +26754,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26290,7 +26777,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.delete
         * @desc Deletes the specified target pool.
@@ -26365,7 +26852,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26387,7 +26876,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.get
         * @desc Returns the specified target pool. Get a list of available
@@ -26462,7 +26951,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26484,7 +26974,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.getHealth
         * @desc Gets the most recent health check results for each IP for the
@@ -26565,7 +27055,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getHealth(params, options, callback) {
+    getHealth(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26587,7 +27079,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.insert
         * @desc Creates a target pool in the specified project and region using
@@ -26664,7 +27156,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26686,7 +27180,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.list
         * @desc Retrieves a list of target pools available to the specified
@@ -26774,7 +27268,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26796,7 +27292,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.removeHealthCheck
         * @desc Removes health check URL from a target pool.
@@ -26874,7 +27370,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeHealthCheck(params, options, callback) {
+    removeHealthCheck(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26896,7 +27394,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.removeInstance
         * @desc Removes instance URL from a target pool.
@@ -26974,7 +27472,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeInstance(params, options, callback) {
+    removeInstance(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -26996,7 +27496,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetPools.setBackup
         * @desc Changes a backup target pool's configurations.
@@ -27077,7 +27577,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackup(params, options, callback) {
+    setBackup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27099,7 +27601,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetPool'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -27175,7 +27677,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27197,7 +27701,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.get
         * @desc Returns the specified TargetSslProxy resource. Get a list of
@@ -27269,7 +27773,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27291,7 +27796,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.insert
         * @desc Creates a TargetSslProxy resource in the specified project using
@@ -27364,7 +27869,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27385,7 +27892,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.list
         * @desc Retrieves the list of TargetSslProxy resources available to the
@@ -27469,7 +27976,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27490,7 +27999,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setBackendService
         * @desc Changes the BackendService for TargetSslProxy.
@@ -27565,7 +28074,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackendService(params, options, callback) {
+    setBackendService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27587,7 +28098,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setProxyHeader
         * @desc Changes the ProxyHeaderType for TargetSslProxy.
@@ -27662,7 +28173,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setProxyHeader(params, options, callback) {
+    setProxyHeader(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27684,7 +28197,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetSslProxies.setSslCertificates
         * @desc Changes SslCertificates for TargetSslProxy.
@@ -27759,7 +28272,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setSslCertificates(params, options, callback) {
+    setSslCertificates(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27781,7 +28296,7 @@ function Compute(options) {
         pathParams: ['project', 'targetSslProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -27857,7 +28372,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27879,7 +28396,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.get
         * @desc Returns the specified TargetTcpProxy resource. Get a list of
@@ -27951,7 +28468,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -27973,7 +28491,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.insert
         * @desc Creates a TargetTcpProxy resource in the specified project using
@@ -28046,7 +28564,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28067,7 +28587,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.list
         * @desc Retrieves the list of TargetTcpProxy resources available to the
@@ -28151,7 +28671,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28172,7 +28694,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.setBackendService
         * @desc Changes the BackendService for TargetTcpProxy.
@@ -28247,7 +28769,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setBackendService(params, options, callback) {
+    setBackendService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28269,7 +28793,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetTcpProxies.setProxyHeader
         * @desc Changes the ProxyHeaderType for TargetTcpProxy.
@@ -28344,7 +28868,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setProxyHeader(params, options, callback) {
+    setProxyHeader(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28366,7 +28892,7 @@ function Compute(options) {
         pathParams: ['project', 'targetTcpProxy'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -28454,7 +28980,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28476,7 +29004,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.delete
         * @desc Deletes the specified target VPN gateway.
@@ -28552,7 +29080,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28574,7 +29104,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetVpnGateway'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.get
         * @desc Returns the specified target VPN gateway. Get a list of
@@ -28650,7 +29180,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28672,7 +29203,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'targetVpnGateway'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.insert
         * @desc Creates a target VPN gateway in the specified project and region
@@ -28749,7 +29280,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28771,7 +29304,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.targetVpnGateways.list
         * @desc Retrieves a list of target VPN gateways available to the
@@ -28859,7 +29392,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -28881,7 +29416,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -28957,7 +29492,9 @@ function Compute(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -28979,7 +29516,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.get
             * @desc Returns the specified UrlMap resource. Get a list of
@@ -29050,7 +29587,8 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -29072,7 +29610,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.insert
             * @desc Creates a UrlMap resource in the specified project using the
@@ -29145,7 +29683,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -29166,7 +29706,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.invalidateCache
             * @desc Initiates a cache invalidation operation, invalidating the
@@ -29241,7 +29781,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        invalidateCache(params, options, callback) {
+        invalidateCache(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -29263,7 +29805,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.list
             * @desc Retrieves the list of UrlMap resources available to the
@@ -29347,7 +29889,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -29368,7 +29912,7 @@ function Compute(options) {
             pathParams: ['project'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.patch
             * @desc Patches the specified UrlMap resource with the data included
@@ -29448,7 +29992,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -29470,7 +30016,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.update
             * @desc Updates the specified UrlMap resource with the data included
@@ -29549,7 +30095,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -29571,7 +30119,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * compute.urlMaps.validate
             * @desc Runs static validation for the UrlMap. In particular, the
@@ -29648,7 +30196,9 @@ function Compute(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        validate(params, options, callback) {
+        validate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -29670,7 +30220,7 @@ function Compute(options) {
             pathParams: ['project', 'urlMap'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -29758,7 +30308,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    aggregatedList(params, options, callback) {
+    aggregatedList(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29779,7 +30331,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.delete
         * @desc Deletes the specified VpnTunnel resource.
@@ -29854,7 +30406,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29876,7 +30430,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'vpnTunnel'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.get
         * @desc Returns the specified VpnTunnel resource. Get a list of
@@ -29951,7 +30505,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -29973,7 +30528,7 @@ function Compute(options) {
         pathParams: ['project', 'region', 'vpnTunnel'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.insert
         * @desc Creates a VpnTunnel resource in the specified project and region
@@ -30050,7 +30605,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30072,7 +30629,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.vpnTunnels.list
         * @desc Retrieves a list of VpnTunnel resources contained in the
@@ -30160,7 +30717,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30182,7 +30741,7 @@ function Compute(options) {
         pathParams: ['project', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -30257,7 +30816,9 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30279,7 +30840,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zoneOperations.get
         * @desc Retrieves the specified zone-specific Operations resource.
@@ -30353,7 +30914,8 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30375,7 +30937,7 @@ function Compute(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zoneOperations.list
         * @desc Retrieves a list of Operation resources contained within the
@@ -30463,7 +31025,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30484,7 +31048,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -30559,7 +31123,8 @@ function Compute(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30579,7 +31144,7 @@ function Compute(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * compute.zones.list
         * @desc Retrieves the list of Zone resources available to the specified
@@ -30663,7 +31228,9 @@ function Compute(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -30683,7 +31250,7 @@ function Compute(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/container/v1.ts
+++ b/src/apis/container/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Kubernetes Engine API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Container
  */
-function Container(options) {
+function Container(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -109,7 +116,9 @@ function Container(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          getServerconfig(params, options, callback) {
+          getServerconfig(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -131,7 +140,7 @@ function Container(options) {
               pathParams: ['projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           clusters:
               {
@@ -219,7 +228,10 @@ function Container(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                addons(params, options, callback) {
+                addons(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -242,7 +254,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.completeIpRotation
                     * @desc Completes master IP rotation.
@@ -330,7 +342,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                completeIpRotation(params, options, callback) {
+                completeIpRotation(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -353,7 +368,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.create
                     * @desc Creates a cluster, consisting of the specified
@@ -444,7 +459,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -467,7 +485,7 @@ function Container(options) {
                     pathParams: ['projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.delete
                     * @desc Deletes the cluster, including the Kubernetes
@@ -555,7 +573,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -578,7 +599,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.get
                     * @desc Gets the details of a specific cluster.
@@ -660,7 +681,9 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -683,7 +706,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.legacyAbac
                     * @desc Enables or disables the ABAC authorization mechanism
@@ -771,7 +794,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                legacyAbac(params, options, callback) {
+                legacyAbac(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -794,7 +820,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.list
                     * @desc Lists all clusters owned by a project in either the
@@ -872,7 +898,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -895,7 +924,7 @@ function Container(options) {
                     pathParams: ['projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.locations
                     * @desc Sets the locations of a specific cluster.
@@ -982,7 +1011,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                locations(params, options, callback) {
+                locations(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1005,7 +1037,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.logging
                     * @desc Sets the logging service of a specific cluster.
@@ -1092,7 +1124,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                logging(params, options, callback) {
+                logging(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1115,7 +1150,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.master
                     * @desc Updates the master of a specific cluster.
@@ -1202,7 +1237,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                master(params, options, callback) {
+                master(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1225,7 +1263,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.monitoring
                     * @desc Sets the monitoring service of a specific cluster.
@@ -1312,7 +1350,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                monitoring(params, options, callback) {
+                monitoring(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1335,7 +1376,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.resourceLabels
                     * @desc Sets labels on a cluster.
@@ -1422,7 +1463,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                resourceLabels(params, options, callback) {
+                resourceLabels(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1445,7 +1489,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.setMaintenancePolicy
                     * @desc Sets the maintenance policy for a cluster.
@@ -1533,7 +1577,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                setMaintenancePolicy(params, options, callback) {
+                setMaintenancePolicy(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1556,7 +1603,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.setMasterAuth
                     * @desc Used to set master auth materials. Currently
@@ -1646,7 +1693,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                setMasterAuth(params, options, callback) {
+                setMasterAuth(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1669,7 +1719,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.setNetworkPolicy
                     * @desc Enables/Disables Network Policy for a cluster.
@@ -1756,7 +1806,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                setNetworkPolicy(params, options, callback) {
+                setNetworkPolicy(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1779,7 +1832,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.startIpRotation
                     * @desc Start master IP rotation.
@@ -1866,7 +1919,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                startIpRotation(params, options, callback) {
+                startIpRotation(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1889,7 +1945,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * container.projects.zones.clusters.update
                     * @desc Updates the settings of a specific cluster.
@@ -1978,7 +2034,10 @@ function Container(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                update(params, options, callback) {
+                update(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -2001,7 +2060,7 @@ function Container(options) {
                     pathParams: ['clusterId', 'projectId', 'zone'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 },
                 nodePools:
                     {
@@ -2102,7 +2161,10 @@ function Container(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      autoscaling(params, options, callback) {
+                      autoscaling(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2127,7 +2189,7 @@ function Container(options) {
                               ['clusterId', 'nodePoolId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.create
                           * @desc Creates a node pool for a cluster.
@@ -2221,7 +2283,10 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      create(params, options, callback) {
+                      create(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2244,7 +2309,7 @@ function Container(options) {
                           pathParams: ['clusterId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.delete
                           * @desc Deletes a node pool from a cluster.
@@ -2337,7 +2402,10 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      delete (params, options, callback) {
+                      delete (
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2362,7 +2430,7 @@ function Container(options) {
                               ['clusterId', 'nodePoolId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.get
                           * @desc Retrieves the node pool requested.
@@ -2455,7 +2523,9 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      get(params, options, callback) {
+                      get(params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2480,7 +2550,7 @@ function Container(options) {
                               ['clusterId', 'nodePoolId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.list
                           * @desc Lists the node pools for a cluster.
@@ -2568,7 +2638,10 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      list(params, options, callback) {
+                      list(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2591,7 +2664,7 @@ function Container(options) {
                           pathParams: ['clusterId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.rollback
                           * @desc Roll back the previously Aborted or Failed
@@ -2692,7 +2765,10 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      rollback(params, options, callback) {
+                      rollback(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2717,7 +2793,7 @@ function Container(options) {
                               ['clusterId', 'nodePoolId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.setManagement
                           * @desc Sets the NodeManagement options for a node
@@ -2817,7 +2893,10 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      setManagement(params, options, callback) {
+                      setManagement(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2842,7 +2921,7 @@ function Container(options) {
                               ['clusterId', 'nodePoolId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.setSize
                           * @desc Sets the size of a specific node pool.
@@ -2941,7 +3020,10 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      setSize(params, options, callback) {
+                      setSize(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2966,7 +3048,7 @@ function Container(options) {
                               ['clusterId', 'nodePoolId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * container.projects.zones.clusters.nodePools.update
                           * @desc Updates the version and/or image type of a
@@ -3066,7 +3148,10 @@ function Container(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      update(params, options, callback) {
+                      update(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -3091,7 +3176,7 @@ function Container(options) {
                               ['clusterId', 'nodePoolId', 'projectId', 'zone'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     }
@@ -3175,7 +3260,9 @@ function Container(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            cancel(params, options, callback) {
+            cancel(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -3198,7 +3285,7 @@ function Container(options) {
                 pathParams: ['operationId', 'projectId', 'zone'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * container.projects.zones.operations.get
                 * @desc Gets the specified operation.
@@ -3278,7 +3365,8 @@ function Container(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -3301,7 +3389,7 @@ function Container(options) {
                 pathParams: ['operationId', 'projectId', 'zone'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * container.projects.zones.operations.list
                 * @desc Lists all operations in a project in a specific zone or
@@ -3376,7 +3464,9 @@ function Container(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -3398,7 +3488,7 @@ function Container(options) {
                 pathParams: ['projectId', 'zone'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -3642,7 +3732,7 @@ function Container(options) {
  * @property {object} labels The map of Kubernetes labels (key/value pairs) to be applied to each node. These will added in addition to any default label(s) that Kubernetes may apply to the node. In case of conflict in label keys, the applied set may differ depending on the Kubernetes version -- it&#39;s best to assume the behavior is undefined and conflicts should be avoided. For more information, including usage and the valid values, see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
  * @property {integer} localSsdCount The number of local SSD disks to be attached to the node.  The limit for this value is dependant upon the maximum number of disks available on a machine per zone. See: https://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_limits for more information.
  * @property {string} machineType The name of a Google Compute Engine [machine type](/compute/docs/machine-types) (e.g. `n1-standard-1`).  If unspecified, the default machine type is `n1-standard-1`.
- * @property {object} metadata The metadata key/value pairs assigned to instances in the cluster.  Keys must conform to the regexp [a-zA-Z0-9-_]+ and be less than 128 bytes in length. These are reflected as part of a URL in the metadata server. Additionally, to avoid ambiguity, keys must not conflict with any other metadata keys for the project or be one of the reserved keys:  &quot;cluster-name&quot;  &quot;cluster-uid&quot;  &quot;configure-sh&quot;  &quot;gci-update-strategy&quot;  &quot;gci-ensure-gke-docker&quot;  &quot;instance-template&quot;  &quot;kube-env&quot;  &quot;startup-script&quot;  &quot;user-data&quot;  Values are free-form strings, and only have meaning as interpreted by the image running in the instance. The only restriction placed on them is that each value&#39;s size must be less than or equal to 32 KB.  The total size of all keys and values must be less than 512 KB.
+ * @property {object} metadata The metadata key/value pairs assigned to instances in the cluster.  Keys must conform to the regexp [a-zA-Z0-9-_]+ and be less than 128 bytes in length. These are reflected as part of a URL in the metadata server. Additionally, to avoid ambiguity, keys must not conflict with any other metadata keys for the project or be one of the reserved keys:  &quot;cluster-location&quot;  &quot;cluster-name&quot;  &quot;cluster-uid&quot;  &quot;configure-sh&quot;  &quot;gci-update-strategy&quot;  &quot;gci-ensure-gke-docker&quot;  &quot;instance-template&quot;  &quot;kube-env&quot;  &quot;startup-script&quot;  &quot;user-data&quot;  Values are free-form strings, and only have meaning as interpreted by the image running in the instance. The only restriction placed on them is that each value&#39;s size must be less than or equal to 32 KB.  The total size of all keys and values must be less than 512 KB.
  * @property {string} minCpuPlatform Minimum CPU platform to be used by this instance. The instance may be scheduled on the specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such as &lt;code&gt;minCpuPlatform: &amp;quot;Intel Haswell&amp;quot;&lt;/code&gt; or &lt;code&gt;minCpuPlatform: &amp;quot;Intel Sandy Bridge&amp;quot;&lt;/code&gt;. For more information, read [how to specify min CPU platform](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
  * @property {string[]} oauthScopes The set of Google API scopes to be made available on all of the node VMs under the &quot;default&quot; service account.  The following scopes are recommended, but not required, and by default are not included:  * `https://www.googleapis.com/auth/compute` is required for mounting persistent storage on your nodes. * `https://www.googleapis.com/auth/devstorage.read_only` is required for communicating with **gcr.io** (the [Google Container Registry](/container-registry/)).  If unspecified, no scopes are added, unless Cloud Logging or Cloud Monitoring are enabled, in which case their required scopes will be added.
  * @property {boolean} preemptible Whether the nodes are created as preemptible VM instances. See: https://cloud.google.com/compute/docs/instances/preemptible for more information about preemptible VM instances.

--- a/src/apis/container/v1beta1.ts
+++ b/src/apis/container/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Kubernetes Engine API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Container
  */
-function Container(options) {
+function Container(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -51,7 +58,9 @@ function Container(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      getServerConfig(params, options, callback) {
+      getServerConfig(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -71,7 +80,7 @@ function Container(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       clusters: {
         /**
@@ -87,7 +96,9 @@ function Container(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        completeIpRotation(params, options, callback) {
+        completeIpRotation(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -108,7 +119,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.create
             * @desc Creates a cluster, consisting of the specified number and
@@ -130,7 +141,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -151,7 +164,7 @@ function Container(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.delete
             * @desc Deletes the cluster, including the Kubernetes endpoint and
@@ -172,7 +185,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -193,7 +208,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.get
             * @desc Gets the details of a specific cluster.
@@ -209,7 +224,8 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -230,7 +246,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.list
             * @desc Lists all clusters owned by a project in either the
@@ -246,7 +262,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -267,7 +285,7 @@ function Container(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setAddons
             * @desc Sets the addons of a specific cluster.
@@ -281,7 +299,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setAddons(params, options, callback) {
+        setAddons(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -302,7 +322,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setLegacyAbac
             * @desc Enables or disables the ABAC authorization mechanism on a
@@ -317,7 +337,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLegacyAbac(params, options, callback) {
+        setLegacyAbac(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -338,7 +360,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setLocations
             * @desc Sets the locations of a specific cluster.
@@ -352,7 +374,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLocations(params, options, callback) {
+        setLocations(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -373,7 +397,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setLogging
             * @desc Sets the logging service of a specific cluster.
@@ -387,7 +411,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setLogging(params, options, callback) {
+        setLogging(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -408,7 +434,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setMaintenancePolicy
             * @desc Sets the maintenance policy for a cluster.
@@ -422,7 +448,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMaintenancePolicy(params, options, callback) {
+        setMaintenancePolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -443,7 +471,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setMasterAuth
             * @desc Used to set master auth materials. Currently supports :-
@@ -460,7 +488,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMasterAuth(params, options, callback) {
+        setMasterAuth(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -481,7 +511,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setMonitoring
             * @desc Sets the monitoring service of a specific cluster.
@@ -495,7 +525,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMonitoring(params, options, callback) {
+        setMonitoring(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -516,7 +548,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setNetworkPolicy
             * @desc Enables/Disables Network Policy for a cluster.
@@ -530,7 +562,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setNetworkPolicy(params, options, callback) {
+        setNetworkPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -551,7 +585,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.setResourceLabels
             * @desc Sets labels on a cluster.
@@ -565,7 +599,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setResourceLabels(params, options, callback) {
+        setResourceLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -586,7 +622,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.startIpRotation
             * @desc Start master IP rotation.
@@ -600,7 +636,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        startIpRotation(params, options, callback) {
+        startIpRotation(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -621,7 +659,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.update
             * @desc Updates the settings of a specific cluster.
@@ -635,7 +673,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -656,7 +696,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.clusters.updateMaster
             * @desc Updates the master of a specific cluster.
@@ -670,7 +710,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        updateMaster(params, options, callback) {
+        updateMaster(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -691,7 +733,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         nodePools:
             {
@@ -708,7 +750,9 @@ function Container(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              create(params, options, callback) {
+              create(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -729,7 +773,7 @@ function Container(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.delete
                   * @desc Deletes a node pool from a cluster.
@@ -747,7 +791,9 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -768,7 +814,7 @@ function Container(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.get
                   * @desc Retrieves the node pool requested.
@@ -785,7 +831,8 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -806,7 +853,7 @@ function Container(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.list
                   * @desc Lists the node pools for a cluster.
@@ -822,7 +869,9 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -843,7 +892,7 @@ function Container(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.rollback
                   * @desc Roll back the previously Aborted or Failed NodePool
@@ -860,7 +909,9 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              rollback(params, options, callback) {
+              rollback(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -881,7 +932,7 @@ function Container(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.setAutoscaling
                   * @desc Sets the autoscaling settings of a specific node pool.
@@ -896,7 +947,9 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              setAutoscaling(params, options, callback) {
+              setAutoscaling(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -917,7 +970,7 @@ function Container(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.setManagement
                   * @desc Sets the NodeManagement options for a node pool.
@@ -932,7 +985,9 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              setManagement(params, options, callback) {
+              setManagement(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -953,7 +1008,7 @@ function Container(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.setSize
                   * @desc Sets the size of a specific node pool.
@@ -968,7 +1023,9 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              setSize(params, options, callback) {
+              setSize(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -989,7 +1046,7 @@ function Container(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * container.projects.locations.clusters.nodePools.update
                   * @desc Updates the version and/or image type of a specific
@@ -1005,7 +1062,9 @@ function Container(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              update(params, options, callback) {
+              update(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1026,7 +1085,7 @@ function Container(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             }
@@ -1045,7 +1104,9 @@ function Container(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        cancel(params, options, callback) {
+        cancel(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1066,7 +1127,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.operations.get
             * @desc Gets the specified operation.
@@ -1082,7 +1143,8 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1103,7 +1165,7 @@ function Container(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.locations.operations.list
             * @desc Lists all operations in a project in a specific zone or all
@@ -1119,7 +1181,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1140,7 +1204,7 @@ function Container(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -1160,7 +1224,9 @@ function Container(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      getServerconfig(params, options, callback) {
+      getServerconfig(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1181,7 +1247,7 @@ function Container(options) {
           pathParams: ['projectId', 'zone'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       clusters: {
         /**
@@ -1199,7 +1265,9 @@ function Container(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        addons(params, options, callback) {
+        addons(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1222,7 +1290,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.completeIpRotation
             * @desc Completes master IP rotation.
@@ -1238,7 +1306,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        completeIpRotation(params, options, callback) {
+        completeIpRotation(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1261,7 +1331,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.create
             * @desc Creates a cluster, consisting of the specified number and
@@ -1284,7 +1354,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1306,7 +1378,7 @@ function Container(options) {
             pathParams: ['projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.delete
             * @desc Deletes the cluster, including the Kubernetes endpoint and
@@ -1327,7 +1399,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1350,7 +1424,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.get
             * @desc Gets the details of a specific cluster.
@@ -1366,7 +1440,8 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1389,7 +1464,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.legacyAbac
             * @desc Enables or disables the ABAC authorization mechanism on a
@@ -1406,7 +1481,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        legacyAbac(params, options, callback) {
+        legacyAbac(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1429,7 +1506,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.list
             * @desc Lists all clusters owned by a project in either the
@@ -1445,7 +1522,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1467,7 +1546,7 @@ function Container(options) {
             pathParams: ['projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.locations
             * @desc Sets the locations of a specific cluster.
@@ -1483,7 +1562,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        locations(params, options, callback) {
+        locations(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1506,7 +1587,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.logging
             * @desc Sets the logging service of a specific cluster.
@@ -1522,7 +1603,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        logging(params, options, callback) {
+        logging(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1545,7 +1628,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.master
             * @desc Updates the master of a specific cluster.
@@ -1561,7 +1644,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        master(params, options, callback) {
+        master(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1584,7 +1669,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.monitoring
             * @desc Sets the monitoring service of a specific cluster.
@@ -1600,7 +1685,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        monitoring(params, options, callback) {
+        monitoring(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1623,7 +1710,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.resourceLabels
             * @desc Sets labels on a cluster.
@@ -1639,7 +1726,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        resourceLabels(params, options, callback) {
+        resourceLabels(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1662,7 +1751,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.setMaintenancePolicy
             * @desc Sets the maintenance policy for a cluster.
@@ -1678,7 +1767,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMaintenancePolicy(params, options, callback) {
+        setMaintenancePolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1701,7 +1792,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.setMasterAuth
             * @desc Used to set master auth materials. Currently supports :-
@@ -1720,7 +1811,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setMasterAuth(params, options, callback) {
+        setMasterAuth(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1743,7 +1836,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.setNetworkPolicy
             * @desc Enables/Disables Network Policy for a cluster.
@@ -1759,7 +1852,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setNetworkPolicy(params, options, callback) {
+        setNetworkPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1782,7 +1877,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.startIpRotation
             * @desc Start master IP rotation.
@@ -1798,7 +1893,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        startIpRotation(params, options, callback) {
+        startIpRotation(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1821,7 +1918,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.clusters.update
             * @desc Updates the settings of a specific cluster.
@@ -1837,7 +1934,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1860,7 +1959,7 @@ function Container(options) {
             pathParams: ['clusterId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         nodePools: {
           /**
@@ -1879,7 +1978,9 @@ function Container(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          autoscaling(params, options, callback) {
+          autoscaling(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1902,7 +2003,7 @@ function Container(options) {
               pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.create
               * @desc Creates a node pool for a cluster.
@@ -1918,7 +2019,9 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1941,7 +2044,7 @@ function Container(options) {
               pathParams: ['clusterId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.delete
               * @desc Deletes a node pool from a cluster.
@@ -1958,7 +2061,9 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1981,7 +2086,7 @@ function Container(options) {
               pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.get
               * @desc Retrieves the node pool requested.
@@ -1998,7 +2103,8 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2021,7 +2127,7 @@ function Container(options) {
               pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.list
               * @desc Lists the node pools for a cluster.
@@ -2037,7 +2143,9 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2060,7 +2168,7 @@ function Container(options) {
               pathParams: ['clusterId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.rollback
               * @desc Roll back the previously Aborted or Failed NodePool
@@ -2079,7 +2187,9 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          rollback(params, options, callback) {
+          rollback(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2102,7 +2212,7 @@ function Container(options) {
               pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.setManagement
               * @desc Sets the NodeManagement options for a node pool.
@@ -2119,7 +2229,9 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          setManagement(params, options, callback) {
+          setManagement(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2142,7 +2254,7 @@ function Container(options) {
               pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.setSize
               * @desc Sets the size of a specific node pool.
@@ -2159,7 +2271,9 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          setSize(params, options, callback) {
+          setSize(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2182,7 +2296,7 @@ function Container(options) {
               pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * container.projects.zones.clusters.nodePools.update
               * @desc Updates the version and/or image type of a specific node
@@ -2200,7 +2314,9 @@ function Container(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2223,7 +2339,7 @@ function Container(options) {
               pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }
@@ -2244,7 +2360,9 @@ function Container(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        cancel(params, options, callback) {
+        cancel(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2267,7 +2385,7 @@ function Container(options) {
             pathParams: ['operationId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.operations.get
             * @desc Gets the specified operation.
@@ -2283,7 +2401,8 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2306,7 +2425,7 @@ function Container(options) {
             pathParams: ['operationId', 'projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * container.projects.zones.operations.list
             * @desc Lists all operations in a project in a specific zone or all
@@ -2322,7 +2441,9 @@ function Container(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2344,7 +2465,7 @@ function Container(options) {
             pathParams: ['projectId', 'zone'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/content/v2.ts
+++ b/src/apis/content/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Content API for Shopping
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Content
  */
-function Content(options) {
+function Content(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -47,7 +54,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    authinfo(params, options, callback) {
+    authinfo(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +76,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.claimwebsite
         * @desc Claims the website of a Merchant Center sub-account.
@@ -82,7 +91,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    claimwebsite(params, options, callback) {
+    claimwebsite(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +115,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.custombatch
         * @desc Retrieves, inserts, updates, and deletes multiple Merchant
@@ -119,7 +130,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +152,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.delete
         * @desc Deletes a Merchant Center sub-account.
@@ -155,7 +168,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -175,7 +190,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.get
         * @desc Retrieves a Merchant Center account.
@@ -189,7 +204,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -209,7 +225,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.insert
         * @desc Creates a Merchant Center sub-account.
@@ -224,7 +240,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -244,7 +262,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.list
         * @desc Lists the sub-accounts in your Merchant Center account.
@@ -259,7 +277,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -279,7 +299,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.patch
         * @desc Updates a Merchant Center account. This method supports patch
@@ -296,7 +316,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -316,7 +338,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounts.update
         * @desc Updates a Merchant Center account.
@@ -332,7 +354,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -352,7 +376,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -368,7 +392,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -388,7 +414,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accountstatuses.get
         * @desc Retrieves the status of a Merchant Center account.
@@ -402,7 +428,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -423,7 +450,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accountstatuses.list
         * @desc Lists the statuses of the sub-accounts in your Merchant Center
@@ -439,7 +466,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -459,7 +488,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -478,7 +507,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -498,7 +529,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounttax.get
         * @desc Retrieves the tax settings of the account.
@@ -512,7 +543,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -532,7 +564,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounttax.list
         * @desc Lists the tax settings of the sub-accounts in your Merchant
@@ -548,7 +580,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -568,7 +602,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounttax.patch
         * @desc Updates the tax settings of the account. This method supports
@@ -585,7 +619,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -605,7 +641,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.accounttax.update
         * @desc Updates the tax settings of the account.
@@ -621,7 +657,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -641,7 +679,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -658,7 +696,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -678,7 +718,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeeds.delete
         * @desc Deletes a datafeed configuration from your Merchant Center
@@ -694,7 +734,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -714,7 +756,7 @@ function Content(options) {
         pathParams: ['datafeedId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeeds.get
         * @desc Retrieves a datafeed configuration from your Merchant Center
@@ -729,7 +771,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -749,7 +792,7 @@ function Content(options) {
         pathParams: ['datafeedId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeeds.insert
         * @desc Registers a datafeed configuration with your Merchant Center
@@ -765,7 +808,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -785,7 +830,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeeds.list
         * @desc Lists the configurations for datafeeds in your Merchant Center
@@ -801,7 +846,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -821,7 +868,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeeds.patch
         * @desc Updates a datafeed configuration of your Merchant Center
@@ -838,7 +885,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -858,7 +907,7 @@ function Content(options) {
         pathParams: ['datafeedId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeeds.update
         * @desc Updates a datafeed configuration of your Merchant Center
@@ -875,7 +924,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -895,7 +946,7 @@ function Content(options) {
         pathParams: ['datafeedId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -911,7 +962,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -931,7 +984,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeedstatuses.get
         * @desc Retrieves the status of a datafeed from your Merchant Center
@@ -948,7 +1001,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -969,7 +1023,7 @@ function Content(options) {
         pathParams: ['datafeedId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.datafeedstatuses.list
         * @desc Lists the statuses of the datafeeds in your Merchant Center
@@ -985,7 +1039,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1005,7 +1061,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1025,7 +1081,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1045,7 +1103,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.inventory.set
         * @desc Updates price and availability of a product in your Merchant
@@ -1063,7 +1121,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    set(params, options, callback) {
+    set(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1085,7 +1144,7 @@ function Content(options) {
         pathParams: ['merchantId', 'productId', 'storeCode'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1104,7 +1163,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    acknowledge(params, options, callback) {
+    acknowledge(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1125,7 +1186,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.advancetestorder
         * @desc Sandbox only. Moves a test order from state "inProgress" to
@@ -1140,7 +1201,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    advancetestorder(params, options, callback) {
+    advancetestorder(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1161,7 +1224,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.cancel
         * @desc Cancels all line items in an order, making a full refund.
@@ -1176,7 +1239,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1197,7 +1262,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.cancellineitem
         * @desc Cancels a line item, making a full refund.
@@ -1212,7 +1277,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    cancellineitem(params, options, callback) {
+    cancellineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1233,7 +1300,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.createtestorder
         * @desc Sandbox only. Creates a test order.
@@ -1247,7 +1314,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    createtestorder(params, options, callback) {
+    createtestorder(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1267,7 +1336,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.custombatch
         * @desc Retrieves or modifies multiple orders in a single request.
@@ -1280,7 +1349,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1300,7 +1371,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.get
         * @desc Retrieves an order from your Merchant Center account.
@@ -1314,7 +1385,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1334,7 +1406,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.getbymerchantorderid
         * @desc Retrieves an order using merchant order id.
@@ -1348,7 +1420,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getbymerchantorderid(params, options, callback) {
+    getbymerchantorderid(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1370,7 +1444,7 @@ function Content(options) {
         pathParams: ['merchantId', 'merchantOrderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.gettestordertemplate
         * @desc Sandbox only. Retrieves an order template that can be used to
@@ -1385,7 +1459,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    gettestordertemplate(params, options, callback) {
+    gettestordertemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1407,7 +1483,7 @@ function Content(options) {
         pathParams: ['merchantId', 'templateName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.instorerefundlineitem
         * @desc Notifies that item return and refund was handled directly in
@@ -1423,7 +1499,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    instorerefundlineitem(params, options, callback) {
+    instorerefundlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1445,7 +1523,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.list
         * @desc Lists the orders in your Merchant Center account.
@@ -1465,7 +1543,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1485,7 +1565,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.refund
         * @desc Refund a portion of the order, up to the full amount paid.
@@ -1500,7 +1580,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    refund(params, options, callback) {
+    refund(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1521,7 +1603,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.rejectreturnlineitem
         * @desc Rejects return on an line item.
@@ -1536,7 +1618,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    rejectreturnlineitem(params, options, callback) {
+    rejectreturnlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1558,7 +1642,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.returnlineitem
         * @desc Returns a line item.
@@ -1573,7 +1657,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    returnlineitem(params, options, callback) {
+    returnlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1594,7 +1680,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.returnrefundlineitem
         * @desc Returns and refunds a line item. Note that this method can only
@@ -1610,7 +1696,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    returnrefundlineitem(params, options, callback) {
+    returnrefundlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1632,7 +1720,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.setlineitemmetadata
         * @desc Sets (overrides) merchant provided annotations on the line item.
@@ -1647,7 +1735,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setlineitemmetadata(params, options, callback) {
+    setlineitemmetadata(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1669,7 +1759,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.shiplineitems
         * @desc Marks line item(s) as shipped.
@@ -1684,7 +1774,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    shiplineitems(params, options, callback) {
+    shiplineitems(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1705,7 +1797,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.updatelineitemshippingdetails
         * @desc Updates ship by and delivery by dates for a line item.
@@ -1720,7 +1812,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updatelineitemshippingdetails(params, options, callback) {
+    updatelineitemshippingdetails(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1742,7 +1836,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.updatemerchantorderid
         * @desc Updates the merchant order ID for a given order.
@@ -1757,7 +1851,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updatemerchantorderid(params, options, callback) {
+    updatemerchantorderid(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1779,7 +1875,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.updateshipment
         * @desc Updates a shipment's status, carrier, and/or tracking ID.
@@ -1794,7 +1890,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateshipment(params, options, callback) {
+    updateshipment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1815,7 +1913,279 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
+    }
+
+  };
+  self.pos = {
+    /**
+     * content.pos.custombatch
+     * @desc Batches multiple POS-related calls in a single request.
+     * @alias content.pos.custombatch
+     * @memberOf! content(v2)
+     *
+     * @param {object} params Parameters for request
+     * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+     * @param {content(v2).PosCustomBatchRequest} params.resource Request body data
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/content/v2/pos/batch')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'POST'
+            },
+            options),
+        params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * content.pos.delete
+        * @desc Deletes a store for the given merchant.
+        * @alias content.pos.delete
+        * @memberOf! content(v2)
+        *
+        * @param {object} params Parameters for request
+        * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+        * @param {string} params.merchantId The ID of the POS provider.
+        * @param {string} params.storeCode A store code that is unique per merchant.
+        * @param {string} params.targetMerchantId The ID of the target merchant.
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url:
+                  (rootUrl +
+                   '/content/v2/{merchantId}/pos/{targetMerchantId}/store/{storeCode}')
+                      .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'DELETE'
+            },
+            options),
+        params,
+        requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
+        pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * content.pos.get
+        * @desc Retrieves information about the given store.
+        * @alias content.pos.get
+        * @memberOf! content(v2)
+        *
+        * @param {object} params Parameters for request
+        * @param {string} params.merchantId The ID of the POS provider.
+        * @param {string} params.storeCode A store code that is unique per merchant.
+        * @param {string} params.targetMerchantId The ID of the target merchant.
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url:
+                  (rootUrl +
+                   '/content/v2/{merchantId}/pos/{targetMerchantId}/store/{storeCode}')
+                      .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
+        pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * content.pos.insert
+        * @desc Creates a store for the given merchant.
+        * @alias content.pos.insert
+        * @memberOf! content(v2)
+        *
+        * @param {object} params Parameters for request
+        * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+        * @param {string} params.merchantId The ID of the POS provider.
+        * @param {string} params.targetMerchantId The ID of the target merchant.
+        * @param {content(v2).PosStore} params.resource Request body data
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl +
+                    '/content/v2/{merchantId}/pos/{targetMerchantId}/store')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'POST'
+            },
+            options),
+        params,
+        requiredParams: ['merchantId', 'targetMerchantId'],
+        pathParams: ['merchantId', 'targetMerchantId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * content.pos.inventory
+        * @desc Submit inventory for the given merchant.
+        * @alias content.pos.inventory
+        * @memberOf! content(v2)
+        *
+        * @param {object} params Parameters for request
+        * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+        * @param {string} params.merchantId The ID of the POS provider.
+        * @param {string} params.targetMerchantId The ID of the target merchant.
+        * @param {content(v2).PosInventoryRequest} params.resource Request body data
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    inventory(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl +
+                    '/content/v2/{merchantId}/pos/{targetMerchantId}/inventory')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'POST'
+            },
+            options),
+        params,
+        requiredParams: ['merchantId', 'targetMerchantId'],
+        pathParams: ['merchantId', 'targetMerchantId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * content.pos.list
+        * @desc Lists the stores of the target merchant.
+        * @alias content.pos.list
+        * @memberOf! content(v2)
+        *
+        * @param {object} params Parameters for request
+        * @param {string} params.merchantId The ID of the POS provider.
+        * @param {string} params.targetMerchantId The ID of the target merchant.
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl +
+                    '/content/v2/{merchantId}/pos/{targetMerchantId}/store')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['merchantId', 'targetMerchantId'],
+        pathParams: ['merchantId', 'targetMerchantId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * content.pos.sale
+        * @desc Submit a sale event for the given merchant.
+        * @alias content.pos.sale
+        * @memberOf! content(v2)
+        *
+        * @param {object} params Parameters for request
+        * @param {boolean=} params.dryRun Flag to run the request in dry-run mode.
+        * @param {string} params.merchantId The ID of the POS provider.
+        * @param {string} params.targetMerchantId The ID of the target merchant.
+        * @param {content(v2).PosSaleRequest} params.resource Request body data
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    sale(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl +
+                    '/content/v2/{merchantId}/pos/{targetMerchantId}/sale')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'POST'
+            },
+            options),
+        params,
+        requiredParams: ['merchantId', 'targetMerchantId'],
+        pathParams: ['merchantId', 'targetMerchantId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1834,7 +2204,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1854,7 +2226,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.products.delete
         * @desc Deletes a product from your Merchant Center account.
@@ -1869,7 +2241,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1889,7 +2263,7 @@ function Content(options) {
         pathParams: ['merchantId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.products.get
         * @desc Retrieves a product from your Merchant Center account.
@@ -1903,7 +2277,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1923,7 +2298,7 @@ function Content(options) {
         pathParams: ['merchantId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.products.insert
         * @desc Uploads a product to your Merchant Center account. If an item
@@ -1940,7 +2315,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1960,7 +2337,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.products.list
         * @desc Lists the products in your Merchant Center account.
@@ -1976,7 +2353,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1996,7 +2375,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2014,7 +2393,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2034,7 +2415,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.productstatuses.get
         * @desc Gets the status of a product from your Merchant Center account.
@@ -2049,7 +2430,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2070,7 +2452,7 @@ function Content(options) {
         pathParams: ['merchantId', 'productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.productstatuses.list
         * @desc Lists the statuses of the products in your Merchant Center
@@ -2088,7 +2470,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2108,7 +2492,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2127,7 +2511,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2147,7 +2533,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.shippingsettings.get
         * @desc Retrieves the shipping settings of the account.
@@ -2161,7 +2547,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2182,7 +2569,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.shippingsettings.getsupportedcarriers
         * @desc Retrieves supported carriers and carrier services for an
@@ -2196,7 +2583,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getsupportedcarriers(params, options, callback) {
+    getsupportedcarriers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2216,7 +2605,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.shippingsettings.getsupportedholidays
         * @desc Retrieves supported holidays for an account.
@@ -2229,7 +2618,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getsupportedholidays(params, options, callback) {
+    getsupportedholidays(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2249,7 +2640,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.shippingsettings.list
         * @desc Lists the shipping settings of the sub-accounts in your Merchant
@@ -2265,7 +2656,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2285,7 +2678,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.shippingsettings.patch
         * @desc Updates the shipping settings of the account. This method
@@ -2302,7 +2695,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2323,7 +2718,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.shippingsettings.update
         * @desc Updates the shipping settings of the account.
@@ -2339,7 +2734,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2360,7 +2757,7 @@ function Content(options) {
         pathParams: ['accountId', 'merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2375,7 +2772,7 @@ function Content(options) {
  * @property {string} id Merchant Center account ID.
  * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#account&quot;.
  * @property {string} name Display name for the account.
- * @property {string} reviewsUrl URL for individual seller reviews, i.e., reviews for each child account.
+ * @property {string} reviewsUrl [DEPRECATED] This field is never returned and will be ignored if provided.
  * @property {string} sellerId Client-specific, locally-unique, internal ID for the child account.
  * @property {content(v2).AccountUser[]} users Users with access to the account. Every account (except for subaccounts) must have at least one admin user.
  * @property {string} websiteUrl The merchant&#39;s website.
@@ -2392,7 +2789,7 @@ function Content(options) {
  * @typedef AccountGoogleMyBusinessLink
  * @memberOf! content(v2)
  * @type object
- * @property {string} gmbEmail The GMB email address.
+ * @property {string} gmbEmail The GMB email address of which a specific account within a GMB account. A sample account within a GMB account could be a business account with set of locations, managed under the GMB account.
  * @property {string} status Status of the link between this Merchant Center account and the GMB account.
  */
 /**
@@ -3583,6 +3980,143 @@ function Content(options) {
  * @type object
  * @property {string} executionStatus The status of the execution.
  * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#ordersUpdateShipmentResponse&quot;.
+ */
+/**
+ * @typedef PosCustomBatchRequest
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).PosCustomBatchRequestEntry[]} entries The request entries to be processed in the batch.
+ */
+/**
+ * @typedef PosCustomBatchRequestEntry
+ * @memberOf! content(v2)
+ * @type object
+ * @property {integer} batchId An entry ID, unique within the batch request.
+ * @property {content(v2).PosInventory} inventory The inventory to submit. Set this only if the method is inventory.
+ * @property {string} merchantId The ID of the POS provider.
+ * @property {string} method
+ * @property {content(v2).PosSale} sale The sale information to submit. Set this only if the method is sale.
+ * @property {content(v2).PosStore} store The store information to submit. Set this only if the method is insert.
+ * @property {string} storeCode The store code. Required only to get/submit store information.
+ * @property {string} targetMerchantId The ID of the account for which to get/submit data.
+ */
+/**
+ * @typedef PosCustomBatchResponse
+ * @memberOf! content(v2)
+ * @type object
+ * @property {content(v2).PosCustomBatchResponseEntry[]} entries The result of the execution of the batch requests.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posCustomBatchResponse&quot;.
+ */
+/**
+ * @typedef PosCustomBatchResponseEntry
+ * @memberOf! content(v2)
+ * @type object
+ * @property {integer} batchId The ID of the request entry to which this entry responds.
+ * @property {content(v2).Errors} errors A list of errors defined if, and only if, the request failed.
+ * @property {content(v2).PosInventory} inventory The updated inventory information.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posCustomBatchResponseEntry&quot;.
+ * @property {content(v2).PosSale} sale The updated sale information.
+ * @property {content(v2).PosStore} store The retrieved or updated store information.
+ */
+/**
+ * @typedef PosInventory
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} contentLanguage The two-letter ISO 639-1 language code for the item.
+ * @property {string} gtin Global Trade Item Number.
+ * @property {string} itemId A unique identifier for the item.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posInventory&quot;.
+ * @property {content(v2).Price} price The current price of the item.
+ * @property {string} quantity The available quantity of the item.
+ * @property {string} storeCode The identifier of the merchant&#39;s store.
+ * @property {string} targetCountry The CLDR territory code for the item.
+ * @property {string} timestamp The inventory timestamp, in ISO 8601 format.
+ */
+/**
+ * @typedef PosInventoryRequest
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} contentLanguage The two-letter ISO 639-1 language code for the item.
+ * @property {string} gtin Global Trade Item Number.
+ * @property {string} itemId A unique identifier for the item.
+ * @property {content(v2).Price} price The current price of the item.
+ * @property {string} quantity The available quantity of the item.
+ * @property {string} storeCode The identifier of the merchant&#39;s store.
+ * @property {string} targetCountry The CLDR territory code for the item.
+ * @property {string} timestamp The inventory timestamp, in ISO 8601 format.
+ */
+/**
+ * @typedef PosInventoryResponse
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} contentLanguage The two-letter ISO 639-1 language code for the item.
+ * @property {string} gtin Global Trade Item Number.
+ * @property {string} itemId A unique identifier for the item.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posInventoryResponse&quot;.
+ * @property {content(v2).Price} price The current price of the item.
+ * @property {string} quantity The available quantity of the item.
+ * @property {string} storeCode The identifier of the merchant&#39;s store.
+ * @property {string} targetCountry The CLDR territory code for the item.
+ * @property {string} timestamp The inventory timestamp, in ISO 8601 format.
+ */
+/**
+ * @typedef PosListResponse
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posListResponse&quot;.
+ * @property {content(v2).PosStore[]} resources
+ */
+/**
+ * @typedef PosSale
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} contentLanguage The two-letter ISO 639-1 language code for the item.
+ * @property {string} gtin Global Trade Item Number.
+ * @property {string} itemId A unique identifier for the item.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posSale&quot;.
+ * @property {content(v2).Price} price The price of the item.
+ * @property {string} quantity The relative change of the available quantity. Negative for items sold.
+ * @property {string} saleId A unique ID to group items from the same sale event.
+ * @property {string} storeCode The identifier of the merchant&#39;s store.
+ * @property {string} targetCountry The CLDR territory code for the item.
+ * @property {string} timestamp The inventory timestamp, in ISO 8601 format.
+ */
+/**
+ * @typedef PosSaleRequest
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} contentLanguage The two-letter ISO 639-1 language code for the item.
+ * @property {string} gtin Global Trade Item Number.
+ * @property {string} itemId A unique identifier for the item.
+ * @property {content(v2).Price} price The price of the item.
+ * @property {string} quantity The relative change of the available quantity. Negative for items sold.
+ * @property {string} saleId A unique ID to group items from the same sale event.
+ * @property {string} storeCode The identifier of the merchant&#39;s store.
+ * @property {string} targetCountry The CLDR territory code for the item.
+ * @property {string} timestamp The inventory timestamp, in ISO 8601 format.
+ */
+/**
+ * @typedef PosSaleResponse
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} contentLanguage The two-letter ISO 639-1 language code for the item.
+ * @property {string} gtin Global Trade Item Number.
+ * @property {string} itemId A unique identifier for the item.
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posSaleResponse&quot;.
+ * @property {content(v2).Price} price The price of the item.
+ * @property {string} quantity The relative change of the available quantity. Negative for items sold.
+ * @property {string} saleId A unique ID to group items from the same sale event.
+ * @property {string} storeCode The identifier of the merchant&#39;s store.
+ * @property {string} targetCountry The CLDR territory code for the item.
+ * @property {string} timestamp The inventory timestamp, in ISO 8601 format.
+ */
+/**
+ * @typedef PosStore
+ * @memberOf! content(v2)
+ * @type object
+ * @property {string} kind Identifies what kind of resource this is. Value: the fixed string &quot;content#posStore&quot;.
+ * @property {string} storeAddress The street address of the store.
+ * @property {string} storeCode A store identifier that is unique for the given merchant.
  */
 /**
  * @typedef PostalCodeGroup

--- a/src/apis/content/v2sandbox.ts
+++ b/src/apis/content/v2sandbox.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Content API for Shopping
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2sandbox
  * @param {object=} options Options for Content
  */
-function Content(options) {
+function Content(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.orders = {
@@ -50,7 +57,9 @@ function Content(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    acknowledge(params, options, callback) {
+    acknowledge(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.advancetestorder
         * @desc Sandbox only. Moves a test order from state "inProgress" to
@@ -87,7 +96,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    advancetestorder(params, options, callback) {
+    advancetestorder(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -109,7 +120,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.cancel
         * @desc Cancels all line items in an order, making a full refund.
@@ -124,7 +135,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -145,7 +158,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.cancellineitem
         * @desc Cancels a line item, making a full refund.
@@ -160,7 +173,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    cancellineitem(params, options, callback) {
+    cancellineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -182,7 +197,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.createtestorder
         * @desc Sandbox only. Creates a test order.
@@ -196,7 +211,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    createtestorder(params, options, callback) {
+    createtestorder(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -216,7 +233,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.custombatch
         * @desc Retrieves or modifies multiple orders in a single request.
@@ -229,7 +246,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    custombatch(params, options, callback) {
+    custombatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -249,7 +268,7 @@ function Content(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.get
         * @desc Retrieves an order from your Merchant Center account.
@@ -263,7 +282,8 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -284,7 +304,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.getbymerchantorderid
         * @desc Retrieves an order using merchant order id.
@@ -298,7 +318,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getbymerchantorderid(params, options, callback) {
+    getbymerchantorderid(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -320,7 +342,7 @@ function Content(options) {
         pathParams: ['merchantId', 'merchantOrderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.gettestordertemplate
         * @desc Sandbox only. Retrieves an order template that can be used to
@@ -335,7 +357,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    gettestordertemplate(params, options, callback) {
+    gettestordertemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -357,7 +381,7 @@ function Content(options) {
         pathParams: ['merchantId', 'templateName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.instorerefundlineitem
         * @desc Notifies that item return and refund was handled directly in
@@ -373,7 +397,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    instorerefundlineitem(params, options, callback) {
+    instorerefundlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -395,7 +421,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.list
         * @desc Lists the orders in your Merchant Center account.
@@ -415,7 +441,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -435,7 +463,7 @@ function Content(options) {
         pathParams: ['merchantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.refund
         * @desc Refund a portion of the order, up to the full amount paid.
@@ -450,7 +478,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    refund(params, options, callback) {
+    refund(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -471,7 +501,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.rejectreturnlineitem
         * @desc Rejects return on an line item.
@@ -486,7 +516,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    rejectreturnlineitem(params, options, callback) {
+    rejectreturnlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -508,7 +540,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.returnlineitem
         * @desc Returns a line item.
@@ -523,7 +555,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    returnlineitem(params, options, callback) {
+    returnlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -545,7 +579,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.returnrefundlineitem
         * @desc Returns and refunds a line item. Note that this method can only
@@ -561,7 +595,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    returnrefundlineitem(params, options, callback) {
+    returnrefundlineitem(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -583,7 +619,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.setlineitemmetadata
         * @desc Sets (overrides) merchant provided annotations on the line item.
@@ -598,7 +634,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setlineitemmetadata(params, options, callback) {
+    setlineitemmetadata(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -620,7 +658,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.shiplineitems
         * @desc Marks line item(s) as shipped.
@@ -635,7 +673,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    shiplineitems(params, options, callback) {
+    shiplineitems(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -657,7 +697,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.updatelineitemshippingdetails
         * @desc Updates ship by and delivery by dates for a line item.
@@ -672,7 +712,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updatelineitemshippingdetails(params, options, callback) {
+    updatelineitemshippingdetails(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -694,7 +736,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.updatemerchantorderid
         * @desc Updates the merchant order ID for a given order.
@@ -709,7 +751,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updatemerchantorderid(params, options, callback) {
+    updatemerchantorderid(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -731,7 +775,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * content.orders.updateshipment
         * @desc Updates a shipment's status, carrier, and/or tracking ID.
@@ -746,7 +790,9 @@ function Content(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateshipment(params, options, callback) {
+    updateshipment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -768,7 +814,7 @@ function Content(options) {
         pathParams: ['merchantId', 'orderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/customsearch/v1.ts
+++ b/src/apis/customsearch/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * CustomSearch API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Customsearch
  */
-function Customsearch(options) {
+function Customsearch(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.cse = {
@@ -78,7 +85,9 @@ function Customsearch(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -97,7 +106,7 @@ function Customsearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     siterestrict: {
       /**
@@ -144,7 +153,9 @@ function Customsearch(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -164,7 +175,7 @@ function Customsearch(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/dataflow/v1b3.ts
+++ b/src/apis/dataflow/v1b3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Dataflow API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1b3
  * @param {object=} options Options for Dataflow
  */
-function Dataflow(options) {
+function Dataflow(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects =
@@ -49,7 +56,9 @@ function Dataflow(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        workerMessages(params, options, callback) {
+        workerMessages(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -69,7 +78,7 @@ function Dataflow(options) {
             pathParams: ['projectId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         jobs: {
           /**
@@ -89,7 +98,9 @@ function Dataflow(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          aggregated(params, options, callback) {
+          aggregated(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -111,7 +122,7 @@ function Dataflow(options) {
               pathParams: ['projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dataflow.projects.jobs.create
               * @desc Creates a Cloud Dataflow job.
@@ -128,7 +139,9 @@ function Dataflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -149,7 +162,7 @@ function Dataflow(options) {
               pathParams: ['projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dataflow.projects.jobs.get
               * @desc Gets the state of the specified Cloud Dataflow job.
@@ -165,7 +178,8 @@ function Dataflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -186,7 +200,7 @@ function Dataflow(options) {
               pathParams: ['jobId', 'projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dataflow.projects.jobs.getMetrics
               * @desc Request the job status.
@@ -202,7 +216,9 @@ function Dataflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          getMetrics(params, options, callback) {
+          getMetrics(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -224,7 +240,7 @@ function Dataflow(options) {
               pathParams: ['jobId', 'projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dataflow.projects.jobs.list
               * @desc List the jobs of a project in a given region.
@@ -242,7 +258,9 @@ function Dataflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -263,7 +281,7 @@ function Dataflow(options) {
               pathParams: ['projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dataflow.projects.jobs.update
               * @desc Updates the state of an existing Cloud Dataflow job.
@@ -279,7 +297,9 @@ function Dataflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -300,7 +320,7 @@ function Dataflow(options) {
               pathParams: ['jobId', 'projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           debug: {
             /**
@@ -318,7 +338,9 @@ function Dataflow(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            getConfig(params, options, callback) {
+            getConfig(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -341,7 +363,7 @@ function Dataflow(options) {
                 pathParams: ['jobId', 'projectId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataflow.projects.jobs.debug.sendCapture
                 * @desc Send encoded debug capture data for component.
@@ -356,7 +378,9 @@ function Dataflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            sendCapture(params, options, callback) {
+            sendCapture(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -379,7 +403,7 @@ function Dataflow(options) {
                 pathParams: ['jobId', 'projectId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -403,7 +427,9 @@ function Dataflow(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -425,7 +451,7 @@ function Dataflow(options) {
                 pathParams: ['jobId', 'projectId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -444,7 +470,9 @@ function Dataflow(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            lease(params, options, callback) {
+            lease(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -467,7 +495,7 @@ function Dataflow(options) {
                 pathParams: ['jobId', 'projectId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataflow.projects.jobs.workItems.reportStatus
                 * @desc Reports the status of dataflow WorkItems leased by a
@@ -483,7 +511,9 @@ function Dataflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            reportStatus(params, options, callback) {
+            reportStatus(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -506,7 +536,7 @@ function Dataflow(options) {
                 pathParams: ['jobId', 'projectId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -527,7 +557,9 @@ function Dataflow(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              workerMessages(params, options, callback) {
+              workerMessages(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -550,7 +582,7 @@ function Dataflow(options) {
                   pathParams: ['location', 'projectId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               },
               jobs:
                   {
@@ -570,7 +602,10 @@ function Dataflow(options) {
                      * @param {callback} callback The callback that handles the response.
                      * @return {object} Request object
                      */
-                    create(params, options, callback) {
+                    create(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -593,7 +628,7 @@ function Dataflow(options) {
                         pathParams: ['location', 'projectId'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataflow.projects.locations.jobs.get
                         * @desc Gets the state of the specified Cloud Dataflow
@@ -610,7 +645,9 @@ function Dataflow(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    get(params, options, callback) {
+                    get(params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -633,7 +670,7 @@ function Dataflow(options) {
                         pathParams: ['jobId', 'location', 'projectId'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataflow.projects.locations.jobs.getMetrics
                         * @desc Request the job status.
@@ -649,7 +686,10 @@ function Dataflow(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    getMetrics(params, options, callback) {
+                    getMetrics(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -672,7 +712,7 @@ function Dataflow(options) {
                         pathParams: ['jobId', 'location', 'projectId'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataflow.projects.locations.jobs.list
                         * @desc List the jobs of a project in a given region.
@@ -690,7 +730,10 @@ function Dataflow(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    list(params, options, callback) {
+                    list(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -713,7 +756,7 @@ function Dataflow(options) {
                         pathParams: ['location', 'projectId'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataflow.projects.locations.jobs.update
                         * @desc Updates the state of an existing Cloud Dataflow
@@ -730,7 +773,10 @@ function Dataflow(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    update(params, options, callback) {
+                    update(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -753,7 +799,7 @@ function Dataflow(options) {
                         pathParams: ['jobId', 'location', 'projectId'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     },
                     debug: {
                       /**
@@ -772,7 +818,10 @@ function Dataflow(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      getConfig(params, options, callback) {
+                      getConfig(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -795,7 +844,7 @@ function Dataflow(options) {
                           pathParams: ['jobId', 'location', 'projectId'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * dataflow.projects.locations.jobs.debug.sendCapture
                           * @desc Send encoded debug capture data for component.
@@ -812,7 +861,10 @@ function Dataflow(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      sendCapture(params, options, callback) {
+                      sendCapture(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -835,7 +887,7 @@ function Dataflow(options) {
                           pathParams: ['jobId', 'location', 'projectId'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     },
@@ -859,7 +911,10 @@ function Dataflow(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      list(params, options, callback) {
+                      list(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -882,7 +937,7 @@ function Dataflow(options) {
                           pathParams: ['jobId', 'location', 'projectId'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     },
@@ -902,7 +957,10 @@ function Dataflow(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      lease(params, options, callback) {
+                      lease(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -925,7 +983,7 @@ function Dataflow(options) {
                           pathParams: ['jobId', 'location', 'projectId'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * dataflow.projects.locations.jobs.workItems.reportStatus
                           * @desc Reports the status of dataflow WorkItems
@@ -943,7 +1001,10 @@ function Dataflow(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      reportStatus(params, options, callback) {
+                      reportStatus(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -966,7 +1027,7 @@ function Dataflow(options) {
                           pathParams: ['jobId', 'location', 'projectId'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     }
@@ -986,7 +1047,10 @@ function Dataflow(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1009,7 +1073,7 @@ function Dataflow(options) {
                     pathParams: ['location', 'projectId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataflow.projects.locations.templates.get
                     * @desc Get the template associated with a template.
@@ -1025,7 +1089,9 @@ function Dataflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1048,7 +1114,7 @@ function Dataflow(options) {
                     pathParams: ['location', 'projectId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataflow.projects.locations.templates.launch
                     * @desc Launch a template.
@@ -1065,7 +1131,10 @@ function Dataflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                launch(params, options, callback) {
+                launch(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1088,7 +1157,7 @@ function Dataflow(options) {
                     pathParams: ['location', 'projectId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               }
@@ -1107,7 +1176,9 @@ function Dataflow(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1128,7 +1199,7 @@ function Dataflow(options) {
               pathParams: ['projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dataflow.projects.templates.get
               * @desc Get the template associated with a template.
@@ -1144,7 +1215,8 @@ function Dataflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1165,7 +1237,7 @@ function Dataflow(options) {
               pathParams: ['projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dataflow.projects.templates.launch
               * @desc Launch a template.
@@ -1182,7 +1254,9 @@ function Dataflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          launch(params, options, callback) {
+          launch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1204,7 +1278,7 @@ function Dataflow(options) {
               pathParams: ['projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }

--- a/src/apis/dataproc/v1.ts
+++ b/src/apis/dataproc/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Dataproc API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Dataproc
  */
-function Dataproc(options) {
+function Dataproc(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -111,7 +118,9 @@ function Dataproc(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -132,7 +141,7 @@ function Dataproc(options) {
             pathParams: ['projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.clusters.delete
             * @desc Deletes a cluster in a project.
@@ -208,7 +217,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -230,7 +241,7 @@ function Dataproc(options) {
             pathParams: ['clusterName', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.clusters.diagnose
             * @desc Gets cluster diagnostic information. After the operation
@@ -311,7 +322,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        diagnose(params, options, callback) {
+        diagnose(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -333,7 +346,7 @@ function Dataproc(options) {
             pathParams: ['clusterName', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.clusters.get
             * @desc Gets the resource representation for a cluster in a project.
@@ -407,7 +420,8 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -429,7 +443,7 @@ function Dataproc(options) {
             pathParams: ['clusterName', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.clusters.list
             * @desc Lists all regions/{region}/clusters in a project.
@@ -518,7 +532,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -539,7 +555,7 @@ function Dataproc(options) {
             pathParams: ['projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.clusters.patch
             * @desc Updates a cluster in a project.
@@ -623,7 +639,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -645,7 +663,7 @@ function Dataproc(options) {
             pathParams: ['clusterName', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -729,7 +747,9 @@ function Dataproc(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        cancel(params, options, callback) {
+        cancel(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -751,7 +771,7 @@ function Dataproc(options) {
             pathParams: ['jobId', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.jobs.delete
             * @desc Deletes the job from the project. If the job is active, the
@@ -824,7 +844,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -846,7 +868,7 @@ function Dataproc(options) {
             pathParams: ['jobId', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.jobs.get
             * @desc Gets the resource representation for a job in a project.
@@ -919,7 +941,8 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -941,7 +964,7 @@ function Dataproc(options) {
             pathParams: ['jobId', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.jobs.list
             * @desc Lists regions/{region}/jobs in a project.
@@ -1030,7 +1053,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1051,7 +1076,7 @@ function Dataproc(options) {
             pathParams: ['projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.jobs.patch
             * @desc Updates a job in a project.
@@ -1132,7 +1157,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1154,7 +1181,7 @@ function Dataproc(options) {
             pathParams: ['jobId', 'projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.jobs.submit
             * @desc Submits a job to a cluster.
@@ -1228,7 +1255,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        submit(params, options, callback) {
+        submit(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1249,7 +1278,7 @@ function Dataproc(options) {
             pathParams: ['projectId', 'region'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -1325,7 +1354,9 @@ function Dataproc(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        cancel(params, options, callback) {
+        cancel(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1345,7 +1376,7 @@ function Dataproc(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.operations.delete
             * @desc Deletes a long-running operation. This method indicates that
@@ -1411,7 +1442,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1430,7 +1463,7 @@ function Dataproc(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.operations.get
             * @desc Gets the latest state of a long-running operation. Clients
@@ -1498,7 +1531,8 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1517,7 +1551,7 @@ function Dataproc(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * dataproc.projects.regions.operations.list
             * @desc Lists operations that match the specified filter in the
@@ -1611,7 +1645,9 @@ function Dataproc(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -1630,7 +1666,7 @@ function Dataproc(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/dataproc/v1beta2.ts
+++ b/src/apis/dataproc/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Dataproc API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Dataproc
  */
-function Dataproc(options) {
+function Dataproc(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects =
@@ -51,7 +58,9 @@ function Dataproc(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -72,7 +81,7 @@ function Dataproc(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataproc.projects.locations.workflowTemplates.delete
                 * @desc Deletes a workflow template. It does not cancel
@@ -87,7 +96,9 @@ function Dataproc(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -108,7 +119,7 @@ function Dataproc(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataproc.projects.locations.workflowTemplates.get
                 * @desc Retrieves the latest workflow template.Can retrieve
@@ -124,7 +135,8 @@ function Dataproc(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -145,7 +157,7 @@ function Dataproc(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataproc.projects.locations.workflowTemplates.instantiate
                 * @desc Instantiates a template and begins execution.The
@@ -167,7 +179,9 @@ function Dataproc(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            instantiate(params, options, callback) {
+            instantiate(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -188,7 +202,7 @@ function Dataproc(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataproc.projects.locations.workflowTemplates.instantiateInline
                 * @desc Instantiates a template and begins execution.This method
@@ -214,7 +228,9 @@ function Dataproc(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            instantiateInline(params, options, callback) {
+            instantiateInline(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -237,7 +253,7 @@ function Dataproc(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataproc.projects.locations.workflowTemplates.list
                 * @desc Lists workflows that match the specified filter in the
@@ -253,7 +269,9 @@ function Dataproc(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -274,7 +292,7 @@ function Dataproc(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dataproc.projects.locations.workflowTemplates.update
                 * @desc Updates (replaces) workflow template. The updated
@@ -290,7 +308,9 @@ function Dataproc(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            update(params, options, callback) {
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -311,7 +331,7 @@ function Dataproc(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -334,7 +354,10 @@ function Dataproc(options) {
                      * @param {callback} callback The callback that handles the response.
                      * @return {object} Request object
                      */
-                    create(params, options, callback) {
+                    create(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -357,7 +380,7 @@ function Dataproc(options) {
                         pathParams: ['projectId', 'region'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.delete
                         * @desc Deletes a cluster in a project.
@@ -373,7 +396,10 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    delete (params, options, callback) {
+                    delete (
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -396,7 +422,7 @@ function Dataproc(options) {
                         pathParams: ['clusterName', 'projectId', 'region'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.diagnose
                         * @desc Gets cluster diagnostic information. After the
@@ -414,7 +440,10 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    diagnose(params, options, callback) {
+                    diagnose(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -437,7 +466,7 @@ function Dataproc(options) {
                         pathParams: ['clusterName', 'projectId', 'region'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.get
                         * @desc Gets the resource representation for a cluster
@@ -453,7 +482,9 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    get(params, options, callback) {
+                    get(params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -476,7 +507,7 @@ function Dataproc(options) {
                         pathParams: ['clusterName', 'projectId', 'region'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.getIamPolicy
                         * @desc Gets the access control policy for a resource.
@@ -491,7 +522,10 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    getIamPolicy(params, options, callback) {
+                    getIamPolicy(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -513,7 +547,7 @@ function Dataproc(options) {
                         pathParams: ['resource'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.list
                         * @desc Lists all regions/{region}/clusters in a
@@ -531,7 +565,10 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    list(params, options, callback) {
+                    list(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -554,7 +591,7 @@ function Dataproc(options) {
                         pathParams: ['projectId', 'region'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.patch
                         * @desc Updates a cluster in a project.
@@ -572,7 +609,10 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    patch(params, options, callback) {
+                    patch(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -595,7 +635,7 @@ function Dataproc(options) {
                         pathParams: ['clusterName', 'projectId', 'region'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.setIamPolicy
                         * @desc Sets the access control policy on the specified
@@ -610,7 +650,10 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    setIamPolicy(params, options, callback) {
+                    setIamPolicy(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -632,7 +675,7 @@ function Dataproc(options) {
                         pathParams: ['resource'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * dataproc.projects.regions.clusters.testIamPermissions
                         * @desc Returns permissions that a caller has on the
@@ -653,7 +696,10 @@ function Dataproc(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    testIamPermissions(params, options, callback) {
+                    testIamPermissions(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -675,7 +721,7 @@ function Dataproc(options) {
                         pathParams: ['resource'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }
 
                   },
@@ -697,7 +743,10 @@ function Dataproc(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                cancel(params, options, callback) {
+                cancel(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -720,7 +769,7 @@ function Dataproc(options) {
                     pathParams: ['jobId', 'projectId', 'region'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.jobs.delete
                     * @desc Deletes the job from the project. If the job is
@@ -737,7 +786,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -760,7 +812,7 @@ function Dataproc(options) {
                     pathParams: ['jobId', 'projectId', 'region'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.jobs.get
                     * @desc Gets the resource representation for a job in a
@@ -776,7 +828,9 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -799,7 +853,7 @@ function Dataproc(options) {
                     pathParams: ['jobId', 'projectId', 'region'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.jobs.list
                     * @desc Lists regions/{region}/jobs in a project.
@@ -818,7 +872,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -841,7 +898,7 @@ function Dataproc(options) {
                     pathParams: ['projectId', 'region'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.jobs.patch
                     * @desc Updates a job in a project.
@@ -858,7 +915,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                patch(params, options, callback) {
+                patch(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -881,7 +941,7 @@ function Dataproc(options) {
                     pathParams: ['jobId', 'projectId', 'region'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.jobs.submit
                     * @desc Submits a job to a cluster.
@@ -896,7 +956,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                submit(params, options, callback) {
+                submit(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -919,7 +982,7 @@ function Dataproc(options) {
                     pathParams: ['projectId', 'region'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               },
@@ -946,7 +1009,10 @@ function Dataproc(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                cancel(params, options, callback) {
+                cancel(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -967,7 +1033,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.operations.delete
                     * @desc Deletes a long-running operation. This method
@@ -984,7 +1050,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1005,7 +1074,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.operations.get
                     * @desc Gets the latest state of a long-running operation.
@@ -1020,7 +1089,9 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1041,7 +1112,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.operations.list
                     * @desc Lists operations that match the specified filter in
@@ -1067,7 +1138,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1088,7 +1162,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               },
@@ -1106,7 +1180,10 @@ function Dataproc(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1127,7 +1204,7 @@ function Dataproc(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.workflowTemplates.delete
                     * @desc Deletes a workflow template. It does not cancel
@@ -1142,7 +1219,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1163,7 +1243,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.workflowTemplates.get
                     * @desc Retrieves the latest workflow template.Can retrieve
@@ -1179,7 +1259,9 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1200,7 +1282,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.workflowTemplates.instantiate
                     * @desc Instantiates a template and begins execution.The
@@ -1223,7 +1305,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                instantiate(params, options, callback) {
+                instantiate(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1244,7 +1329,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.workflowTemplates.instantiateInline
                     * @desc Instantiates a template and begins execution.This
@@ -1270,7 +1355,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                instantiateInline(params, options, callback) {
+                instantiateInline(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1293,7 +1381,7 @@ function Dataproc(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.workflowTemplates.list
                     * @desc Lists workflows that match the specified filter in
@@ -1309,7 +1397,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1330,7 +1421,7 @@ function Dataproc(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dataproc.projects.regions.workflowTemplates.update
                     * @desc Updates (replaces) workflow template. The updated
@@ -1346,7 +1437,10 @@ function Dataproc(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                update(params, options, callback) {
+                update(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1367,7 +1461,7 @@ function Dataproc(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               }

--- a/src/apis/datastore/v1.ts
+++ b/src/apis/datastore/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Datastore API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Datastore
  */
-function Datastore(options) {
+function Datastore(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -50,7 +57,9 @@ function Datastore(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    allocateIds(params, options, callback) {
+    allocateIds(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.beginTransaction
         * @desc Begins a new transaction.
@@ -84,7 +93,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    beginTransaction(params, options, callback) {
+    beginTransaction(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +115,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.commit
         * @desc Commits a transaction, optionally creating, deleting or
@@ -119,7 +130,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    commit(params, options, callback) {
+    commit(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +152,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.lookup
         * @desc Looks up entities by key.
@@ -153,7 +166,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    lookup(params, options, callback) {
+    lookup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +188,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.reserveIds
         * @desc Prevents the supplied keys' IDs from being auto-allocated by
@@ -188,7 +203,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reserveIds(params, options, callback) {
+    reserveIds(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -208,7 +225,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.rollback
         * @desc Rolls back a transaction.
@@ -222,7 +239,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    rollback(params, options, callback) {
+    rollback(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -242,7 +261,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.runQuery
         * @desc Queries for entities.
@@ -256,7 +275,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    runQuery(params, options, callback) {
+    runQuery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -276,7 +297,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     operations: {
       /**
@@ -299,7 +320,9 @@ function Datastore(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -319,7 +342,7 @@ function Datastore(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * datastore.projects.operations.delete
           * @desc Deletes a long-running operation. This method indicates that
@@ -335,7 +358,9 @@ function Datastore(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -354,7 +379,7 @@ function Datastore(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * datastore.projects.operations.get
           * @desc Gets the latest state of a long-running operation.  Clients
@@ -369,7 +394,8 @@ function Datastore(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -388,7 +414,7 @@ function Datastore(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * datastore.projects.operations.list
           * @desc Lists operations that match the specified filter in the
@@ -413,7 +439,9 @@ function Datastore(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -433,7 +461,7 @@ function Datastore(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/datastore/v1beta1.ts
+++ b/src/apis/datastore/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Datastore API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Datastore
  */
-function Datastore(options) {
+function Datastore(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -56,7 +63,9 @@ function Datastore(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    export(params, options, callback) {
+    export(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -76,7 +85,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.import
         * @desc Imports entities into Google Cloud Datastore. Existing entities
@@ -95,7 +104,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    import(params, options, callback) {
+    import(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -115,7 +126,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/datastore/v1beta3.ts
+++ b/src/apis/datastore/v1beta3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Datastore API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta3
  * @param {object=} options Options for Datastore
  */
-function Datastore(options) {
+function Datastore(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -50,7 +57,9 @@ function Datastore(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    allocateIds(params, options, callback) {
+    allocateIds(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.beginTransaction
         * @desc Begins a new transaction.
@@ -84,7 +93,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    beginTransaction(params, options, callback) {
+    beginTransaction(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +115,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.commit
         * @desc Commits a transaction, optionally creating, deleting or
@@ -119,7 +130,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    commit(params, options, callback) {
+    commit(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +152,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.lookup
         * @desc Looks up entities by key.
@@ -153,7 +166,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    lookup(params, options, callback) {
+    lookup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +188,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.reserveIds
         * @desc Prevents the supplied keys' IDs from being auto-allocated by
@@ -188,7 +203,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reserveIds(params, options, callback) {
+    reserveIds(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -208,7 +225,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.rollback
         * @desc Rolls back a transaction.
@@ -222,7 +239,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    rollback(params, options, callback) {
+    rollback(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -242,7 +261,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * datastore.projects.runQuery
         * @desc Queries for entities.
@@ -256,7 +275,9 @@ function Datastore(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    runQuery(params, options, callback) {
+    runQuery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -276,7 +297,7 @@ function Datastore(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/deploymentmanager/alpha.ts
+++ b/src/apis/deploymentmanager/alpha.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Deployment Manager Alpha API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation alpha
  * @param {object=} options Options for Deploymentmanager
  */
-function Deploymentmanager(options) {
+function Deploymentmanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.compositeTypes = {
@@ -49,7 +56,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.get
         * @desc Gets information about a specific composite type.
@@ -85,7 +94,8 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +117,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.insert
         * @desc Creates a composite type.
@@ -121,7 +131,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -143,7 +155,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.list
         * @desc Lists all composite types for Deployment Manager.
@@ -151,7 +163,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(alpha)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -160,7 +172,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -182,7 +196,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.patch
         * @desc Updates a composite type. This method supports patch semantics.
@@ -197,7 +211,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +235,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.update
         * @desc Updates a composite type.
@@ -234,7 +250,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -256,7 +274,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -276,7 +294,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancelPreview(params, options, callback) {
+    cancelPreview(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -298,7 +318,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.delete
         * @desc Deletes a deployment and all of the resources in the deployment.
@@ -313,7 +333,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -335,7 +357,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.get
         * @desc Gets information about a specific deployment.
@@ -349,7 +371,8 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -371,7 +394,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -386,7 +409,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -408,7 +433,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.insert
         * @desc Creates a deployment and all of the resources described by the
@@ -425,7 +450,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -447,7 +474,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.list
         * @desc Lists all deployments for a given project.
@@ -455,7 +482,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(alpha)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -464,7 +491,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -486,7 +515,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.patch
         * @desc Updates a deployment and all of the resources described by the
@@ -505,7 +534,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -527,7 +558,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -543,7 +574,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -565,7 +598,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.stop
         * @desc Stops an ongoing operation. This does not roll back any work
@@ -582,7 +615,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -604,7 +639,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -619,7 +654,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -641,7 +678,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.update
         * @desc Updates a deployment and all of the resources described by the
@@ -660,7 +697,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -682,7 +721,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -701,7 +740,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -723,7 +763,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'manifest', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.manifests.list
         * @desc Lists all manifests for a given deployment.
@@ -732,7 +772,7 @@ function Deploymentmanager(options) {
         *
         * @param {object} params Parameters for request
         * @param {string} params.deployment The name of the deployment for this request.
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -741,7 +781,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -763,7 +805,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -781,7 +823,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -803,7 +846,7 @@ function Deploymentmanager(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.operations.list
         * @desc Lists all operations for a project.
@@ -811,7 +854,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(alpha)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -820,7 +863,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -842,7 +887,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -861,7 +906,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -883,7 +929,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.resources.list
         * @desc Lists all resources in a given deployment.
@@ -892,7 +938,7 @@ function Deploymentmanager(options) {
         *
         * @param {object} params Parameters for request
         * @param {string} params.deployment The name of the deployment for this request.
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -901,7 +947,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -923,312 +971,329 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
-  self.typeProviders = {
-    /**
-     * deploymentmanager.typeProviders.delete
-     * @desc Deletes a type provider.
-     * @alias deploymentmanager.typeProviders.delete
-     * @memberOf! deploymentmanager(alpha)
-     *
-     * @param {object} params Parameters for request
-     * @param {string} params.project The project ID for this request.
-     * @param {string} params.typeProvider The name of the type provider for this request.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    delete (params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'DELETE'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.get
-        * @desc Gets information about a specific type provider.
-        * @alias deploymentmanager.typeProviders.get
-        * @memberOf! deploymentmanager(alpha)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    get(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.getType
-        * @desc Gets a type info for a type provided by a TypeProvider.
-        * @alias deploymentmanager.typeProviders.getType
-        * @memberOf! deploymentmanager(alpha)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.type The name of the type provider for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    getType(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}/types/{type}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider', 'type'],
-        pathParams: ['project', 'type', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.insert
-        * @desc Creates a type provider.
-        * @alias deploymentmanager.typeProviders.insert
-        * @memberOf! deploymentmanager(alpha)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {deploymentmanager(alpha).TypeProvider} params.resource Request body data
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    insert(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'POST'
-            },
-            options),
-        params,
-        requiredParams: ['project'],
-        pathParams: ['project'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.list
-        * @desc Lists all resource type providers for Deployment Manager.
-        * @alias deploymentmanager.typeProviders.list
-        * @memberOf! deploymentmanager(alpha)
-        *
-        * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
-        * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
-        * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
-        * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
-        * @param {string} params.project The project ID for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    list(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project'],
-        pathParams: ['project'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.listTypes
-        * @desc Lists all the type info for a TypeProvider.
-        * @alias deploymentmanager.typeProviders.listTypes
-        * @memberOf! deploymentmanager(alpha)
-        *
-        * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
-        * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
-        * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
-        * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    listTypes(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}/types')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.patch
-        * @desc Updates a type provider. This method supports patch semantics.
-        * @alias deploymentmanager.typeProviders.patch
-        * @memberOf! deploymentmanager(alpha)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {deploymentmanager(alpha).TypeProvider} params.resource Request body data
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    patch(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'PATCH'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.update
-        * @desc Updates a type provider.
-        * @alias deploymentmanager.typeProviders.update
-        * @memberOf! deploymentmanager(alpha)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {deploymentmanager(alpha).TypeProvider} params.resource Request body data
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    update(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'PUT'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }
+  self.typeProviders =
+      {
+        /**
+         * deploymentmanager.typeProviders.delete
+         * @desc Deletes a type provider.
+         * @alias deploymentmanager.typeProviders.delete
+         * @memberOf! deploymentmanager(alpha)
+         *
+         * @param {object} params Parameters for request
+         * @param {string} params.project The project ID for this request.
+         * @param {string} params.typeProvider The name of the type provider for this request.
+         * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+         * @param {callback} callback The callback that handles the response.
+         * @return {object} Request object
+         */
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'DELETE'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.get
+            * @desc Gets information about a specific type provider.
+            * @alias deploymentmanager.typeProviders.get
+            * @memberOf! deploymentmanager(alpha)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.getType
+            * @desc Gets a type info for a type provided by a TypeProvider.
+            * @alias deploymentmanager.typeProviders.getType
+            * @memberOf! deploymentmanager(alpha)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.type The name of the type provider for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        getType(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}/types/{type}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider', 'type'],
+            pathParams: ['project', 'type', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.insert
+            * @desc Creates a type provider.
+            * @alias deploymentmanager.typeProviders.insert
+            * @memberOf! deploymentmanager(alpha)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {deploymentmanager(alpha).TypeProvider} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'POST'
+                },
+                options),
+            params,
+            requiredParams: ['project'],
+            pathParams: ['project'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.list
+            * @desc Lists all resource type providers for Deployment Manager.
+            * @alias deploymentmanager.typeProviders.list
+            * @memberOf! deploymentmanager(alpha)
+            *
+            * @param {object} params Parameters for request
+            * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
+            * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+            * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+            * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+            * @param {string} params.project The project ID for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project'],
+            pathParams: ['project'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.listTypes
+            * @desc Lists all the type info for a TypeProvider.
+            * @alias deploymentmanager.typeProviders.listTypes
+            * @memberOf! deploymentmanager(alpha)
+            *
+            * @param {object} params Parameters for request
+            * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
+            * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+            * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+            * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        listTypes(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}/types')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.patch
+            * @desc Updates a type provider. This method supports patch
+            * semantics.
+            * @alias deploymentmanager.typeProviders.patch
+            * @memberOf! deploymentmanager(alpha)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {deploymentmanager(alpha).TypeProvider} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'PATCH'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.update
+            * @desc Updates a type provider.
+            * @alias deploymentmanager.typeProviders.update
+            * @memberOf! deploymentmanager(alpha)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {deploymentmanager(alpha).TypeProvider} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/alpha/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'PUT'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }
 
-  };
+      };
   self.types = {
     /**
      * deploymentmanager.types.delete
@@ -1243,7 +1308,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1265,7 +1332,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'type'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.types.get
         * @desc Gets information about a specific type.
@@ -1279,7 +1346,8 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1301,7 +1369,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'type'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.types.insert
         * @desc Creates a type.
@@ -1315,7 +1383,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1336,7 +1406,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.types.list
         * @desc Lists all resource types for Deployment Manager.
@@ -1344,7 +1414,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(alpha)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -1353,7 +1423,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1374,7 +1446,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.types.patch
         * @desc Updates a type. This method supports patch semantics.
@@ -1389,7 +1461,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1411,7 +1485,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'type'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.types.update
         * @desc Updates a type.
@@ -1426,7 +1500,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1448,7 +1524,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'type'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1932,7 +2008,7 @@ function Deploymentmanager(options) {
  * @property {string} id Output only. Unique identifier for the resource; defined by the server.
  * @property {string} insertTime Output only. Timestamp when the type provider was created, in RFC3339 text format.
  * @property {deploymentmanager(alpha).TypeProviderLabelEntry[]} labels Map of labels; provided by the client when the resource is created or updated. Specifically: Label keys must be between 1 and 63 characters long and must conform to the following regular expression: [a-z]([-a-z0-9]*[a-z0-9])? Label values must be between 0 and 63 characters long and must conform to the regular expression ([a-z]([-a-z0-9]*[a-z0-9])?)?
- * @property {string} name Name of the type provider.
+ * @property {string} name Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
  * @property {deploymentmanager(alpha).Operation} operation Output only. The Operation that most recently ran, or is currently running, on this type provider.
  * @property {deploymentmanager(alpha).Options} options Options to apply when handling any resources in this service.
  * @property {string} selfLink Output only. Self link for the type provider.

--- a/src/apis/deploymentmanager/v2.ts
+++ b/src/apis/deploymentmanager/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Deployment Manager API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Deploymentmanager
  */
-function Deploymentmanager(options) {
+function Deploymentmanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.deployments = {
@@ -108,7 +115,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancelPreview(params, options, callback) {
+    cancelPreview(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -130,7 +139,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.delete
         * @desc Deletes a deployment and all of the resources in the deployment.
@@ -200,7 +209,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -222,7 +233,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.get
         * @desc Gets information about a specific deployment.
@@ -293,7 +304,8 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -315,7 +327,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -385,7 +397,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -407,7 +421,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.insert
         * @desc Creates a deployment and all of the resources described by the
@@ -479,7 +493,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -501,7 +517,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.list
         * @desc Lists all deployments for a given project.
@@ -577,7 +593,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(v2)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -586,7 +602,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -608,7 +626,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.patch
         * @desc Updates a deployment and all of the resources described by the
@@ -688,7 +706,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -710,7 +730,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -785,7 +805,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -807,7 +829,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.stop
         * @desc Stops an ongoing operation. This does not roll back any work
@@ -883,7 +905,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -905,7 +929,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -979,7 +1003,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1001,7 +1027,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.update
         * @desc Updates a deployment and all of the resources described by the
@@ -1081,7 +1107,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1103,7 +1131,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1181,7 +1209,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1203,7 +1232,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'manifest', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.manifests.list
         * @desc Lists all manifests for a given deployment.
@@ -1283,7 +1312,7 @@ function Deploymentmanager(options) {
         *
         * @param {object} params Parameters for request
         * @param {string} params.deployment The name of the deployment for this request.
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -1292,7 +1321,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1314,7 +1345,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1388,7 +1419,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1410,7 +1442,7 @@ function Deploymentmanager(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.operations.list
         * @desc Lists all operations for a project.
@@ -1486,7 +1518,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(v2)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -1495,7 +1527,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1517,7 +1551,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1595,7 +1629,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1617,7 +1652,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.resources.list
         * @desc Lists all resources in a given deployment.
@@ -1697,7 +1732,7 @@ function Deploymentmanager(options) {
         *
         * @param {object} params Parameters for request
         * @param {string} params.deployment The name of the deployment for this request.
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -1706,7 +1741,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1728,7 +1765,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1806,7 +1843,7 @@ function Deploymentmanager(options) {
      * @memberOf! deploymentmanager(v2)
      *
      * @param {object} params Parameters for request
-     * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+     * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
      * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
      * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
      * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -1815,7 +1852,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1836,7 +1875,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/deploymentmanager/v2beta.ts
+++ b/src/apis/deploymentmanager/v2beta.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Deployment Manager API V2Beta Methods
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta
  * @param {object=} options Options for Deploymentmanager
  */
-function Deploymentmanager(options) {
+function Deploymentmanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.compositeTypes = {
@@ -49,7 +56,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.get
         * @desc Gets information about a specific composite type.
@@ -85,7 +94,8 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +117,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.insert
         * @desc Creates a composite type.
@@ -121,7 +131,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -143,7 +155,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.list
         * @desc Lists all composite types for Deployment Manager.
@@ -151,7 +163,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(v2beta)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -160,7 +172,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -182,7 +196,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.patch
         * @desc Updates a composite type. This method supports patch semantics.
@@ -197,7 +211,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +235,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.compositeTypes.update
         * @desc Updates a composite type.
@@ -234,7 +250,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -256,7 +274,7 @@ function Deploymentmanager(options) {
         pathParams: ['compositeType', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -276,7 +294,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancelPreview(params, options, callback) {
+    cancelPreview(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -298,7 +318,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.delete
         * @desc Deletes a deployment and all of the resources in the deployment.
@@ -313,7 +333,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -335,7 +357,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.get
         * @desc Gets information about a specific deployment.
@@ -349,7 +371,8 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -371,7 +394,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.getIamPolicy
         * @desc Gets the access control policy for a resource. May be empty if
@@ -386,7 +409,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -408,7 +433,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.insert
         * @desc Creates a deployment and all of the resources described by the
@@ -425,7 +450,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -447,7 +474,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.list
         * @desc Lists all deployments for a given project.
@@ -455,7 +482,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(v2beta)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -464,7 +491,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -486,7 +515,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.patch
         * @desc Updates a deployment and all of the resources described by the
@@ -505,7 +534,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -527,7 +558,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -543,7 +574,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -565,7 +598,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.stop
         * @desc Stops an ongoing operation. This does not roll back any work
@@ -582,7 +615,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -604,7 +639,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -619,7 +654,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -641,7 +678,7 @@ function Deploymentmanager(options) {
         pathParams: ['project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.deployments.update
         * @desc Updates a deployment and all of the resources described by the
@@ -660,7 +697,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -682,7 +721,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -701,7 +740,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -723,7 +763,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'manifest', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.manifests.list
         * @desc Lists all manifests for a given deployment.
@@ -732,7 +772,7 @@ function Deploymentmanager(options) {
         *
         * @param {object} params Parameters for request
         * @param {string} params.deployment The name of the deployment for this request.
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -741,7 +781,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -763,7 +805,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -781,7 +823,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -803,7 +846,7 @@ function Deploymentmanager(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.operations.list
         * @desc Lists all operations for a project.
@@ -811,7 +854,7 @@ function Deploymentmanager(options) {
         * @memberOf! deploymentmanager(v2beta)
         *
         * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -820,7 +863,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -842,7 +887,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -861,7 +906,8 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -883,7 +929,7 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project', 'resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * deploymentmanager.resources.list
         * @desc Lists all resources in a given deployment.
@@ -892,7 +938,7 @@ function Deploymentmanager(options) {
         *
         * @param {object} params Parameters for request
         * @param {string} params.deployment The name of the deployment for this request.
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+        * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
         * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
         * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
         * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -901,7 +947,9 @@ function Deploymentmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -923,312 +971,329 @@ function Deploymentmanager(options) {
         pathParams: ['deployment', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
-  self.typeProviders = {
-    /**
-     * deploymentmanager.typeProviders.delete
-     * @desc Deletes a type provider.
-     * @alias deploymentmanager.typeProviders.delete
-     * @memberOf! deploymentmanager(v2beta)
-     *
-     * @param {object} params Parameters for request
-     * @param {string} params.project The project ID for this request.
-     * @param {string} params.typeProvider The name of the type provider for this request.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    delete (params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'DELETE'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.get
-        * @desc Gets information about a specific type provider.
-        * @alias deploymentmanager.typeProviders.get
-        * @memberOf! deploymentmanager(v2beta)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    get(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.getType
-        * @desc Gets a type info for a type provided by a TypeProvider.
-        * @alias deploymentmanager.typeProviders.getType
-        * @memberOf! deploymentmanager(v2beta)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.type The name of the type provider for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    getType(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}/types/{type}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider', 'type'],
-        pathParams: ['project', 'type', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.insert
-        * @desc Creates a type provider.
-        * @alias deploymentmanager.typeProviders.insert
-        * @memberOf! deploymentmanager(v2beta)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {deploymentmanager(v2beta).TypeProvider} params.resource Request body data
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    insert(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'POST'
-            },
-            options),
-        params,
-        requiredParams: ['project'],
-        pathParams: ['project'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.list
-        * @desc Lists all resource type providers for Deployment Manager.
-        * @alias deploymentmanager.typeProviders.list
-        * @memberOf! deploymentmanager(v2beta)
-        *
-        * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
-        * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
-        * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
-        * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
-        * @param {string} params.project The project ID for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    list(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project'],
-        pathParams: ['project'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.listTypes
-        * @desc Lists all the type info for a TypeProvider.
-        * @alias deploymentmanager.typeProviders.listTypes
-        * @memberOf! deploymentmanager(v2beta)
-        *
-        * @param {object} params Parameters for request
-        * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
-        * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
-        * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
-        * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    listTypes(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}/types')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.patch
-        * @desc Updates a type provider. This method supports patch semantics.
-        * @alias deploymentmanager.typeProviders.patch
-        * @memberOf! deploymentmanager(v2beta)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {deploymentmanager(v2beta).TypeProvider} params.resource Request body data
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    patch(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'PATCH'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }, /**
-        * deploymentmanager.typeProviders.update
-        * @desc Updates a type provider.
-        * @alias deploymentmanager.typeProviders.update
-        * @memberOf! deploymentmanager(v2beta)
-        *
-        * @param {object} params Parameters for request
-        * @param {string} params.project The project ID for this request.
-        * @param {string} params.typeProvider The name of the type provider for this request.
-        * @param {deploymentmanager(v2beta).TypeProvider} params.resource Request body data
-        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-        * @param {callback} callback The callback that handles the response.
-        * @return {object} Request object
-        */
-    update(params, options, callback) {
-      if (typeof options === 'function') {
-        callback = options;
-        options = {};
-      }
-      options = options || {};
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url:
-                  (rootUrl +
-                   '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
-                      .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'PUT'
-            },
-            options),
-        params,
-        requiredParams: ['project', 'typeProvider'],
-        pathParams: ['project', 'typeProvider'],
-        context: self
-      };
-      return createAPIRequest(parameters, callback);
-    }
+  self.typeProviders =
+      {
+        /**
+         * deploymentmanager.typeProviders.delete
+         * @desc Deletes a type provider.
+         * @alias deploymentmanager.typeProviders.delete
+         * @memberOf! deploymentmanager(v2beta)
+         *
+         * @param {object} params Parameters for request
+         * @param {string} params.project The project ID for this request.
+         * @param {string} params.typeProvider The name of the type provider for this request.
+         * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+         * @param {callback} callback The callback that handles the response.
+         * @return {object} Request object
+         */
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'DELETE'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.get
+            * @desc Gets information about a specific type provider.
+            * @alias deploymentmanager.typeProviders.get
+            * @memberOf! deploymentmanager(v2beta)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.getType
+            * @desc Gets a type info for a type provided by a TypeProvider.
+            * @alias deploymentmanager.typeProviders.getType
+            * @memberOf! deploymentmanager(v2beta)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.type The name of the type provider for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        getType(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}/types/{type}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider', 'type'],
+            pathParams: ['project', 'type', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.insert
+            * @desc Creates a type provider.
+            * @alias deploymentmanager.typeProviders.insert
+            * @memberOf! deploymentmanager(v2beta)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {deploymentmanager(v2beta).TypeProvider} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'POST'
+                },
+                options),
+            params,
+            requiredParams: ['project'],
+            pathParams: ['project'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.list
+            * @desc Lists all resource type providers for Deployment Manager.
+            * @alias deploymentmanager.typeProviders.list
+            * @memberOf! deploymentmanager(v2beta)
+            *
+            * @param {object} params Parameters for request
+            * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
+            * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+            * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+            * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+            * @param {string} params.project The project ID for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project'],
+            pathParams: ['project'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.listTypes
+            * @desc Lists all the type info for a TypeProvider.
+            * @alias deploymentmanager.typeProviders.listTypes
+            * @memberOf! deploymentmanager(v2beta)
+            *
+            * @param {object} params Parameters for request
+            * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
+            * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+            * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
+            * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        listTypes(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}/types')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'GET'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.patch
+            * @desc Updates a type provider. This method supports patch
+            * semantics.
+            * @alias deploymentmanager.typeProviders.patch
+            * @memberOf! deploymentmanager(v2beta)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {deploymentmanager(v2beta).TypeProvider} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'PATCH'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }, /**
+            * deploymentmanager.typeProviders.update
+            * @desc Updates a type provider.
+            * @alias deploymentmanager.typeProviders.update
+            * @memberOf! deploymentmanager(v2beta)
+            *
+            * @param {object} params Parameters for request
+            * @param {string} params.project The project ID for this request.
+            * @param {string} params.typeProvider The name of the type provider for this request.
+            * @param {deploymentmanager(v2beta).TypeProvider} params.resource Request body data
+            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+            * @param {callback} callback The callback that handles the response.
+            * @return {object} Request object
+            */
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
+          if (typeof options === 'function') {
+            callback = options;
+            options = {};
+          }
+          options = options || {};
+          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+          const parameters = {
+            options: Object.assign(
+                {
+                  url:
+                      (rootUrl +
+                       '/deploymentmanager/v2beta/projects/{project}/global/typeProviders/{typeProvider}')
+                          .replace(/([^:]\/)\/+/g, '$1'),
+                  method: 'PUT'
+                },
+                options),
+            params,
+            requiredParams: ['project', 'typeProvider'],
+            pathParams: ['project', 'typeProvider'],
+            context: self
+          };
+          return createAPIRequest(parameters, callback!);
+        }
 
-  };
+      };
   self.types = {
     /**
      * deploymentmanager.types.list
@@ -1237,7 +1302,7 @@ function Deploymentmanager(options) {
      * @memberOf! deploymentmanager(v2beta)
      *
      * @param {object} params Parameters for request
-     * @param {string=} params.filter Sets a filter {expression} for filtering listed resources. Your {expression} must be in the format: field_name comparison_string literal_string.  The field_name is the name of the field you want to compare. Only atomic field types are supported (string, number, boolean). The comparison_string must be either eq (equals) or ne (not equals). The literal_string is the string value to filter to. The literal value must be valid for the type of field you are filtering by (string, number, boolean). For string fields, the literal value is interpreted as a regular expression using RE2 syntax. The literal value must match the entire field.  For example, to filter for instances that do not have a name of example-instance, you would use name ne example-instance.  You can filter on nested fields. For example, you could filter on instances that have set the scheduling.automaticRestart field to true. Use filtering on nested fields to take advantage of labels to organize and search for results based on label values.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart eq true) (zone eq us-central1-f). Multiple expressions are treated as AND expressions, meaning that resources must match all expressions to pass the filters.
+     * @param {string=} params.filter A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.  For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.  You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.  To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
      * @param {integer=} params.maxResults The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
      * @param {string=} params.orderBy Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.  You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.  Currently, only sorting by name or creationTimestamp desc is supported.
      * @param {string=} params.pageToken Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
@@ -1246,7 +1311,9 @@ function Deploymentmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1267,7 +1334,7 @@ function Deploymentmanager(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1726,7 +1793,7 @@ function Deploymentmanager(options) {
  * @property {string} id Output only. Unique identifier for the resource; defined by the server.
  * @property {string} insertTime Output only. Timestamp when the type provider was created, in RFC3339 text format.
  * @property {deploymentmanager(v2beta).TypeProviderLabelEntry[]} labels Map of labels; provided by the client when the resource is created or updated. Specifically: Label keys must be between 1 and 63 characters long and must conform to the following regular expression: [a-z]([-a-z0-9]*[a-z0-9])? Label values must be between 0 and 63 characters long and must conform to the regular expression ([a-z]([-a-z0-9]*[a-z0-9])?)?
- * @property {string} name Name of the type provider.
+ * @property {string} name Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
  * @property {deploymentmanager(v2beta).Operation} operation Output only. The Operation that most recently ran, or is currently running, on this type provider.
  * @property {deploymentmanager(v2beta).Options} options Options to apply when handling any resources in this service.
  * @property {string} selfLink Output only. Self link for the type provider.

--- a/src/apis/dfareporting/v2.8.ts
+++ b/src/apis/dfareporting/v2.8.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * DCM/DFA Reporting And Trafficking API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2.8
  * @param {object=} options Options for Dfareporting
  */
-function Dfareporting(options) {
+function Dfareporting(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accountActiveAdSummaries = {
@@ -97,7 +104,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -119,7 +127,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'summaryAccountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -186,7 +194,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -208,7 +217,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountPermissionGroups.list
         * @desc Retrieves the list of account permission groups.
@@ -267,7 +276,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -289,7 +300,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -358,7 +369,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -380,7 +392,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountPermissions.list
         * @desc Retrieves the list of account permissions.
@@ -439,7 +451,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -461,7 +475,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -530,7 +544,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -551,7 +566,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accounts.list
         * @desc Retrieves the list of accounts, possibly filtered. This method
@@ -633,7 +648,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -654,7 +671,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accounts.patch
         * @desc Updates an existing account. This method supports patch
@@ -727,7 +744,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -748,7 +767,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accounts.update
         * @desc Updates an existing account.
@@ -816,7 +835,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -837,7 +858,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -906,7 +927,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -928,7 +950,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.insert
         * @desc Inserts a new account user profile.
@@ -992,7 +1014,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1014,7 +1038,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.list
         * @desc Retrieves a list of account user profiles, possibly filtered.
@@ -1100,7 +1124,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1122,7 +1148,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.patch
         * @desc Updates an existing account user profile. This method supports
@@ -1193,7 +1219,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1215,7 +1243,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.update
         * @desc Updates an existing account user profile.
@@ -1281,7 +1309,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1303,7 +1333,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1372,7 +1402,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1393,7 +1424,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.insert
         * @desc Inserts a new ad.
@@ -1459,7 +1490,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1479,7 +1512,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.list
         * @desc Retrieves a list of ads, possibly filtered. This method supports
@@ -1577,7 +1610,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1597,7 +1632,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.patch
         * @desc Updates an existing ad. This method supports patch semantics.
@@ -1669,7 +1704,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1689,7 +1726,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.update
         * @desc Updates an existing ad.
@@ -1757,7 +1794,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1777,7 +1816,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1843,7 +1882,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1865,7 +1906,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.get
         * @desc Gets one advertiser group by ID.
@@ -1930,7 +1971,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1952,7 +1994,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.insert
         * @desc Inserts a new advertiser group.
@@ -2016,7 +2058,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2038,7 +2082,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.list
         * @desc Retrieves a list of advertiser groups, possibly filtered. This
@@ -2120,7 +2164,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2142,7 +2188,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.patch
         * @desc Updates an existing advertiser group. This method supports patch
@@ -2213,7 +2259,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2235,7 +2283,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.update
         * @desc Updates an existing advertiser group.
@@ -2301,7 +2349,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2323,7 +2373,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2392,7 +2442,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2414,7 +2465,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.insert
         * @desc Inserts a new advertiser.
@@ -2480,7 +2531,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2501,7 +2554,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.list
         * @desc Retrieves a list of advertisers, possibly filtered. This method
@@ -2589,7 +2642,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2610,7 +2665,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.patch
         * @desc Updates an existing advertiser. This method supports patch
@@ -2683,7 +2738,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2704,7 +2761,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.update
         * @desc Updates an existing advertiser.
@@ -2772,7 +2829,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2793,7 +2852,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2858,7 +2917,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2879,7 +2940,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2953,7 +3014,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2975,7 +3038,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaignCreativeAssociations.list
         * @desc Retrieves the list of creative IDs associated with the specified
@@ -3061,7 +3124,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3083,7 +3148,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3152,7 +3217,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3174,7 +3240,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.insert
         * @desc Inserts a new campaign.
@@ -3249,7 +3315,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3271,7 +3339,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.list
         * @desc Retrieves a list of campaigns, possibly filtered. This method
@@ -3360,7 +3428,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3381,7 +3451,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.patch
         * @desc Updates an existing campaign. This method supports patch
@@ -3454,7 +3524,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3475,7 +3547,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.update
         * @desc Updates an existing campaign.
@@ -3543,7 +3615,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3564,7 +3638,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3633,7 +3707,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3655,7 +3730,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.changeLogs.list
         * @desc Retrieves a list of change logs. This method supports paging.
@@ -3740,7 +3815,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3761,7 +3838,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3830,7 +3907,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3851,7 +3930,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3920,7 +3999,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3942,7 +4022,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.connectionTypes.list
         * @desc Retrieves a list of connection types.
@@ -4003,7 +4083,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4025,7 +4107,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4091,7 +4173,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4113,7 +4197,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.get
         * @desc Gets one content category by ID.
@@ -4176,7 +4260,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4198,7 +4283,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.insert
         * @desc Inserts a new content category.
@@ -4262,7 +4347,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4284,7 +4371,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.list
         * @desc Retrieves a list of content categories, possibly filtered. This
@@ -4366,7 +4453,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4388,7 +4477,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.patch
         * @desc Updates an existing content category. This method supports patch
@@ -4459,7 +4548,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4481,7 +4572,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.update
         * @desc Updates an existing content category.
@@ -4547,7 +4638,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4569,7 +4662,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4639,7 +4732,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchinsert(params, options, callback) {
+    batchinsert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4661,7 +4756,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.conversions.batchupdate
         * @desc Updates existing conversions.
@@ -4725,7 +4820,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    batchupdate(params, options, callback) {
+    batchupdate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4747,7 +4844,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4816,7 +4913,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4838,7 +4936,7 @@ function Dfareporting(options) {
         pathParams: ['dartId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.countries.list
         * @desc Retrieves a list of countries.
@@ -4899,7 +4997,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4920,7 +5020,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5004,7 +5104,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5030,7 +5132,7 @@ function Dfareporting(options) {
         pathParams: ['advertiserId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5096,7 +5198,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5118,7 +5222,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.get
         * @desc Gets one creative field by ID.
@@ -5183,7 +5287,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5205,7 +5310,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.insert
         * @desc Inserts a new creative field.
@@ -5269,7 +5374,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5291,7 +5398,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.list
         * @desc Retrieves a list of creative fields, possibly filtered. This
@@ -5374,7 +5481,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5396,7 +5505,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.patch
         * @desc Updates an existing creative field. This method supports patch
@@ -5469,7 +5578,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5491,7 +5602,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.update
         * @desc Updates an existing creative field.
@@ -5557,7 +5668,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5579,7 +5692,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5649,7 +5762,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5671,7 +5786,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.get
         * @desc Gets one creative field value by ID.
@@ -5738,7 +5853,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5760,7 +5876,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.insert
         * @desc Inserts a new creative field value.
@@ -5828,7 +5944,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5850,7 +5968,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.list
         * @desc Retrieves a list of creative field values, possibly filtered.
@@ -5937,7 +6055,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5959,7 +6079,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.patch
         * @desc Updates an existing creative field value. This method supports
@@ -6034,7 +6154,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6056,7 +6178,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.update
         * @desc Updates an existing creative field value.
@@ -6126,7 +6248,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6148,7 +6272,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6217,7 +6341,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6239,7 +6364,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.insert
         * @desc Inserts a new creative group.
@@ -6303,7 +6428,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6325,7 +6452,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.list
         * @desc Retrieves a list of creative groups, possibly filtered. This
@@ -6409,7 +6536,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6431,7 +6560,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.patch
         * @desc Updates an existing creative group. This method supports patch
@@ -6504,7 +6633,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6526,7 +6657,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.update
         * @desc Updates an existing creative group.
@@ -6592,7 +6723,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6614,7 +6747,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6683,7 +6816,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6705,7 +6839,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.insert
         * @desc Inserts a new creative.
@@ -6771,7 +6905,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6792,7 +6928,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.list
         * @desc Retrieves a list of creatives, possibly filtered. This method
@@ -6884,7 +7020,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6905,7 +7043,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.patch
         * @desc Updates an existing creative. This method supports patch
@@ -6978,7 +7116,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6999,7 +7139,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.update
         * @desc Updates an existing creative.
@@ -7067,7 +7207,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7088,7 +7230,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7173,7 +7315,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7195,7 +7339,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7262,7 +7406,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7284,7 +7429,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.directorySiteContacts.list
         * @desc Retrieves a list of directory site contacts, possibly filtered.
@@ -7368,7 +7513,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7390,7 +7537,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7459,7 +7606,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7481,7 +7629,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.directorySites.insert
         * @desc Inserts a new directory site.
@@ -7545,7 +7693,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7567,7 +7717,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.directorySites.list
         * @desc Retrieves a list of directory sites, possibly filtered. This
@@ -7656,7 +7806,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7678,7 +7830,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7754,7 +7906,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7776,7 +7930,7 @@ function Dfareporting(options) {
         pathParams: ['objectId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.dynamicTargetingKeys.insert
         * @desc Inserts a new dynamic targeting key. Keys must be created at the
@@ -7844,7 +7998,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7866,7 +8022,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.dynamicTargetingKeys.list
         * @desc Retrieves a list of dynamic targeting keys.
@@ -7929,7 +8085,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7951,7 +8109,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8017,7 +8175,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8039,7 +8199,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.get
         * @desc Gets one event tag by ID.
@@ -8104,7 +8264,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8126,7 +8287,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.insert
         * @desc Inserts a new event tag.
@@ -8192,7 +8353,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8213,7 +8376,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.list
         * @desc Retrieves a list of event tags, possibly filtered.
@@ -8284,7 +8447,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8305,7 +8470,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.patch
         * @desc Updates an existing event tag. This method supports patch
@@ -8378,7 +8543,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8399,7 +8566,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.update
         * @desc Updates an existing event tag.
@@ -8467,7 +8634,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8488,7 +8657,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8562,7 +8731,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8583,7 +8753,7 @@ function Dfareporting(options) {
         pathParams: ['fileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.files.list
         * @desc Lists files for a user profile.
@@ -8662,7 +8832,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8683,7 +8855,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -8749,7 +8921,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8771,7 +8945,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.generatetag
         * @desc Generates a tag for a floodlight activity.
@@ -8831,7 +9005,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generatetag(params, options, callback) {
+    generatetag(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8853,7 +9029,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.get
         * @desc Gets one floodlight activity by ID.
@@ -8916,7 +9092,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -8938,7 +9115,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.insert
         * @desc Inserts a new floodlight activity.
@@ -9002,7 +9179,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9024,7 +9203,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.list
         * @desc Retrieves a list of floodlight activities, possibly filtered.
@@ -9114,7 +9293,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9136,7 +9317,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.patch
         * @desc Updates an existing floodlight activity. This method supports
@@ -9207,7 +9388,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9229,7 +9412,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.update
         * @desc Updates an existing floodlight activity.
@@ -9295,7 +9478,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9317,7 +9502,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -9384,7 +9569,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9406,7 +9592,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.insert
         * @desc Inserts a new floodlight activity group.
@@ -9470,7 +9656,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9492,7 +9680,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.list
         * @desc Retrieves a list of floodlight activity groups, possibly
@@ -9578,7 +9766,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9600,7 +9790,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.patch
         * @desc Updates an existing floodlight activity group. This method
@@ -9671,7 +9861,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9693,7 +9885,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.update
         * @desc Updates an existing floodlight activity group.
@@ -9759,7 +9951,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9781,7 +9975,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -9848,7 +10042,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9870,7 +10065,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightConfigurations.list
         * @desc Retrieves a list of floodlight configurations, possibly
@@ -9931,7 +10126,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -9953,7 +10150,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightConfigurations.patch
         * @desc Updates an existing floodlight configuration. This method
@@ -10024,7 +10221,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10046,7 +10245,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightConfigurations.update
         * @desc Updates an existing floodlight configuration.
@@ -10112,7 +10311,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10134,7 +10335,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -10207,7 +10408,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10229,7 +10431,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.inventoryItems.list
         * @desc Retrieves a list of inventory items, possibly filtered. This
@@ -10318,7 +10520,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10340,7 +10544,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -10410,7 +10614,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10432,7 +10638,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.landingPages.get
         * @desc Gets one campaign landing page by ID.
@@ -10501,7 +10707,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10523,7 +10730,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.landingPages.insert
         * @desc Inserts a new landing page for the specified campaign.
@@ -10593,7 +10800,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10615,7 +10824,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.landingPages.list
         * @desc Retrieves the list of landing pages for the specified campaign.
@@ -10680,7 +10889,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10702,7 +10913,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.landingPages.patch
         * @desc Updates an existing campaign landing page. This method supports
@@ -10779,7 +10990,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10801,7 +11014,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.landingPages.update
         * @desc Updates an existing campaign landing page.
@@ -10873,7 +11086,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10895,7 +11110,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -10960,7 +11175,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -10981,7 +11198,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11046,7 +11263,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11067,7 +11286,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11136,7 +11355,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11158,7 +11378,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.mobileCarriers.list
         * @desc Retrieves a list of mobile carriers.
@@ -11219,7 +11439,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11241,7 +11463,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11310,7 +11532,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11332,7 +11555,7 @@ function Dfareporting(options) {
         pathParams: ['dartId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.operatingSystems.list
         * @desc Retrieves a list of operating systems.
@@ -11391,7 +11614,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11413,7 +11638,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11480,7 +11705,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11502,7 +11728,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.operatingSystemVersions.list
         * @desc Retrieves a list of operating system versions.
@@ -11561,7 +11787,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11583,7 +11811,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11656,7 +11884,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11678,7 +11907,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.orderDocuments.list
         * @desc Retrieves a list of order documents, possibly filtered. This
@@ -11767,7 +11996,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11789,7 +12020,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -11862,7 +12093,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11884,7 +12116,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.orders.list
         * @desc Retrieves a list of orders, possibly filtered. This method
@@ -11970,7 +12202,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -11992,7 +12226,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -12061,7 +12295,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12083,7 +12318,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.insert
         * @desc Inserts a new placement group.
@@ -12147,7 +12382,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12169,7 +12406,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.list
         * @desc Retrieves a list of placement groups, possibly filtered. This
@@ -12264,7 +12501,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12286,7 +12525,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.patch
         * @desc Updates an existing placement group. This method supports patch
@@ -12357,7 +12596,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12379,7 +12620,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.update
         * @desc Updates an existing placement group.
@@ -12445,7 +12686,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12467,7 +12710,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -12535,7 +12778,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generatetags(params, options, callback) {
+    generatetags(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12557,7 +12802,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.get
         * @desc Gets one placement by ID.
@@ -12622,7 +12867,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12644,7 +12890,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.insert
         * @desc Inserts a new placement.
@@ -12710,7 +12956,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12731,7 +12979,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.list
         * @desc Retrieves a list of placements, possibly filtered. This method
@@ -12829,7 +13077,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12850,7 +13100,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.patch
         * @desc Updates an existing placement. This method supports patch
@@ -12923,7 +13173,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -12944,7 +13196,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.update
         * @desc Updates an existing placement.
@@ -13012,7 +13264,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13033,7 +13287,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13099,7 +13353,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13121,7 +13377,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.get
         * @desc Gets one placement strategy by ID.
@@ -13184,7 +13440,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13206,7 +13463,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.insert
         * @desc Inserts a new placement strategy.
@@ -13270,7 +13527,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13292,7 +13551,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.list
         * @desc Retrieves a list of placement strategies, possibly filtered.
@@ -13375,7 +13634,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13397,7 +13658,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.patch
         * @desc Updates an existing placement strategy. This method supports
@@ -13468,7 +13729,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13490,7 +13753,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.update
         * @desc Updates an existing placement strategy.
@@ -13556,7 +13819,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13578,7 +13843,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13647,7 +13912,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13669,7 +13935,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.platformTypes.list
         * @desc Retrieves a list of platform types.
@@ -13730,7 +13996,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13751,7 +14019,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13820,7 +14088,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13842,7 +14111,7 @@ function Dfareporting(options) {
         pathParams: ['code', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.postalCodes.list
         * @desc Retrieves a list of postal codes.
@@ -13903,7 +14172,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -13924,7 +14195,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -13993,7 +14264,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14014,7 +14286,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.projects.list
         * @desc Retrieves a list of projects, possibly filtered. This method
@@ -14096,7 +14368,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14117,7 +14391,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14182,7 +14456,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14203,7 +14479,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14272,7 +14548,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14294,7 +14571,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.insert
         * @desc Inserts a new remarketing list.
@@ -14358,7 +14635,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14380,7 +14659,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.list
         * @desc Retrieves a list of remarketing lists, possibly filtered. This
@@ -14467,7 +14746,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14489,7 +14770,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.patch
         * @desc Updates an existing remarketing list. This method supports patch
@@ -14560,7 +14841,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14582,7 +14865,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.update
         * @desc Updates an existing remarketing list.
@@ -14648,7 +14931,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14670,7 +14955,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -14737,7 +15022,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14759,7 +15045,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'remarketingListId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingListShares.patch
         * @desc Updates an existing remarketing list share. This method supports
@@ -14830,7 +15116,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14852,7 +15140,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingListShares.update
         * @desc Updates an existing remarketing list share.
@@ -14918,7 +15206,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -14940,7 +15230,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -15006,7 +15296,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15028,7 +15320,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.get
         * @desc Retrieves a report by its ID.
@@ -15093,7 +15385,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15115,7 +15408,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.insert
         * @desc Creates a report.
@@ -15181,7 +15474,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15202,7 +15497,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.list
         * @desc Retrieves list of reports.
@@ -15281,7 +15576,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15302,7 +15599,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.patch
         * @desc Updates a report. This method supports patch semantics.
@@ -15374,7 +15671,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15396,7 +15695,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.run
         * @desc Runs a report.
@@ -15462,7 +15761,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    run(params, options, callback) {
+    run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15484,7 +15784,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.update
         * @desc Updates a report.
@@ -15556,7 +15856,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15578,7 +15880,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     compatibleFields: {
       /**
@@ -15646,7 +15948,9 @@ function Dfareporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      query(params, options, callback) {
+      query(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -15668,7 +15972,7 @@ function Dfareporting(options) {
           pathParams: ['profileId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -15745,7 +16049,8 @@ function Dfareporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -15767,7 +16072,7 @@ function Dfareporting(options) {
           pathParams: ['fileId', 'profileId', 'reportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dfareporting.reports.files.list
           * @desc Lists files for a report.
@@ -15849,7 +16154,9 @@ function Dfareporting(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -15871,7 +16178,7 @@ function Dfareporting(options) {
           pathParams: ['profileId', 'reportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -15941,7 +16248,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -15962,7 +16270,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.insert
         * @desc Inserts a new site.
@@ -16028,7 +16336,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16049,7 +16359,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.list
         * @desc Retrieves a list of sites, possibly filtered. This method
@@ -16139,7 +16449,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16160,7 +16472,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.patch
         * @desc Updates an existing site. This method supports patch semantics.
@@ -16232,7 +16544,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16253,7 +16567,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.update
         * @desc Updates an existing site.
@@ -16321,7 +16635,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16342,7 +16658,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -16411,7 +16727,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16432,7 +16749,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sizes.insert
         * @desc Inserts a new size.
@@ -16498,7 +16815,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16519,7 +16838,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sizes.list
         * @desc Retrieves a list of sizes, possibly filtered.
@@ -16584,7 +16903,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16605,7 +16926,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -16674,7 +16995,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16696,7 +17018,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.insert
         * @desc Inserts a new subaccount.
@@ -16762,7 +17084,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16783,7 +17107,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.list
         * @desc Gets a list of subaccounts, possibly filtered. This method
@@ -16865,7 +17189,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16886,7 +17212,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.patch
         * @desc Updates an existing subaccount. This method supports patch
@@ -16959,7 +17285,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -16980,7 +17308,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.update
         * @desc Updates an existing subaccount.
@@ -17048,7 +17376,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17069,7 +17399,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17136,7 +17466,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17158,7 +17489,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetableRemarketingLists.list
         * @desc Retrieves a list of targetable remarketing lists, possibly
@@ -17246,7 +17577,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17268,7 +17601,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17337,7 +17670,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17359,7 +17693,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.insert
         * @desc Inserts a new targeting template.
@@ -17423,7 +17757,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17445,7 +17781,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.list
         * @desc Retrieves a list of targeting templates, optionally filtered.
@@ -17528,7 +17864,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17550,7 +17888,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.patch
         * @desc Updates an existing targeting template. This method supports
@@ -17621,7 +17959,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17643,7 +17983,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.update
         * @desc Updates an existing targeting template.
@@ -17709,7 +18049,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17731,7 +18073,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17797,7 +18139,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17817,7 +18160,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userProfiles.list
         * @desc Retrieves list of user profiles for a user.
@@ -17875,7 +18218,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17895,7 +18240,7 @@ function Dfareporting(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -17962,7 +18307,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -17984,7 +18330,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRolePermissionGroups.list
         * @desc Gets a list of all supported user role permission groups.
@@ -18043,7 +18389,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18065,7 +18413,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18134,7 +18482,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18156,7 +18505,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRolePermissions.list
         * @desc Gets a list of user role permissions, possibly filtered.
@@ -18216,7 +18565,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18238,7 +18589,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18304,7 +18655,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18326,7 +18679,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.get
         * @desc Gets one user role by ID.
@@ -18391,7 +18744,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18413,7 +18767,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.insert
         * @desc Inserts a new user role.
@@ -18479,7 +18833,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18500,7 +18856,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.list
         * @desc Retrieves a list of user roles, possibly filtered. This method
@@ -18584,7 +18940,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18605,7 +18963,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.patch
         * @desc Updates an existing user role. This method supports patch
@@ -18678,7 +19036,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18699,7 +19059,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.update
         * @desc Updates an existing user role.
@@ -18767,7 +19127,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18788,7 +19150,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -18857,7 +19219,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18879,7 +19242,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.videoFormats.list
         * @desc Lists available video formats.
@@ -18940,7 +19303,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -18961,7 +19326,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/dfareporting/v3.0.ts
+++ b/src/apis/dfareporting/v3.0.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * DCM/DFA Reporting And Trafficking API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3.0
  * @param {object=} options Options for Dfareporting
  */
-function Dfareporting(options) {
+function Dfareporting(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accountActiveAdSummaries = {
@@ -48,7 +55,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +78,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'summaryAccountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -88,7 +96,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +119,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountPermissionGroups.list
         * @desc Retrieves the list of account permission groups.
@@ -123,7 +132,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -145,7 +156,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -163,7 +174,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -185,7 +197,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountPermissions.list
         * @desc Retrieves the list of account permissions.
@@ -198,7 +210,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -220,7 +234,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -238,7 +252,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -259,7 +274,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accounts.list
         * @desc Retrieves the list of accounts, possibly filtered. This method
@@ -280,7 +295,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -301,7 +318,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accounts.patch
         * @desc Updates an existing account. This method supports patch
@@ -317,7 +334,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -338,7 +357,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accounts.update
         * @desc Updates an existing account.
@@ -352,7 +371,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -373,7 +394,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -391,7 +412,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -413,7 +435,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.insert
         * @desc Inserts a new account user profile.
@@ -427,7 +449,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -449,7 +473,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.list
         * @desc Retrieves a list of account user profiles, possibly filtered.
@@ -472,7 +496,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -494,7 +520,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.patch
         * @desc Updates an existing account user profile. This method supports
@@ -510,7 +536,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -532,7 +560,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.accountUserProfiles.update
         * @desc Updates an existing account user profile.
@@ -546,7 +574,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -568,7 +598,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -586,7 +616,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -607,7 +638,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.insert
         * @desc Inserts a new ad.
@@ -621,7 +652,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -641,7 +674,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.list
         * @desc Retrieves a list of ads, possibly filtered. This method supports
@@ -678,7 +711,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -698,7 +733,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.patch
         * @desc Updates an existing ad. This method supports patch semantics.
@@ -713,7 +748,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -733,7 +770,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.ads.update
         * @desc Updates an existing ad.
@@ -747,7 +784,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -767,7 +806,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -785,7 +824,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -807,7 +848,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.get
         * @desc Gets one advertiser group by ID.
@@ -821,7 +862,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -843,7 +885,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.insert
         * @desc Inserts a new advertiser group.
@@ -857,7 +899,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -879,7 +923,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.list
         * @desc Retrieves a list of advertiser groups, possibly filtered. This
@@ -899,7 +943,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -921,7 +967,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.patch
         * @desc Updates an existing advertiser group. This method supports patch
@@ -937,7 +983,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -959,7 +1007,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserGroups.update
         * @desc Updates an existing advertiser group.
@@ -973,7 +1021,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -995,7 +1045,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1013,7 +1063,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1035,7 +1086,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserLandingPages.insert
         * @desc Inserts a new landing page.
@@ -1049,7 +1100,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1071,7 +1124,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserLandingPages.list
         * @desc Retrieves a list of landing pages.
@@ -1093,7 +1146,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1115,7 +1170,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserLandingPages.patch
         * @desc Updates an existing landing page. This method supports patch
@@ -1131,7 +1186,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1153,7 +1210,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertiserLandingPages.update
         * @desc Updates an existing landing page.
@@ -1167,7 +1224,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1189,7 +1248,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1207,7 +1266,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1229,7 +1289,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.insert
         * @desc Inserts a new advertiser.
@@ -1243,7 +1303,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1264,7 +1326,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.list
         * @desc Retrieves a list of advertisers, possibly filtered. This method
@@ -1290,7 +1352,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1311,7 +1375,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.patch
         * @desc Updates an existing advertiser. This method supports patch
@@ -1327,7 +1391,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1348,7 +1414,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.advertisers.update
         * @desc Updates an existing advertiser.
@@ -1362,7 +1428,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1383,7 +1451,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1400,7 +1468,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1421,7 +1491,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1442,7 +1512,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1464,7 +1536,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaignCreativeAssociations.list
         * @desc Retrieves the list of creative IDs associated with the specified
@@ -1482,7 +1554,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1504,7 +1578,7 @@ function Dfareporting(options) {
         pathParams: ['campaignId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1522,7 +1596,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1544,7 +1619,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.insert
         * @desc Inserts a new campaign.
@@ -1558,7 +1633,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1579,7 +1656,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.list
         * @desc Retrieves a list of campaigns, possibly filtered. This method
@@ -1606,7 +1683,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1627,7 +1706,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.patch
         * @desc Updates an existing campaign. This method supports patch
@@ -1643,7 +1722,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1664,7 +1745,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.campaigns.update
         * @desc Updates an existing campaign.
@@ -1678,7 +1759,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1699,7 +1782,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1717,7 +1800,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1739,7 +1823,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.changeLogs.list
         * @desc Retrieves a list of change logs. This method supports paging.
@@ -1762,7 +1846,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1783,7 +1869,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1804,7 +1890,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1825,7 +1913,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1843,7 +1931,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1865,7 +1954,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.connectionTypes.list
         * @desc Retrieves a list of connection types.
@@ -1878,7 +1967,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1900,7 +1991,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1918,7 +2009,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1940,7 +2033,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.get
         * @desc Gets one content category by ID.
@@ -1954,7 +2047,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1976,7 +2070,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.insert
         * @desc Inserts a new content category.
@@ -1990,7 +2084,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2012,7 +2108,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.list
         * @desc Retrieves a list of content categories, possibly filtered. This
@@ -2032,7 +2128,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2054,7 +2152,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.patch
         * @desc Updates an existing content category. This method supports patch
@@ -2070,7 +2168,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2092,7 +2192,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.contentCategories.update
         * @desc Updates an existing content category.
@@ -2106,7 +2206,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2128,7 +2230,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2146,7 +2248,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchinsert(params, options, callback) {
+    batchinsert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2168,7 +2272,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.conversions.batchupdate
         * @desc Updates existing conversions.
@@ -2182,7 +2286,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    batchupdate(params, options, callback) {
+    batchupdate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2204,7 +2310,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2222,7 +2328,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2244,7 +2351,7 @@ function Dfareporting(options) {
         pathParams: ['dartId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.countries.list
         * @desc Retrieves a list of countries.
@@ -2257,7 +2364,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2278,7 +2387,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2300,7 +2409,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2326,7 +2437,7 @@ function Dfareporting(options) {
         pathParams: ['advertiserId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2344,7 +2455,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2366,7 +2479,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.get
         * @desc Gets one creative field by ID.
@@ -2380,7 +2493,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2402,7 +2516,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.insert
         * @desc Inserts a new creative field.
@@ -2416,7 +2530,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2438,7 +2554,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.list
         * @desc Retrieves a list of creative fields, possibly filtered. This
@@ -2459,7 +2575,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2481,7 +2599,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.patch
         * @desc Updates an existing creative field. This method supports patch
@@ -2497,7 +2615,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2519,7 +2639,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFields.update
         * @desc Updates an existing creative field.
@@ -2533,7 +2653,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2555,7 +2677,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2574,7 +2696,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2596,7 +2720,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.get
         * @desc Gets one creative field value by ID.
@@ -2611,7 +2735,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2633,7 +2758,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.insert
         * @desc Inserts a new creative field value.
@@ -2648,7 +2773,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2670,7 +2797,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.list
         * @desc Retrieves a list of creative field values, possibly filtered.
@@ -2691,7 +2818,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2713,7 +2842,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.patch
         * @desc Updates an existing creative field value. This method supports
@@ -2730,7 +2859,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2752,7 +2883,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeFieldValues.update
         * @desc Updates an existing creative field value.
@@ -2767,7 +2898,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2789,7 +2922,7 @@ function Dfareporting(options) {
         pathParams: ['creativeFieldId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2807,7 +2940,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2829,7 +2963,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.insert
         * @desc Inserts a new creative group.
@@ -2843,7 +2977,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2865,7 +3001,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.list
         * @desc Retrieves a list of creative groups, possibly filtered. This
@@ -2887,7 +3023,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2909,7 +3047,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.patch
         * @desc Updates an existing creative group. This method supports patch
@@ -2925,7 +3063,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2947,7 +3087,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creativeGroups.update
         * @desc Updates an existing creative group.
@@ -2961,7 +3101,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2983,7 +3125,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3001,7 +3143,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3023,7 +3166,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.insert
         * @desc Inserts a new creative.
@@ -3037,7 +3180,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3058,7 +3203,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.list
         * @desc Retrieves a list of creatives, possibly filtered. This method
@@ -3088,7 +3233,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3109,7 +3256,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.patch
         * @desc Updates an existing creative. This method supports patch
@@ -3125,7 +3272,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3146,7 +3295,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.creatives.update
         * @desc Updates an existing creative.
@@ -3160,7 +3309,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3181,7 +3332,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3201,7 +3352,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3223,7 +3376,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3241,7 +3394,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3263,7 +3417,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.directorySiteContacts.list
         * @desc Retrieves a list of directory site contacts, possibly filtered.
@@ -3284,7 +3438,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3306,7 +3462,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3324,7 +3480,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3346,7 +3503,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.directorySites.insert
         * @desc Inserts a new directory site.
@@ -3360,7 +3517,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3382,7 +3541,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.directorySites.list
         * @desc Retrieves a list of directory sites, possibly filtered. This
@@ -3409,7 +3568,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3431,7 +3592,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3451,7 +3612,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3473,7 +3636,7 @@ function Dfareporting(options) {
         pathParams: ['objectId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.dynamicTargetingKeys.insert
         * @desc Inserts a new dynamic targeting key. Keys must be created at the
@@ -3491,7 +3654,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3513,7 +3678,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.dynamicTargetingKeys.list
         * @desc Retrieves a list of dynamic targeting keys.
@@ -3530,7 +3695,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3552,7 +3719,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3570,7 +3737,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3592,7 +3761,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.get
         * @desc Gets one event tag by ID.
@@ -3606,7 +3775,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3628,7 +3798,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.insert
         * @desc Inserts a new event tag.
@@ -3642,7 +3812,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3663,7 +3835,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.list
         * @desc Retrieves a list of event tags, possibly filtered.
@@ -3686,7 +3858,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3707,7 +3881,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.patch
         * @desc Updates an existing event tag. This method supports patch
@@ -3723,7 +3897,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3744,7 +3920,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.eventTags.update
         * @desc Updates an existing event tag.
@@ -3758,7 +3934,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3779,7 +3957,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3798,7 +3976,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3819,7 +3998,7 @@ function Dfareporting(options) {
         pathParams: ['fileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.files.list
         * @desc Lists files for a user profile.
@@ -3837,7 +4016,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3858,7 +4039,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3876,7 +4057,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3898,7 +4081,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.generatetag
         * @desc Generates a tag for a floodlight activity.
@@ -3912,7 +4095,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generatetag(params, options, callback) {
+    generatetag(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3934,7 +4119,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.get
         * @desc Gets one floodlight activity by ID.
@@ -3948,7 +4133,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3970,7 +4156,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.insert
         * @desc Inserts a new floodlight activity.
@@ -3984,7 +4170,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4006,7 +4194,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.list
         * @desc Retrieves a list of floodlight activities, possibly filtered.
@@ -4033,7 +4221,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4055,7 +4245,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.patch
         * @desc Updates an existing floodlight activity. This method supports
@@ -4071,7 +4261,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4093,7 +4285,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivities.update
         * @desc Updates an existing floodlight activity.
@@ -4107,7 +4299,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4129,7 +4323,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4147,7 +4341,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4169,7 +4364,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.insert
         * @desc Inserts a new floodlight activity group.
@@ -4183,7 +4378,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4205,7 +4402,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.list
         * @desc Retrieves a list of floodlight activity groups, possibly
@@ -4228,7 +4425,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4250,7 +4449,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.patch
         * @desc Updates an existing floodlight activity group. This method
@@ -4266,7 +4465,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4288,7 +4489,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightActivityGroups.update
         * @desc Updates an existing floodlight activity group.
@@ -4302,7 +4503,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4324,7 +4527,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4342,7 +4545,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4364,7 +4568,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightConfigurations.list
         * @desc Retrieves a list of floodlight configurations, possibly
@@ -4379,7 +4583,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4401,7 +4607,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightConfigurations.patch
         * @desc Updates an existing floodlight configuration. This method
@@ -4417,7 +4623,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4439,7 +4647,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.floodlightConfigurations.update
         * @desc Updates an existing floodlight configuration.
@@ -4453,7 +4661,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4475,7 +4685,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4494,7 +4704,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4516,7 +4727,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.inventoryItems.list
         * @desc Retrieves a list of inventory items, possibly filtered. This
@@ -4540,7 +4751,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4562,7 +4775,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4579,7 +4792,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4600,7 +4815,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4617,7 +4832,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4638,7 +4855,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4656,7 +4873,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4678,7 +4896,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.mobileCarriers.list
         * @desc Retrieves a list of mobile carriers.
@@ -4691,7 +4909,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4713,7 +4933,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4731,7 +4951,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4753,7 +4974,7 @@ function Dfareporting(options) {
         pathParams: ['dartId', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.operatingSystems.list
         * @desc Retrieves a list of operating systems.
@@ -4766,7 +4987,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4788,7 +5011,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4806,7 +5029,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4828,7 +5052,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.operatingSystemVersions.list
         * @desc Retrieves a list of operating system versions.
@@ -4841,7 +5065,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4863,7 +5089,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4882,7 +5108,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4904,7 +5131,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.orderDocuments.list
         * @desc Retrieves a list of order documents, possibly filtered. This
@@ -4928,7 +5155,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4950,7 +5179,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4969,7 +5198,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4991,7 +5221,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.orders.list
         * @desc Retrieves a list of orders, possibly filtered. This method
@@ -5013,7 +5243,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5035,7 +5267,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5053,7 +5285,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5075,7 +5308,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.insert
         * @desc Inserts a new placement group.
@@ -5089,7 +5322,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5111,7 +5346,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.list
         * @desc Retrieves a list of placement groups, possibly filtered. This
@@ -5144,7 +5379,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5166,7 +5403,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.patch
         * @desc Updates an existing placement group. This method supports patch
@@ -5182,7 +5419,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5204,7 +5443,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementGroups.update
         * @desc Updates an existing placement group.
@@ -5218,7 +5457,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5240,7 +5481,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5260,7 +5501,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generatetags(params, options, callback) {
+    generatetags(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5282,7 +5525,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.get
         * @desc Gets one placement by ID.
@@ -5296,7 +5539,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5318,7 +5562,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.insert
         * @desc Inserts a new placement.
@@ -5332,7 +5576,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5353,7 +5599,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.list
         * @desc Retrieves a list of placements, possibly filtered. This method
@@ -5389,7 +5635,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5410,7 +5658,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.patch
         * @desc Updates an existing placement. This method supports patch
@@ -5426,7 +5674,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5447,7 +5697,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placements.update
         * @desc Updates an existing placement.
@@ -5461,7 +5711,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5482,7 +5734,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5500,7 +5752,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5522,7 +5776,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.get
         * @desc Gets one placement strategy by ID.
@@ -5536,7 +5790,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5558,7 +5813,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.insert
         * @desc Inserts a new placement strategy.
@@ -5572,7 +5827,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5594,7 +5851,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.list
         * @desc Retrieves a list of placement strategies, possibly filtered.
@@ -5614,7 +5871,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5636,7 +5895,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.patch
         * @desc Updates an existing placement strategy. This method supports
@@ -5652,7 +5911,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5674,7 +5935,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.placementStrategies.update
         * @desc Updates an existing placement strategy.
@@ -5688,7 +5949,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5710,7 +5973,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5728,7 +5991,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5750,7 +6014,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.platformTypes.list
         * @desc Retrieves a list of platform types.
@@ -5763,7 +6027,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5784,7 +6050,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5802,7 +6068,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5824,7 +6091,7 @@ function Dfareporting(options) {
         pathParams: ['code', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.postalCodes.list
         * @desc Retrieves a list of postal codes.
@@ -5837,7 +6104,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5858,7 +6127,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5876,7 +6145,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5897,7 +6167,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.projects.list
         * @desc Retrieves a list of projects, possibly filtered. This method
@@ -5918,7 +6188,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5939,7 +6211,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5956,7 +6228,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5977,7 +6251,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -5995,7 +6269,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6017,7 +6292,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.insert
         * @desc Inserts a new remarketing list.
@@ -6031,7 +6306,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6053,7 +6330,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.list
         * @desc Retrieves a list of remarketing lists, possibly filtered. This
@@ -6075,7 +6352,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6097,7 +6376,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.patch
         * @desc Updates an existing remarketing list. This method supports patch
@@ -6113,7 +6392,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6135,7 +6416,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingLists.update
         * @desc Updates an existing remarketing list.
@@ -6149,7 +6430,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6171,7 +6454,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6189,7 +6472,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6211,7 +6495,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'remarketingListId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingListShares.patch
         * @desc Updates an existing remarketing list share. This method supports
@@ -6227,7 +6511,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6249,7 +6535,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.remarketingListShares.update
         * @desc Updates an existing remarketing list share.
@@ -6263,7 +6549,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6285,7 +6573,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6303,7 +6591,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6325,7 +6615,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.get
         * @desc Retrieves a report by its ID.
@@ -6339,7 +6629,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6361,7 +6652,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.insert
         * @desc Creates a report.
@@ -6375,7 +6666,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6396,7 +6689,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.list
         * @desc Retrieves list of reports.
@@ -6414,7 +6707,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6435,7 +6730,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.patch
         * @desc Updates a report. This method supports patch semantics.
@@ -6450,7 +6745,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6472,7 +6769,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.run
         * @desc Runs a report.
@@ -6487,7 +6784,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    run(params, options, callback) {
+    run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6509,7 +6807,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.reports.update
         * @desc Updates a report.
@@ -6524,7 +6822,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6546,7 +6846,7 @@ function Dfareporting(options) {
         pathParams: ['profileId', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     compatibleFields: {
       /**
@@ -6564,7 +6864,9 @@ function Dfareporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      query(params, options, callback) {
+      query(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -6586,7 +6888,7 @@ function Dfareporting(options) {
           pathParams: ['profileId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -6605,7 +6907,8 @@ function Dfareporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -6627,7 +6930,7 @@ function Dfareporting(options) {
           pathParams: ['fileId', 'profileId', 'reportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dfareporting.reports.files.list
           * @desc Lists files for a report.
@@ -6645,7 +6948,9 @@ function Dfareporting(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -6667,7 +6972,7 @@ function Dfareporting(options) {
           pathParams: ['profileId', 'reportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -6686,7 +6991,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6707,7 +7013,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.insert
         * @desc Inserts a new site.
@@ -6721,7 +7027,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6742,7 +7050,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.list
         * @desc Retrieves a list of sites, possibly filtered. This method
@@ -6771,7 +7079,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6792,7 +7102,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.patch
         * @desc Updates an existing site. This method supports patch semantics.
@@ -6807,7 +7117,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6828,7 +7140,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sites.update
         * @desc Updates an existing site.
@@ -6842,7 +7154,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6863,7 +7177,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6881,7 +7195,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6902,7 +7217,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sizes.insert
         * @desc Inserts a new size.
@@ -6916,7 +7231,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6937,7 +7254,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.sizes.list
         * @desc Retrieves a list of sizes, possibly filtered.
@@ -6954,7 +7271,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -6975,7 +7294,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -6993,7 +7312,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7015,7 +7335,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.insert
         * @desc Inserts a new subaccount.
@@ -7029,7 +7349,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7050,7 +7372,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.list
         * @desc Gets a list of subaccounts, possibly filtered. This method
@@ -7070,7 +7392,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7091,7 +7415,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.patch
         * @desc Updates an existing subaccount. This method supports patch
@@ -7107,7 +7431,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7128,7 +7454,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.subaccounts.update
         * @desc Updates an existing subaccount.
@@ -7142,7 +7468,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7163,7 +7491,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7181,7 +7509,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7203,7 +7532,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetableRemarketingLists.list
         * @desc Retrieves a list of targetable remarketing lists, possibly
@@ -7224,7 +7553,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7246,7 +7577,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7264,7 +7595,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7286,7 +7618,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.insert
         * @desc Inserts a new targeting template.
@@ -7300,7 +7632,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7322,7 +7656,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.list
         * @desc Retrieves a list of targeting templates, optionally filtered.
@@ -7343,7 +7677,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7365,7 +7701,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.patch
         * @desc Updates an existing targeting template. This method supports
@@ -7381,7 +7717,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7403,7 +7741,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.targetingTemplates.update
         * @desc Updates an existing targeting template.
@@ -7417,7 +7755,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7439,7 +7779,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7456,7 +7796,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7476,7 +7817,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userProfiles.list
         * @desc Retrieves list of user profiles for a user.
@@ -7488,7 +7829,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7508,7 +7851,7 @@ function Dfareporting(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7526,7 +7869,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7548,7 +7892,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRolePermissionGroups.list
         * @desc Gets a list of all supported user role permission groups.
@@ -7561,7 +7905,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7583,7 +7929,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7601,7 +7947,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7623,7 +7970,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRolePermissions.list
         * @desc Gets a list of user role permissions, possibly filtered.
@@ -7637,7 +7984,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7659,7 +8008,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7677,7 +8026,9 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7699,7 +8050,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.get
         * @desc Gets one user role by ID.
@@ -7713,7 +8064,8 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7735,7 +8087,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.insert
         * @desc Inserts a new user role.
@@ -7749,7 +8101,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7770,7 +8124,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.list
         * @desc Retrieves a list of user roles, possibly filtered. This method
@@ -7792,7 +8146,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7813,7 +8169,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.patch
         * @desc Updates an existing user role. This method supports patch
@@ -7829,7 +8185,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7850,7 +8208,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.userRoles.update
         * @desc Updates an existing user role.
@@ -7864,7 +8222,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7885,7 +8245,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -7903,7 +8263,8 @@ function Dfareporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7925,7 +8286,7 @@ function Dfareporting(options) {
         pathParams: ['id', 'profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dfareporting.videoFormats.list
         * @desc Lists available video formats.
@@ -7938,7 +8299,9 @@ function Dfareporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -7959,7 +8322,7 @@ function Dfareporting(options) {
         pathParams: ['profileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/dialogflow/v2beta1.ts
+++ b/src/apis/dialogflow/v2beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Dialogflow API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta1
  * @param {object=} options Options for Dialogflow
  */
-function Dialogflow(options) {
+function Dialogflow(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -48,7 +55,9 @@ function Dialogflow(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getAgent(params, options, callback) {
+    getAgent(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Dialogflow(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     agent:
         {
@@ -87,7 +96,9 @@ function Dialogflow(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          export(params, options, callback) {
+          export(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -108,7 +119,7 @@ function Dialogflow(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dialogflow.projects.agent.import
               * @desc Imports the specified agent from a ZIP file.  Uploads new
@@ -127,7 +138,9 @@ function Dialogflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          import(params, options, callback) {
+          import(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -148,7 +161,7 @@ function Dialogflow(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dialogflow.projects.agent.restore
               * @desc Restores the specified agent from a ZIP file.  Replaces
@@ -166,7 +179,9 @@ function Dialogflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          restore(params, options, callback) {
+          restore(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -187,7 +202,7 @@ function Dialogflow(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dialogflow.projects.agent.search
               * @desc Returns the list of agents.  Since there is at most one
@@ -207,7 +222,9 @@ function Dialogflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          search(params, options, callback) {
+          search(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -228,7 +245,7 @@ function Dialogflow(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * dialogflow.projects.agent.train
               * @desc Trains the specified agent.   Operation <response:
@@ -244,7 +261,9 @@ function Dialogflow(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          train(params, options, callback) {
+          train(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -265,7 +284,7 @@ function Dialogflow(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           entityTypes: {
             /**
@@ -283,7 +302,9 @@ function Dialogflow(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            batchDelete(params, options, callback) {
+            batchDelete(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -305,7 +326,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.entityTypes.batchUpdate
                 * @desc Updates/Creates multiple entity types in the specified
@@ -321,7 +342,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            batchUpdate(params, options, callback) {
+            batchUpdate(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -343,7 +366,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.entityTypes.create
                 * @desc Creates an entity type in the specified agent.
@@ -358,7 +381,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -379,7 +404,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.entityTypes.delete
                 * @desc Deletes the specified entity type.
@@ -392,7 +417,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -413,7 +440,7 @@ function Dialogflow(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.entityTypes.get
                 * @desc Retrieves the specified entity type.
@@ -427,7 +454,8 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -448,7 +476,7 @@ function Dialogflow(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.entityTypes.list
                 * @desc Returns the list of all entity types in the specified
@@ -465,7 +493,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -486,7 +516,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.entityTypes.patch
                 * @desc Updates the specified entity type.
@@ -502,7 +532,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -523,7 +555,7 @@ function Dialogflow(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             },
             entities: {
               /**
@@ -542,7 +574,9 @@ function Dialogflow(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              batchCreate(params, options, callback) {
+              batchCreate(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -564,7 +598,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.entityTypes.entities.batchDelete
                   * @desc Deletes entities in the specified entity type.
@@ -581,7 +615,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              batchDelete(params, options, callback) {
+              batchDelete(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -603,7 +639,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.entityTypes.entities.batchUpdate
                   * @desc Updates entities in the specified entity type
@@ -621,7 +657,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              batchUpdate(params, options, callback) {
+              batchUpdate(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -643,7 +681,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             }
@@ -663,7 +701,9 @@ function Dialogflow(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            batchDelete(params, options, callback) {
+            batchDelete(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -684,7 +724,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.intents.batchUpdate
                 * @desc Updates/Creates multiple intents in the specified agent.
@@ -699,7 +739,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            batchUpdate(params, options, callback) {
+            batchUpdate(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -720,7 +762,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.intents.create
                 * @desc Creates an intent in the specified agent.
@@ -736,7 +778,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -757,7 +801,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.intents.delete
                 * @desc Deletes the specified intent.
@@ -770,7 +814,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -791,7 +837,7 @@ function Dialogflow(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.intents.get
                 * @desc Retrieves the specified intent.
@@ -806,7 +852,8 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -827,7 +874,7 @@ function Dialogflow(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.intents.list
                 * @desc Returns the list of all intents in the specified agent.
@@ -844,7 +891,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -865,7 +914,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.intents.patch
                 * @desc Updates the specified intent.
@@ -882,7 +931,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -903,7 +954,7 @@ function Dialogflow(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -922,7 +973,9 @@ function Dialogflow(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              deleteContexts(params, options, callback) {
+              deleteContexts(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -943,7 +996,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.runtimes.sessions.detectIntent
                   * @desc Processes a natural language query and returns
@@ -962,7 +1015,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              detectIntent(params, options, callback) {
+              detectIntent(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -983,7 +1038,7 @@ function Dialogflow(options) {
                   pathParams: ['session'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               },
               contexts: {
                 /**
@@ -1000,7 +1055,10 @@ function Dialogflow(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1021,7 +1079,7 @@ function Dialogflow(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.contexts.delete
                     * @desc Deletes the specified context.
@@ -1035,7 +1093,10 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1056,7 +1117,7 @@ function Dialogflow(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.contexts.get
                     * @desc Retrieves the specified context.
@@ -1070,7 +1131,9 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1091,7 +1154,7 @@ function Dialogflow(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.contexts.list
                     * @desc Returns the list of all contexts in the specified
@@ -1108,7 +1171,10 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1129,7 +1195,7 @@ function Dialogflow(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.contexts.patch
                     * @desc Updates the specified context.
@@ -1145,7 +1211,10 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                patch(params, options, callback) {
+                patch(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1166,7 +1235,7 @@ function Dialogflow(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               },
@@ -1185,7 +1254,10 @@ function Dialogflow(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1206,7 +1278,7 @@ function Dialogflow(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.entityTypes.delete
                     * @desc Deletes the specified session entity type.
@@ -1220,7 +1292,10 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1241,7 +1316,7 @@ function Dialogflow(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.entityTypes.get
                     * @desc Retrieves the specified session entity type.
@@ -1255,7 +1330,9 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1276,7 +1353,7 @@ function Dialogflow(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.entityTypes.list
                     * @desc Returns the list of all session entity types in the
@@ -1293,7 +1370,10 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1314,7 +1394,7 @@ function Dialogflow(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * dialogflow.projects.agent.runtimes.sessions.entityTypes.patch
                     * @desc Updates the specified session entity type.
@@ -1330,7 +1410,10 @@ function Dialogflow(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                patch(params, options, callback) {
+                patch(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1351,7 +1434,7 @@ function Dialogflow(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               }
@@ -1370,7 +1453,9 @@ function Dialogflow(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            deleteContexts(params, options, callback) {
+            deleteContexts(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1391,7 +1476,7 @@ function Dialogflow(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * dialogflow.projects.agent.sessions.detectIntent
                 * @desc Processes a natural language query and returns
@@ -1409,7 +1494,9 @@ function Dialogflow(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            detectIntent(params, options, callback) {
+            detectIntent(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1430,7 +1517,7 @@ function Dialogflow(options) {
                 pathParams: ['session'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             },
             contexts: {
               /**
@@ -1446,7 +1533,9 @@ function Dialogflow(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              create(params, options, callback) {
+              create(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1467,7 +1556,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.contexts.delete
                   * @desc Deletes the specified context.
@@ -1480,7 +1569,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1501,7 +1592,7 @@ function Dialogflow(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.contexts.get
                   * @desc Retrieves the specified context.
@@ -1514,7 +1605,8 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1535,7 +1627,7 @@ function Dialogflow(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.contexts.list
                   * @desc Returns the list of all contexts in the specified
@@ -1551,7 +1643,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1572,7 +1666,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.contexts.patch
                   * @desc Updates the specified context.
@@ -1587,7 +1681,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              patch(params, options, callback) {
+              patch(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1608,7 +1704,7 @@ function Dialogflow(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             },
@@ -1626,7 +1722,9 @@ function Dialogflow(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              create(params, options, callback) {
+              create(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1647,7 +1745,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.entityTypes.delete
                   * @desc Deletes the specified session entity type.
@@ -1660,7 +1758,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1681,7 +1781,7 @@ function Dialogflow(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.entityTypes.get
                   * @desc Retrieves the specified session entity type.
@@ -1694,7 +1794,8 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1715,7 +1816,7 @@ function Dialogflow(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.entityTypes.list
                   * @desc Returns the list of all session entity types in the
@@ -1731,7 +1832,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1752,7 +1855,7 @@ function Dialogflow(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * dialogflow.projects.agent.sessions.entityTypes.patch
                   * @desc Updates the specified session entity type.
@@ -1767,7 +1870,9 @@ function Dialogflow(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              patch(params, options, callback) {
+              patch(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1788,7 +1893,7 @@ function Dialogflow(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             }
@@ -1809,7 +1914,8 @@ function Dialogflow(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1829,7 +1935,7 @@ function Dialogflow(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/digitalassetlinks/v1.ts
+++ b/src/apis/digitalassetlinks/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Digital Asset Links API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Digitalassetlinks
  */
-function Digitalassetlinks(options) {
+function Digitalassetlinks(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.assetlinks = {
@@ -72,7 +79,9 @@ function Digitalassetlinks(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    check(params, options, callback) {
+    check(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -93,7 +102,7 @@ function Digitalassetlinks(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -126,7 +135,9 @@ function Digitalassetlinks(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +158,7 @@ function Digitalassetlinks(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/discovery/v1.ts
+++ b/src/apis/discovery/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * APIs Discovery Service
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Discovery
  */
-function Discovery(options) {
+function Discovery(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.apis = {
@@ -49,7 +56,9 @@ function Discovery(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getRest(params, options, callback) {
+    getRest(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Discovery(options) {
         pathParams: ['api', 'version'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * discovery.apis.list
         * @desc Retrieve the list of APIs supported at this endpoint.
@@ -83,7 +92,9 @@ function Discovery(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -103,7 +114,7 @@ function Discovery(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/dlp/v2beta1.ts
+++ b/src/apis/dlp/v2beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * DLP API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta1
  * @param {object=} options Options for Dlp
  */
-function Dlp(options) {
+function Dlp(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.content = {
@@ -50,7 +57,9 @@ function Dlp(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    deidentify(params, options, callback) {
+    deidentify(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Dlp(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dlp.content.inspect
         * @desc Finds potentially sensitive info in a list of strings. This
@@ -84,7 +93,9 @@ function Dlp(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    inspect(params, options, callback) {
+    inspect(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +115,7 @@ function Dlp(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dlp.content.redact
         * @desc Redacts potentially sensitive info from a list of strings. This
@@ -118,7 +129,9 @@ function Dlp(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    redact(params, options, callback) {
+    redact(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +151,7 @@ function Dlp(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -156,7 +169,9 @@ function Dlp(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    analyze(params, options, callback) {
+    analyze(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -176,7 +191,7 @@ function Dlp(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -197,7 +212,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -217,7 +234,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.inspect.operations.create
           * @desc Schedules a job scanning content in a Google Cloud Platform
@@ -231,7 +248,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -251,7 +270,7 @@ function Dlp(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.inspect.operations.delete
           * @desc This method is not supported and the server returns
@@ -265,7 +284,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -285,7 +306,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.inspect.operations.get
           * @desc Gets the latest state of a long-running operation.  Clients
@@ -300,7 +321,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -320,7 +342,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.inspect.operations.list
           * @desc Fetches the list of long running operations.
@@ -336,7 +358,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -356,7 +380,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -378,7 +402,9 @@ function Dlp(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -398,7 +424,7 @@ function Dlp(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -421,7 +447,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -441,7 +469,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.riskAnalysis.operations.delete
           * @desc This method is not supported and the server returns
@@ -455,7 +483,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -475,7 +505,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.riskAnalysis.operations.get
           * @desc Gets the latest state of a long-running operation.  Clients
@@ -490,7 +520,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -510,7 +541,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.riskAnalysis.operations.list
           * @desc Fetches the list of long running operations.
@@ -526,7 +557,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -546,7 +579,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -564,7 +597,9 @@ function Dlp(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -584,7 +619,7 @@ function Dlp(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     infoTypes: {
       /**
@@ -600,7 +635,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -620,7 +657,7 @@ function Dlp(options) {
           pathParams: ['category'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/dlp/v2beta2.ts
+++ b/src/apis/dlp/v2beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * DLP API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta2
  * @param {object=} options Options for Dlp
  */
-function Dlp(options) {
+function Dlp(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.infoTypes = {
@@ -50,7 +57,9 @@ function Dlp(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Dlp(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -90,7 +99,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -110,7 +121,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.deidentifyTemplates.delete
           * @desc Deletes inspect templates.
@@ -123,7 +134,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -143,7 +156,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.deidentifyTemplates.get
           * @desc Gets an inspect template.
@@ -156,7 +169,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -176,7 +190,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.deidentifyTemplates.list
           * @desc Lists inspect templates.
@@ -191,7 +205,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -211,7 +227,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.deidentifyTemplates.patch
           * @desc Updates the inspect template.
@@ -225,7 +241,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -245,7 +263,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -264,7 +282,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -284,7 +304,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.inspectTemplates.delete
           * @desc Deletes inspect templates.
@@ -297,7 +317,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -317,7 +339,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.inspectTemplates.get
           * @desc Gets an inspect template.
@@ -330,7 +352,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -350,7 +373,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.inspectTemplates.list
           * @desc Lists inspect templates.
@@ -365,7 +388,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -385,7 +410,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.organizations.inspectTemplates.patch
           * @desc Updates the inspect template.
@@ -399,7 +424,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -419,7 +446,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -441,7 +468,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      deidentify(params, options, callback) {
+      deidentify(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -461,7 +490,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.content.inspect
           * @desc Finds potentially sensitive info in content. This method has
@@ -478,7 +507,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      inspect(params, options, callback) {
+      inspect(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -498,7 +529,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.content.reidentify
           * @desc Re-identify content that has been de-identified.
@@ -512,7 +543,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      reidentify(params, options, callback) {
+      reidentify(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -532,7 +565,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -552,7 +585,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      analyze(params, options, callback) {
+      analyze(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -572,7 +607,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.dataSource.inspect
           * @desc Schedules a job scanning content in a Google Cloud Platform
@@ -587,7 +622,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      inspect(params, options, callback) {
+      inspect(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -607,7 +644,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -626,7 +663,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -646,7 +685,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.deidentifyTemplates.delete
           * @desc Deletes inspect templates.
@@ -659,7 +698,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -679,7 +720,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.deidentifyTemplates.get
           * @desc Gets an inspect template.
@@ -692,7 +733,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -712,7 +754,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.deidentifyTemplates.list
           * @desc Lists inspect templates.
@@ -727,7 +769,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -747,7 +791,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.deidentifyTemplates.patch
           * @desc Updates the inspect template.
@@ -761,7 +805,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -781,7 +827,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -801,7 +847,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -821,7 +869,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.dlpJobs.delete
           * @desc Deletes a long-running DlpJob. This method indicates that the
@@ -836,7 +884,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -856,7 +906,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.dlpJobs.get
           * @desc Gets the latest state of a long-running DlpJob.
@@ -869,7 +919,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -889,7 +940,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.dlpJobs.list
           * @desc Lists DlpJobs that match the specified filter in the request.
@@ -906,7 +957,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -926,7 +979,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -946,7 +999,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      redact(params, options, callback) {
+      redact(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -966,7 +1021,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -985,7 +1040,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1005,7 +1062,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.inspectTemplates.delete
           * @desc Deletes inspect templates.
@@ -1018,7 +1075,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1038,7 +1097,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.inspectTemplates.get
           * @desc Gets an inspect template.
@@ -1051,7 +1110,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1071,7 +1131,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.inspectTemplates.list
           * @desc Lists inspect templates.
@@ -1086,7 +1146,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1106,7 +1168,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.inspectTemplates.patch
           * @desc Updates the inspect template.
@@ -1120,7 +1182,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1140,7 +1204,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1159,7 +1223,9 @@ function Dlp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1179,7 +1245,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.jobTriggers.delete
           * @desc Deletes a job trigger.
@@ -1192,7 +1258,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1212,7 +1280,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.jobTriggers.get
           * @desc Gets a job trigger.
@@ -1225,7 +1293,8 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1245,7 +1314,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.jobTriggers.list
           * @desc Lists job triggers.
@@ -1261,7 +1330,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1281,7 +1352,7 @@ function Dlp(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * dlp.projects.jobTriggers.patch
           * @desc Updates a job trigger.
@@ -1295,7 +1366,9 @@ function Dlp(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1315,7 +1388,7 @@ function Dlp(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/dns/v1.ts
+++ b/src/apis/dns/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud DNS API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Dns
  */
-function Dns(options) {
+function Dns(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.changes = {
@@ -110,7 +117,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -132,7 +141,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.changes.get
         * @desc Fetch the representation of an existing Change.
@@ -208,7 +217,8 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -230,7 +240,7 @@ function Dns(options) {
         pathParams: ['changeId', 'managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.changes.list
         * @desc Enumerate Changes to a ResourceRecordSet collection.
@@ -318,7 +328,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -340,7 +352,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -415,7 +427,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -435,7 +449,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.delete
         * @desc Delete a previously created ManagedZone.
@@ -503,7 +517,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -524,7 +540,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.get
         * @desc Fetch the representation of an existing ManagedZone.
@@ -595,7 +611,8 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -616,7 +633,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.list
         * @desc Enumerate ManagedZones that have been created but not yet
@@ -700,7 +717,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -720,7 +739,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -790,7 +809,8 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -810,7 +830,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -903,7 +923,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -925,7 +947,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/dns/v1beta2.ts
+++ b/src/apis/dns/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud DNS API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Dns
  */
-function Dns(options) {
+function Dns(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.changes = {
@@ -50,7 +57,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.changes.get
         * @desc Fetch the representation of an existing Change.
@@ -88,7 +97,8 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +120,7 @@ function Dns(options) {
         pathParams: ['changeId', 'managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.changes.list
         * @desc Enumerate Changes to a ResourceRecordSet collection.
@@ -128,7 +138,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -150,7 +162,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -171,7 +183,8 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -193,7 +206,7 @@ function Dns(options) {
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.dnsKeys.list
         * @desc Enumerate DnsKeys to a ResourceRecordSet collection.
@@ -210,7 +223,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -232,7 +247,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -252,7 +267,8 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -274,7 +290,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZoneOperations.list
         * @desc Enumerate Operations for the given ManagedZone.
@@ -291,7 +307,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -313,7 +331,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -332,7 +350,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -352,7 +372,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.delete
         * @desc Delete a previously created ManagedZone.
@@ -367,7 +387,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -389,7 +411,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.get
         * @desc Fetch the representation of an existing ManagedZone.
@@ -404,7 +426,8 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -426,7 +449,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.list
         * @desc Enumerate ManagedZones that have been created but not yet
@@ -443,7 +466,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -463,7 +488,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.patch
         * @desc Update an existing ManagedZone. This method supports patch
@@ -480,7 +505,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -502,7 +529,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.update
         * @desc Update an existing ManagedZone.
@@ -518,7 +545,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -540,7 +569,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -558,7 +587,8 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -578,7 +608,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -601,7 +631,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -623,7 +655,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/dns/v2beta1.ts
+++ b/src/apis/dns/v2beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud DNS API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta1
  * @param {object=} options Options for Dns
  */
-function Dns(options) {
+function Dns(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.changes = {
@@ -111,7 +118,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -133,7 +142,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.changes.get
         * @desc Fetch the representation of an existing Change.
@@ -210,7 +219,8 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -232,7 +242,7 @@ function Dns(options) {
         pathParams: ['changeId', 'managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.changes.list
         * @desc Enumerate Changes to a ResourceRecordSet collection.
@@ -320,7 +330,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -342,7 +354,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -423,7 +435,8 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -445,7 +458,7 @@ function Dns(options) {
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.dnsKeys.list
         * @desc Enumerate DnsKeys to a ResourceRecordSet collection.
@@ -532,7 +545,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -554,7 +569,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -633,7 +648,8 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -655,7 +671,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZoneOperations.list
         * @desc Enumerate Operations for the given ManagedZone.
@@ -743,7 +759,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -765,7 +783,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -841,7 +859,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -861,7 +881,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.delete
         * @desc Delete a previously created ManagedZone.
@@ -933,7 +953,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -955,7 +977,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.get
         * @desc Fetch the representation of an existing ManagedZone.
@@ -1027,7 +1049,8 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1049,7 +1072,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.list
         * @desc Enumerate ManagedZones that have been created but not yet
@@ -1133,7 +1156,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1153,7 +1178,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.patch
         * @desc Update an existing ManagedZone. This method supports patch
@@ -1233,7 +1258,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1255,7 +1282,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * dns.managedZones.update
         * @desc Update an existing ManagedZone.
@@ -1334,7 +1361,9 @@ function Dns(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1356,7 +1385,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1427,7 +1456,8 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1447,7 +1477,7 @@ function Dns(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1540,7 +1570,9 @@ function Dns(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1562,7 +1594,7 @@ function Dns(options) {
         pathParams: ['managedZone', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/doubleclickbidmanager/v1.ts
+++ b/src/apis/doubleclickbidmanager/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * DoubleClick Bid Manager API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Doubleclickbidmanager
  */
-function Doubleclickbidmanager(options) {
+function Doubleclickbidmanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.lineitems = {
@@ -48,7 +55,9 @@ function Doubleclickbidmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    downloadlineitems(params, options, callback) {
+    downloadlineitems(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Doubleclickbidmanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclickbidmanager.lineitems.uploadlineitems
         * @desc Uploads line items in CSV format. TrueView line items are not
@@ -83,7 +92,9 @@ function Doubleclickbidmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    uploadlineitems(params, options, callback) {
+    uploadlineitems(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +115,7 @@ function Doubleclickbidmanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -121,7 +132,9 @@ function Doubleclickbidmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    createquery(params, options, callback) {
+    createquery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -141,7 +154,7 @@ function Doubleclickbidmanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclickbidmanager.queries.deletequery
         * @desc Deletes a stored query as well as the associated stored reports.
@@ -154,7 +167,9 @@ function Doubleclickbidmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deletequery(params, options, callback) {
+    deletequery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -174,7 +189,7 @@ function Doubleclickbidmanager(options) {
         pathParams: ['queryId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclickbidmanager.queries.getquery
         * @desc Retrieves a stored query.
@@ -187,7 +202,9 @@ function Doubleclickbidmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getquery(params, options, callback) {
+    getquery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +224,7 @@ function Doubleclickbidmanager(options) {
         pathParams: ['queryId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclickbidmanager.queries.listqueries
         * @desc Retrieves stored queries.
@@ -219,7 +236,9 @@ function Doubleclickbidmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listqueries(params, options, callback) {
+    listqueries(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -239,7 +258,7 @@ function Doubleclickbidmanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclickbidmanager.queries.runquery
         * @desc Runs a stored query to generate a report.
@@ -253,7 +272,9 @@ function Doubleclickbidmanager(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    runquery(params, options, callback) {
+    runquery(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -273,7 +294,7 @@ function Doubleclickbidmanager(options) {
         pathParams: ['queryId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -290,7 +311,9 @@ function Doubleclickbidmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    listreports(params, options, callback) {
+    listreports(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -311,7 +334,7 @@ function Doubleclickbidmanager(options) {
         pathParams: ['queryId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -328,7 +351,9 @@ function Doubleclickbidmanager(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    download(params, options, callback) {
+    download(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -348,7 +373,7 @@ function Doubleclickbidmanager(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/doubleclicksearch/v2.ts
+++ b/src/apis/doubleclicksearch/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * DoubleClick Search API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Doubleclicksearch
  */
-function Doubleclicksearch(options) {
+function Doubleclicksearch(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.conversion = {
@@ -59,7 +66,8 @@ function Doubleclicksearch(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -84,7 +92,7 @@ function Doubleclicksearch(options) {
         pathParams: ['advertiserId', 'agencyId', 'engineAccountId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclicksearch.conversion.insert
         * @desc Inserts a batch of new conversions into DoubleClick Search.
@@ -97,7 +105,9 @@ function Doubleclicksearch(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -117,7 +127,7 @@ function Doubleclicksearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclicksearch.conversion.patch
         * @desc Updates a batch of conversions in DoubleClick Search. This
@@ -138,7 +148,9 @@ function Doubleclicksearch(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -161,7 +173,7 @@ function Doubleclicksearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclicksearch.conversion.update
         * @desc Updates a batch of conversions in DoubleClick Search.
@@ -174,7 +186,9 @@ function Doubleclicksearch(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -194,7 +208,7 @@ function Doubleclicksearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclicksearch.conversion.updateAvailability
         * @desc Updates the availabilities of a batch of floodlight activities
@@ -208,7 +222,9 @@ function Doubleclicksearch(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateAvailability(params, options, callback) {
+    updateAvailability(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -229,7 +245,7 @@ function Doubleclicksearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -246,7 +262,9 @@ function Doubleclicksearch(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    generate(params, options, callback) {
+    generate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -266,7 +284,7 @@ function Doubleclicksearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclicksearch.reports.get
         * @desc Polls for the status of a report request.
@@ -279,7 +297,8 @@ function Doubleclicksearch(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -299,7 +318,7 @@ function Doubleclicksearch(options) {
         pathParams: ['reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclicksearch.reports.getFile
         * @desc Downloads a report file encoded in UTF-8.
@@ -313,7 +332,9 @@ function Doubleclicksearch(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getFile(params, options, callback) {
+    getFile(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -335,7 +356,7 @@ function Doubleclicksearch(options) {
         pathParams: ['reportFragment', 'reportId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * doubleclicksearch.reports.request
         * @desc Inserts a report request into the reporting system.
@@ -348,7 +369,9 @@ function Doubleclicksearch(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    request(params, options, callback) {
+    request(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -368,7 +391,7 @@ function Doubleclicksearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -386,7 +409,9 @@ function Doubleclicksearch(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -408,7 +433,7 @@ function Doubleclicksearch(options) {
         pathParams: ['advertiserId', 'agencyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/drive/v2.ts
+++ b/src/apis/drive/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Drive API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Drive
  */
-function Drive(options) {
+function Drive(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.about = {
@@ -51,7 +58,8 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +78,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -87,7 +95,8 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +116,7 @@ function Drive(options) {
         pathParams: ['appId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.apps.list
         * @desc Lists a user's installed apps.
@@ -122,7 +131,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -141,7 +152,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -161,7 +172,8 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -181,7 +193,7 @@ function Drive(options) {
         pathParams: ['changeId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.changes.getStartPageToken
         * @desc Gets the starting pageToken for listing future changes.
@@ -195,7 +207,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getStartPageToken(params, options, callback) {
+    getStartPageToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -215,7 +229,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.changes.list
         * @desc Lists the changes for a user or Team Drive.
@@ -237,7 +251,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -257,7 +273,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.changes.watch
         * @desc Subscribe to changes for a user.
@@ -280,7 +296,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -300,7 +318,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -317,7 +335,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -337,7 +357,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -355,7 +375,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -375,7 +397,7 @@ function Drive(options) {
         pathParams: ['childId', 'folderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.children.get
         * @desc Gets a specific child reference.
@@ -389,7 +411,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -409,7 +432,7 @@ function Drive(options) {
         pathParams: ['childId', 'folderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.children.insert
         * @desc Inserts a file into a folder.
@@ -424,7 +447,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -444,7 +469,7 @@ function Drive(options) {
         pathParams: ['folderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.children.list
         * @desc Lists a folder's children.
@@ -461,7 +486,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -481,7 +508,7 @@ function Drive(options) {
         pathParams: ['folderId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -499,7 +526,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -519,7 +548,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.get
         * @desc Gets a comment by ID.
@@ -534,7 +563,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -554,7 +584,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.insert
         * @desc Creates a new comment on the given file.
@@ -568,7 +598,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -588,7 +620,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.list
         * @desc Lists a file's comments.
@@ -605,7 +637,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -625,7 +659,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.patch
         * @desc Updates an existing comment. This method supports patch
@@ -641,7 +675,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -661,7 +697,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.update
         * @desc Updates an existing comment.
@@ -676,7 +712,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -696,7 +734,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -722,7 +760,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    copy(params, options, callback) {
+    copy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -742,7 +782,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.delete
         * @desc Permanently deletes a file by ID. Skips the trash. The currently
@@ -758,7 +798,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -778,7 +820,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.emptyTrash
         * @desc Permanently deletes all of the user's trashed files.
@@ -790,7 +832,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    emptyTrash(params, options, callback) {
+    emptyTrash(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -810,7 +854,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.export
         * @desc Exports a Google Doc to the requested MIME type and returns the
@@ -826,7 +870,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    export(params, options, callback) {
+    export(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -846,7 +892,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.generateIds
         * @desc Generates a set of file IDs which can be provided in insert
@@ -861,7 +907,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generateIds(params, options, callback) {
+    generateIds(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -881,7 +929,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.get
         * @desc Gets a file's metadata by ID.
@@ -899,7 +947,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -919,7 +968,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.insert
         * @desc Insert a new file.
@@ -944,7 +993,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -965,7 +1016,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.list
         * @desc Lists the user's files.
@@ -988,7 +1039,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1007,7 +1060,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.patch
         * @desc Updates file metadata and/or content. This method supports patch
@@ -1036,7 +1089,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1056,7 +1111,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.touch
         * @desc Set the file's updated time to the current server time.
@@ -1070,7 +1125,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    touch(params, options, callback) {
+    touch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1090,7 +1147,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.trash
         * @desc Moves a file to the trash. The currently authenticated user must
@@ -1105,7 +1162,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    trash(params, options, callback) {
+    trash(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1125,7 +1184,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.untrash
         * @desc Restores a file from the trash.
@@ -1139,7 +1198,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    untrash(params, options, callback) {
+    untrash(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1159,7 +1220,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.update
         * @desc Updates file metadata and/or content.
@@ -1190,7 +1251,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1212,7 +1275,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.watch
         * @desc Subscribe to changes on a file
@@ -1231,7 +1294,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1251,7 +1316,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1269,7 +1334,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1289,7 +1356,7 @@ function Drive(options) {
         pathParams: ['fileId', 'parentId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.parents.get
         * @desc Gets a specific parent reference.
@@ -1303,7 +1370,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1323,7 +1391,7 @@ function Drive(options) {
         pathParams: ['fileId', 'parentId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.parents.insert
         * @desc Adds a parent folder for a file.
@@ -1338,7 +1406,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1358,7 +1428,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.parents.list
         * @desc Lists a file's parents.
@@ -1371,7 +1441,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1391,7 +1463,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1411,7 +1483,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1432,7 +1506,7 @@ function Drive(options) {
         pathParams: ['fileId', 'permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.get
         * @desc Gets a permission by ID.
@@ -1448,7 +1522,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1469,7 +1544,7 @@ function Drive(options) {
         pathParams: ['fileId', 'permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.getIdForEmail
         * @desc Returns the permission ID for an email address.
@@ -1482,7 +1557,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIdForEmail(params, options, callback) {
+    getIdForEmail(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1502,7 +1579,7 @@ function Drive(options) {
         pathParams: ['email'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.insert
         * @desc Inserts a permission for a file or Team Drive.
@@ -1520,7 +1597,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1540,7 +1619,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.list
         * @desc Lists a file's or Team Drive's permissions.
@@ -1557,7 +1636,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1577,7 +1658,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.patch
         * @desc Updates a permission using patch semantics.
@@ -1596,7 +1677,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1617,7 +1700,7 @@ function Drive(options) {
         pathParams: ['fileId', 'permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.update
         * @desc Updates a permission.
@@ -1636,7 +1719,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1657,7 +1742,7 @@ function Drive(options) {
         pathParams: ['fileId', 'permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1676,7 +1761,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1697,7 +1784,7 @@ function Drive(options) {
         pathParams: ['fileId', 'propertyKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.properties.get
         * @desc Gets a property by its key.
@@ -1712,7 +1799,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1733,7 +1821,7 @@ function Drive(options) {
         pathParams: ['fileId', 'propertyKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.properties.insert
         * @desc Adds a property to a file, or updates it if it already exists.
@@ -1747,7 +1835,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1767,7 +1857,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.properties.list
         * @desc Lists a file's properties.
@@ -1780,7 +1870,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1800,7 +1892,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.properties.patch
         * @desc Updates a property, or adds it if it doesn't exist. This method
@@ -1817,7 +1909,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1838,7 +1932,7 @@ function Drive(options) {
         pathParams: ['fileId', 'propertyKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.properties.update
         * @desc Updates a property, or adds it if it doesn't exist.
@@ -1854,7 +1948,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1875,7 +1971,7 @@ function Drive(options) {
         pathParams: ['fileId', 'propertyKey'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1894,7 +1990,8 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1914,7 +2011,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.realtime.update
         * @desc Overwrites the Realtime API data model associated with this file
@@ -1932,7 +2029,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1954,7 +2053,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1973,7 +2072,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1995,7 +2096,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId', 'replyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.get
         * @desc Gets a reply.
@@ -2011,7 +2112,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2033,7 +2135,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId', 'replyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.insert
         * @desc Creates a new reply to the given comment.
@@ -2048,7 +2150,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2069,7 +2173,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.list
         * @desc Lists all of the replies to a comment.
@@ -2086,7 +2190,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2107,7 +2213,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.patch
         * @desc Updates an existing reply. This method supports patch semantics.
@@ -2123,7 +2229,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2145,7 +2253,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId', 'replyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.update
         * @desc Updates an existing reply.
@@ -2161,7 +2269,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2183,7 +2293,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId', 'replyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2201,7 +2311,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2221,7 +2333,7 @@ function Drive(options) {
         pathParams: ['fileId', 'revisionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.revisions.get
         * @desc Gets a specific revision.
@@ -2235,7 +2347,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2255,7 +2368,7 @@ function Drive(options) {
         pathParams: ['fileId', 'revisionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.revisions.list
         * @desc Lists a file's revisions.
@@ -2270,7 +2383,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2290,7 +2405,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.revisions.patch
         * @desc Updates a revision. This method supports patch semantics.
@@ -2305,7 +2420,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2325,7 +2442,7 @@ function Drive(options) {
         pathParams: ['fileId', 'revisionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.revisions.update
         * @desc Updates a revision.
@@ -2340,7 +2457,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2360,7 +2479,7 @@ function Drive(options) {
         pathParams: ['fileId', 'revisionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2378,7 +2497,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2398,7 +2519,7 @@ function Drive(options) {
         pathParams: ['teamDriveId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.get
         * @desc Gets a Team Drive's metadata by ID.
@@ -2412,7 +2533,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2432,7 +2554,7 @@ function Drive(options) {
         pathParams: ['teamDriveId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.insert
         * @desc Creates a new Team Drive.
@@ -2446,7 +2568,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2466,7 +2590,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.list
         * @desc Lists the user's Team Drives.
@@ -2482,7 +2606,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2502,7 +2628,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.update
         * @desc Updates a Team Drive's metadata
@@ -2516,7 +2642,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2536,7 +2664,7 @@ function Drive(options) {
         pathParams: ['teamDriveId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/drive/v3.ts
+++ b/src/apis/drive/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Drive API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Drive
  */
-function Drive(options) {
+function Drive(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.about = {
@@ -48,7 +55,8 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -85,7 +93,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getStartPageToken(params, options, callback) {
+    getStartPageToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +115,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.changes.list
         * @desc Lists the changes for a user or Team Drive.
@@ -126,7 +136,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -146,7 +158,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.changes.watch
         * @desc Subscribes to changes for a user.
@@ -168,7 +180,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -188,7 +202,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -205,7 +219,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -225,7 +241,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -243,7 +259,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -263,7 +281,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.delete
         * @desc Deletes a comment.
@@ -277,7 +295,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -297,7 +317,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.get
         * @desc Gets a comment by ID.
@@ -312,7 +332,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -332,7 +353,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.list
         * @desc Lists a file's comments.
@@ -349,7 +370,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -369,7 +392,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.comments.update
         * @desc Updates a comment with patch semantics.
@@ -384,7 +407,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -404,7 +429,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -427,7 +452,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    copy(params, options, callback) {
+    copy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -447,7 +474,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.create
         * @desc Creates a new file.
@@ -468,7 +495,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -489,7 +518,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.delete
         * @desc Permanently deletes a file owned by the user without moving it
@@ -506,7 +535,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -526,7 +557,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.emptyTrash
         * @desc Permanently deletes all of the user's trashed files.
@@ -538,7 +569,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    emptyTrash(params, options, callback) {
+    emptyTrash(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -558,7 +591,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.export
         * @desc Exports a Google Doc to the requested MIME type and returns the
@@ -574,7 +607,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    export(params, options, callback) {
+    export(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -594,7 +629,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.generateIds
         * @desc Generates a set of file IDs which can be provided in create
@@ -609,7 +644,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generateIds(params, options, callback) {
+    generateIds(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -629,7 +666,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.get
         * @desc Gets a file's metadata or content by ID.
@@ -644,7 +681,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -664,7 +702,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.list
         * @desc Lists or searches files.
@@ -686,7 +724,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -705,7 +745,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.update
         * @desc Updates a file's metadata and/or content with patch semantics.
@@ -728,7 +768,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -750,7 +792,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.files.watch
         * @desc Subscribes to changes to a file
@@ -766,7 +808,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watch(params, options, callback) {
+    watch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -786,7 +830,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -809,7 +853,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -829,7 +875,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.delete
         * @desc Deletes a permission.
@@ -845,7 +891,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -866,7 +914,7 @@ function Drive(options) {
         pathParams: ['fileId', 'permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.get
         * @desc Gets a permission by ID.
@@ -882,7 +930,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -903,7 +952,7 @@ function Drive(options) {
         pathParams: ['fileId', 'permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.list
         * @desc Lists a file's or Team Drive's permissions.
@@ -920,7 +969,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -940,7 +991,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.permissions.update
         * @desc Updates a permission with patch semantics.
@@ -959,7 +1010,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -980,7 +1033,7 @@ function Drive(options) {
         pathParams: ['fileId', 'permissionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -999,7 +1052,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1020,7 +1075,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.delete
         * @desc Deletes a reply.
@@ -1035,7 +1090,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1057,7 +1114,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId', 'replyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.get
         * @desc Gets a reply by ID.
@@ -1073,7 +1130,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1095,7 +1153,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId', 'replyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.list
         * @desc Lists a comment's replies.
@@ -1112,7 +1170,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1133,7 +1193,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.replies.update
         * @desc Updates a reply with patch semantics.
@@ -1149,7 +1209,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1171,7 +1233,7 @@ function Drive(options) {
         pathParams: ['commentId', 'fileId', 'replyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1190,7 +1252,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1210,7 +1274,7 @@ function Drive(options) {
         pathParams: ['fileId', 'revisionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.revisions.get
         * @desc Gets a revision's metadata or content by ID.
@@ -1225,7 +1289,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1245,7 +1310,7 @@ function Drive(options) {
         pathParams: ['fileId', 'revisionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.revisions.list
         * @desc Lists a file's revisions.
@@ -1260,7 +1325,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1280,7 +1347,7 @@ function Drive(options) {
         pathParams: ['fileId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.revisions.update
         * @desc Updates a revision with patch semantics.
@@ -1295,7 +1362,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1315,7 +1384,7 @@ function Drive(options) {
         pathParams: ['fileId', 'revisionId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1333,7 +1402,9 @@ function Drive(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1353,7 +1424,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.delete
         * @desc Permanently deletes a Team Drive for which the user is an
@@ -1367,7 +1438,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1387,7 +1460,7 @@ function Drive(options) {
         pathParams: ['teamDriveId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.get
         * @desc Gets a Team Drive's metadata by ID.
@@ -1401,7 +1474,8 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1421,7 +1495,7 @@ function Drive(options) {
         pathParams: ['teamDriveId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.list
         * @desc Lists the user's Team Drives.
@@ -1437,7 +1511,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1457,7 +1533,7 @@ function Drive(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * drive.teamdrives.update
         * @desc Updates a Team Drive's metadata
@@ -1471,7 +1547,9 @@ function Drive(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1491,7 +1569,7 @@ function Drive(options) {
         pathParams: ['teamDriveId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/firebasedynamiclinks/v1.ts
+++ b/src/apis/firebasedynamiclinks/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Firebase Dynamic Links API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Firebasedynamiclinks
  */
-function Firebasedynamiclinks(options) {
+function Firebasedynamiclinks(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.shortLinks = {
@@ -52,7 +59,9 @@ function Firebasedynamiclinks(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Firebasedynamiclinks(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -92,7 +101,9 @@ function Firebasedynamiclinks(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getLinkStats(params, options, callback) {
+    getLinkStats(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -113,7 +124,7 @@ function Firebasedynamiclinks(options) {
         pathParams: ['dynamicLink'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * firebasedynamiclinks.installAttribution
         * @desc Get iOS strong/weak-match info for post-install attribution.
@@ -126,7 +137,9 @@ function Firebasedynamiclinks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    installAttribution(params, options, callback) {
+    installAttribution(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +160,7 @@ function Firebasedynamiclinks(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/firebaserules/v1.ts
+++ b/src/apis/firebaserules/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Firebase Rules API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Firebaserules
  */
-function Firebaserules(options) {
+function Firebaserules(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -61,7 +68,9 @@ function Firebaserules(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    test(params, options, callback) {
+    test(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -81,7 +90,7 @@ function Firebaserules(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     releases: {
       /**
@@ -112,7 +121,9 @@ function Firebaserules(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -133,7 +144,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.releases.delete
           * @desc Delete a `Release` by resource name.
@@ -146,7 +157,9 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -166,7 +179,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.releases.get
           * @desc Get a `Release` by name.
@@ -179,7 +192,8 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -199,7 +213,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.releases.getExecutable
           * @desc Get the `Release` executable to use when enforcing rules.
@@ -213,7 +227,9 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getExecutable(params, options, callback) {
+      getExecutable(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -234,7 +250,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.releases.list
           * @desc List the `Release` values for a project. This list may
@@ -252,7 +268,9 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -273,7 +291,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.releases.patch
           * @desc Update a `Release` via PATCH.  Only updates to the
@@ -290,7 +308,9 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -310,7 +330,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -332,7 +352,9 @@ function Firebaserules(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -353,7 +375,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.rulesets.delete
           * @desc Delete a `Ruleset` by resource name.  If the `Ruleset` is
@@ -367,7 +389,9 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -387,7 +411,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.rulesets.get
           * @desc Get a `Ruleset` by name including the full `Source` contents.
@@ -400,7 +424,8 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -420,7 +445,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * firebaserules.projects.rulesets.list
           * @desc List `Ruleset` metadata only and optionally filter the results
@@ -438,7 +463,9 @@ function Firebaserules(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -459,7 +486,7 @@ function Firebaserules(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/firestore/v1beta1.ts
+++ b/src/apis/firestore/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Firestore API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Firestore
  */
-function Firestore(options) {
+function Firestore(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -52,7 +59,9 @@ function Firestore(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        batchGet(params, options, callback) {
+        batchGet(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -73,7 +82,7 @@ function Firestore(options) {
             pathParams: ['database'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.beginTransaction
             * @desc Starts a new transaction.
@@ -87,7 +96,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        beginTransaction(params, options, callback) {
+        beginTransaction(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -109,7 +120,7 @@ function Firestore(options) {
             pathParams: ['database'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.commit
             * @desc Commits a transaction, while optionally updating documents.
@@ -123,7 +134,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        commit(params, options, callback) {
+        commit(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -144,7 +157,7 @@ function Firestore(options) {
             pathParams: ['database'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.createDocument
             * @desc Creates a new document.
@@ -161,7 +174,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        createDocument(params, options, callback) {
+        createDocument(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -182,7 +197,7 @@ function Firestore(options) {
             pathParams: ['collectionId', 'parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.delete
             * @desc Deletes a document.
@@ -197,7 +212,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -218,7 +235,7 @@ function Firestore(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.get
             * @desc Gets a single document.
@@ -234,7 +251,8 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -255,7 +273,7 @@ function Firestore(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.list
             * @desc Lists documents.
@@ -276,7 +294,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -297,7 +317,7 @@ function Firestore(options) {
             pathParams: ['collectionId', 'parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.listCollectionIds
             * @desc Lists all the collection IDs underneath a document.
@@ -311,7 +331,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listCollectionIds(params, options, callback) {
+        listCollectionIds(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -332,7 +354,7 @@ function Firestore(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.listen
             * @desc Listens to changes.
@@ -346,7 +368,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        listen(params, options, callback) {
+        listen(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -367,7 +391,7 @@ function Firestore(options) {
             pathParams: ['database'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.patch
             * @desc Updates or inserts a document.
@@ -385,7 +409,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -406,7 +432,7 @@ function Firestore(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.rollback
             * @desc Rolls back a transaction.
@@ -420,7 +446,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        rollback(params, options, callback) {
+        rollback(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -441,7 +469,7 @@ function Firestore(options) {
             pathParams: ['database'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.runQuery
             * @desc Runs a query.
@@ -455,7 +483,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        runQuery(params, options, callback) {
+        runQuery(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -476,7 +506,7 @@ function Firestore(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.documents.write
             * @desc Streams batches of document updates and deletes, in order.
@@ -490,7 +520,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        write(params, options, callback) {
+        write(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -511,7 +543,7 @@ function Firestore(options) {
             pathParams: ['database'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -537,7 +569,9 @@ function Firestore(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -558,7 +592,7 @@ function Firestore(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.indexes.delete
             * @desc Deletes an index.
@@ -571,7 +605,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -592,7 +628,7 @@ function Firestore(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.indexes.get
             * @desc Gets an index.
@@ -605,7 +641,8 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -626,7 +663,7 @@ function Firestore(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * firestore.projects.databases.indexes.list
             * @desc Lists the indexes that match the specified filters.
@@ -642,7 +679,9 @@ function Firestore(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -663,7 +702,7 @@ function Firestore(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/fitness/v1.ts
+++ b/src/apis/fitness/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Fitness
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Fitness
  */
-function Fitness(options) {
+function Fitness(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.users = {
@@ -52,7 +59,9 @@ function Fitness(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      aggregate(params, options, callback) {
+      aggregate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -72,7 +81,7 @@ function Fitness(options) {
           pathParams: ['userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -97,7 +106,9 @@ function Fitness(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -117,7 +128,7 @@ function Fitness(options) {
           pathParams: ['userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * fitness.users.dataSources.delete
           * @desc Deletes the specified data source. The request will fail if
@@ -132,7 +143,9 @@ function Fitness(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -153,7 +166,7 @@ function Fitness(options) {
           pathParams: ['dataSourceId', 'userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * fitness.users.dataSources.get
           * @desc Returns the specified data source.
@@ -167,7 +180,8 @@ function Fitness(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -188,7 +202,7 @@ function Fitness(options) {
           pathParams: ['dataSourceId', 'userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * fitness.users.dataSources.list
           * @desc Lists all data sources that are visible to the developer,
@@ -205,7 +219,9 @@ function Fitness(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -225,7 +241,7 @@ function Fitness(options) {
           pathParams: ['userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * fitness.users.dataSources.patch
           * @desc Updates the specified data source. The dataStreamId, dataType,
@@ -243,7 +259,9 @@ function Fitness(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -264,7 +282,7 @@ function Fitness(options) {
           pathParams: ['dataSourceId', 'userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * fitness.users.dataSources.update
           * @desc Updates the specified data source. The dataStreamId, dataType,
@@ -282,7 +300,9 @@ function Fitness(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -303,7 +323,7 @@ function Fitness(options) {
           pathParams: ['dataSourceId', 'userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       dataPointChanges: {
         /**
@@ -322,7 +342,9 @@ function Fitness(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -344,7 +366,7 @@ function Fitness(options) {
             pathParams: ['dataSourceId', 'userId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -371,7 +393,9 @@ function Fitness(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -393,7 +417,7 @@ function Fitness(options) {
             pathParams: ['datasetId', 'dataSourceId', 'userId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * fitness.users.dataSources.datasets.get
             * @desc Returns a dataset containing all data points whose start and
@@ -414,7 +438,8 @@ function Fitness(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -436,7 +461,7 @@ function Fitness(options) {
             pathParams: ['datasetId', 'dataSourceId', 'userId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * fitness.users.dataSources.datasets.patch
             * @desc Adds data points to a dataset. The dataset need not be
@@ -457,7 +482,9 @@ function Fitness(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -479,7 +506,7 @@ function Fitness(options) {
             pathParams: ['datasetId', 'dataSourceId', 'userId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -499,7 +526,9 @@ function Fitness(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -520,7 +549,7 @@ function Fitness(options) {
           pathParams: ['sessionId', 'userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * fitness.users.sessions.list
           * @desc Lists sessions previously created.
@@ -537,7 +566,9 @@ function Fitness(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -557,7 +588,7 @@ function Fitness(options) {
           pathParams: ['userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * fitness.users.sessions.update
           * @desc Updates or insert a given session.
@@ -573,7 +604,9 @@ function Fitness(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -594,7 +627,7 @@ function Fitness(options) {
           pathParams: ['sessionId', 'userId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/fusiontables/v1.ts
+++ b/src/apis/fusiontables/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Fusion Tables API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Fusiontables
  */
-function Fusiontables(options) {
+function Fusiontables(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.column = {
@@ -48,7 +55,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.get
         * @desc Retrieves a specific column by its id.
@@ -83,7 +92,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +114,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.insert
         * @desc Adds a new column to the table.
@@ -118,7 +128,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +150,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.list
         * @desc Retrieves a list of columns.
@@ -153,7 +165,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +187,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.patch
         * @desc Updates the name or type of an existing column. This method
@@ -189,7 +203,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -210,7 +226,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.update
         * @desc Updates the name or type of an existing column.
@@ -225,7 +241,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -246,7 +264,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -266,7 +284,8 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    sql(params, options, callback) {
+    sql(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -286,7 +305,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.query.sqlGet
         * @desc Executes an SQL SELECT/SHOW/DESCRIBE statement.
@@ -301,7 +320,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    sqlGet(params, options, callback) {
+    sqlGet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -321,7 +342,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -339,7 +360,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -360,7 +383,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.get
         * @desc Gets a specific style.
@@ -374,7 +397,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -395,7 +419,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.insert
         * @desc Adds a new style for the table.
@@ -409,7 +433,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -429,7 +455,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.list
         * @desc Retrieves a list of styles.
@@ -444,7 +470,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -464,7 +492,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.patch
         * @desc Updates an existing style. This method supports patch semantics.
@@ -479,7 +507,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -500,7 +530,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.update
         * @desc Updates an existing style.
@@ -515,7 +545,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -536,7 +568,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -554,7 +586,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    copy(params, options, callback) {
+    copy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -574,7 +608,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.delete
         * @desc Deletes a table.
@@ -587,7 +621,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -607,7 +643,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.get
         * @desc Retrieves a specific table by its id.
@@ -620,7 +656,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -640,7 +677,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.importRows
         * @desc Import more rows into a table.
@@ -661,7 +698,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    importRows(params, options, callback) {
+    importRows(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -683,7 +722,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.importTable
         * @desc Import a new table.
@@ -701,7 +740,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    importTable(params, options, callback) {
+    importTable(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -723,7 +764,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.insert
         * @desc Creates a new table.
@@ -736,7 +777,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -756,7 +799,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.list
         * @desc Retrieves a list of tables a user owns.
@@ -770,7 +813,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -790,7 +835,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.patch
         * @desc Updates an existing table. Unless explicitly requested, only the
@@ -807,7 +852,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -827,7 +874,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.update
         * @desc Updates an existing table. Unless explicitly requested, only the
@@ -843,7 +890,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -863,7 +912,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -881,7 +930,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -902,7 +953,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'taskId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.task.get
         * @desc Retrieves a specific task by its id.
@@ -916,7 +967,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -937,7 +989,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'taskId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.task.list
         * @desc Retrieves a list of tasks.
@@ -953,7 +1005,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -973,7 +1027,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -991,7 +1045,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1012,7 +1068,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.get
         * @desc Retrieves a specific template by its id
@@ -1026,7 +1082,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1047,7 +1104,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.insert
         * @desc Creates a new template for the table.
@@ -1061,7 +1118,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1081,7 +1140,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.list
         * @desc Retrieves a list of templates.
@@ -1096,7 +1155,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1116,7 +1177,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.patch
         * @desc Updates an existing template. This method supports patch
@@ -1132,7 +1193,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1153,7 +1216,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.update
         * @desc Updates an existing template
@@ -1168,7 +1231,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1189,7 +1254,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/fusiontables/v2.ts
+++ b/src/apis/fusiontables/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Fusion Tables API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Fusiontables
  */
-function Fusiontables(options) {
+function Fusiontables(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.column = {
@@ -48,7 +55,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.get
         * @desc Retrieves a specific column by its ID.
@@ -83,7 +92,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +114,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.insert
         * @desc Adds a new column to the table.
@@ -118,7 +128,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +150,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.list
         * @desc Retrieves a list of columns.
@@ -153,7 +165,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +187,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.patch
         * @desc Updates the name or type of an existing column. This method
@@ -189,7 +203,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -210,7 +226,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.column.update
         * @desc Updates the name or type of an existing column.
@@ -225,7 +241,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -246,7 +264,7 @@ function Fusiontables(options) {
         pathParams: ['columnId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -266,7 +284,8 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    sql(params, options, callback) {
+    sql(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -286,7 +305,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.query.sqlGet
         * @desc Executes a SQL statement which can be any of  - SELECT - SHOW -
@@ -302,7 +321,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    sqlGet(params, options, callback) {
+    sqlGet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -322,7 +343,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -340,7 +361,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -361,7 +384,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.get
         * @desc Gets a specific style.
@@ -375,7 +398,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -396,7 +420,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.insert
         * @desc Adds a new style for the table.
@@ -410,7 +434,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -430,7 +456,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.list
         * @desc Retrieves a list of styles.
@@ -445,7 +471,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -465,7 +493,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.patch
         * @desc Updates an existing style. This method supports patch semantics.
@@ -480,7 +508,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -501,7 +531,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.style.update
         * @desc Updates an existing style.
@@ -516,7 +546,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -537,7 +569,7 @@ function Fusiontables(options) {
         pathParams: ['styleId', 'tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -555,7 +587,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    copy(params, options, callback) {
+    copy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -575,7 +609,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.delete
         * @desc Deletes a table.
@@ -588,7 +622,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -608,7 +644,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.get
         * @desc Retrieves a specific table by its ID.
@@ -621,7 +657,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -641,7 +678,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.importRows
         * @desc Imports more rows into a table.
@@ -662,7 +699,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    importRows(params, options, callback) {
+    importRows(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -684,7 +723,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.importTable
         * @desc Imports a new table.
@@ -702,7 +741,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    importTable(params, options, callback) {
+    importTable(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -724,7 +765,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.insert
         * @desc Creates a new table.
@@ -737,7 +778,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -757,7 +800,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.list
         * @desc Retrieves a list of tables a user owns.
@@ -771,7 +814,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -791,7 +836,7 @@ function Fusiontables(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.patch
         * @desc Updates an existing table. Unless explicitly requested, only the
@@ -808,7 +853,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -828,7 +875,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.refetchSheet
         * @desc Replaces rows of the table with the rows of the spreadsheet that
@@ -843,7 +890,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    refetchSheet(params, options, callback) {
+    refetchSheet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -863,7 +912,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.replaceRows
         * @desc Replaces rows of an existing table. Current rows remain visible
@@ -885,7 +934,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    replaceRows(params, options, callback) {
+    replaceRows(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -907,7 +958,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.table.update
         * @desc Updates an existing table. Unless explicitly requested, only the
@@ -923,7 +974,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -943,7 +996,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -962,7 +1015,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -983,7 +1038,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'taskId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.task.get
         * @desc Retrieves a specific task by its ID.
@@ -997,7 +1052,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1018,7 +1074,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'taskId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.task.list
         * @desc Retrieves a list of tasks.
@@ -1034,7 +1090,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1054,7 +1112,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1072,7 +1130,9 @@ function Fusiontables(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1093,7 +1153,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.get
         * @desc Retrieves a specific template by its id
@@ -1107,7 +1167,8 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1128,7 +1189,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.insert
         * @desc Creates a new template for the table.
@@ -1142,7 +1203,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1162,7 +1225,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.list
         * @desc Retrieves a list of templates.
@@ -1177,7 +1240,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1197,7 +1262,7 @@ function Fusiontables(options) {
         pathParams: ['tableId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.patch
         * @desc Updates an existing template. This method supports patch
@@ -1213,7 +1278,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1234,7 +1301,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * fusiontables.template.update
         * @desc Updates an existing template
@@ -1249,7 +1316,9 @@ function Fusiontables(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1270,7 +1339,7 @@ function Fusiontables(options) {
         pathParams: ['tableId', 'templateId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/games/v1.ts
+++ b/src/apis/games/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play Game Services API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Games
  */
-function Games(options) {
+function Games(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.achievementDefinitions = {
@@ -49,7 +56,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -89,7 +98,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    increment(params, options, callback) {
+    increment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +121,7 @@ function Games(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.achievements.list
         * @desc Lists the progress for all your application's achievements for
@@ -128,7 +139,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -148,7 +161,7 @@ function Games(options) {
         pathParams: ['playerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.achievements.reveal
         * @desc Sets the state of the achievement with the given ID to REVEALED
@@ -162,7 +175,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reveal(params, options, callback) {
+    reveal(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -182,7 +197,7 @@ function Games(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.achievements.setStepsAtLeast
         * @desc Sets the steps for the currently authenticated player towards
@@ -199,7 +214,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setStepsAtLeast(params, options, callback) {
+    setStepsAtLeast(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -220,7 +237,7 @@ function Games(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.achievements.unlock
         * @desc Unlocks this achievement for the currently authenticated player.
@@ -233,7 +250,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    unlock(params, options, callback) {
+    unlock(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -253,7 +272,7 @@ function Games(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.achievements.updateMultiple
         * @desc Updates multiple achievements for the currently authenticated
@@ -267,7 +286,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateMultiple(params, options, callback) {
+    updateMultiple(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -287,7 +308,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -308,7 +329,8 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -328,7 +350,7 @@ function Games(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.applications.played
         * @desc Indicate that the the currently authenticated user is playing
@@ -341,7 +363,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    played(params, options, callback) {
+    played(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -361,7 +385,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.applications.verify
         * @desc Verifies the auth token provided with this request is for the
@@ -376,7 +400,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    verify(params, options, callback) {
+    verify(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -396,7 +422,7 @@ function Games(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -416,7 +442,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    listByPlayer(params, options, callback) {
+    listByPlayer(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -435,7 +463,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.events.listDefinitions
         * @desc Returns a list of the event definitions in this application.
@@ -450,7 +478,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listDefinitions(params, options, callback) {
+    listDefinitions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -470,7 +500,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.events.record
         * @desc Records a batch of changes to the number of times events have
@@ -485,7 +515,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    record(params, options, callback) {
+    record(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -504,7 +536,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -522,7 +554,8 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -542,7 +575,7 @@ function Games(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.leaderboards.list
         * @desc Lists all the leaderboard metadata for your application.
@@ -557,7 +590,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -577,7 +612,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -593,7 +628,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getMetagameConfig(params, options, callback) {
+    getMetagameConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -613,7 +650,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.metagame.listCategoriesByPlayer
         * @desc List play data aggregated per category for the player
@@ -631,7 +668,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listCategoriesByPlayer(params, options, callback) {
+    listCategoriesByPlayer(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -652,7 +691,7 @@ function Games(options) {
         pathParams: ['collection', 'playerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -671,7 +710,8 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -691,7 +731,7 @@ function Games(options) {
         pathParams: ['playerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.players.list
         * @desc Get the collection of players for the currently authenticated
@@ -708,7 +748,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -728,7 +770,7 @@ function Games(options) {
         pathParams: ['collection'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -746,7 +788,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    remove(params, options, callback) {
+    remove(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -766,7 +810,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.pushtokens.update
         * @desc Registers a push token for the current user and application.
@@ -779,7 +823,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -799,7 +845,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -820,7 +866,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    claim(params, options, callback) {
+    claim(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -841,7 +889,7 @@ function Games(options) {
         pathParams: ['milestoneId', 'questId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -860,7 +908,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    accept(params, options, callback) {
+    accept(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -880,7 +930,7 @@ function Games(options) {
         pathParams: ['questId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.quests.list
         * @desc Get a list of quests for your application and the currently
@@ -897,7 +947,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -917,7 +969,7 @@ function Games(options) {
         pathParams: ['playerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -934,7 +986,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    check(params, options, callback) {
+    check(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -954,7 +1008,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -973,7 +1027,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -993,7 +1049,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.rooms.decline
         * @desc Decline an invitation to join a room. For internal use by the
@@ -1008,7 +1064,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    decline(params, options, callback) {
+    decline(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1028,7 +1086,7 @@ function Games(options) {
         pathParams: ['roomId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.rooms.dismiss
         * @desc Dismiss an invitation to join a room. For internal use by the
@@ -1042,7 +1100,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    dismiss(params, options, callback) {
+    dismiss(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1062,7 +1122,7 @@ function Games(options) {
         pathParams: ['roomId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.rooms.get
         * @desc Get the data for a room.
@@ -1076,7 +1136,8 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1096,7 +1157,7 @@ function Games(options) {
         pathParams: ['roomId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.rooms.join
         * @desc Join a room. For internal use by the Games SDK only. Calling
@@ -1112,7 +1173,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    join(params, options, callback) {
+    join(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1132,7 +1195,7 @@ function Games(options) {
         pathParams: ['roomId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.rooms.leave
         * @desc Leave a room. For internal use by the Games SDK only. Calling
@@ -1148,7 +1211,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    leave(params, options, callback) {
+    leave(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1168,7 +1233,7 @@ function Games(options) {
         pathParams: ['roomId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.rooms.list
         * @desc Returns invitations to join rooms.
@@ -1183,7 +1248,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1202,7 +1269,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.rooms.reportStatus
         * @desc Updates sent by a client reporting the status of peers in a
@@ -1219,7 +1286,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reportStatus(params, options, callback) {
+    reportStatus(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1239,7 +1308,7 @@ function Games(options) {
         pathParams: ['roomId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1266,7 +1335,8 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1288,7 +1358,7 @@ function Games(options) {
         pathParams: ['leaderboardId', 'playerId', 'timeSpan'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.scores.list
         * @desc Lists the scores in a leaderboard, starting from the top.
@@ -1306,7 +1376,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1328,7 +1400,7 @@ function Games(options) {
         pathParams: ['collection', 'leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.scores.listWindow
         * @desc Lists the scores in a leaderboard around (and including) a
@@ -1349,7 +1421,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listWindow(params, options, callback) {
+    listWindow(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1371,7 +1445,7 @@ function Games(options) {
         pathParams: ['collection', 'leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.scores.submit
         * @desc Submits a score to the specified leaderboard.
@@ -1387,7 +1461,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    submit(params, options, callback) {
+    submit(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1407,7 +1483,7 @@ function Games(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.scores.submitMultiple
         * @desc Submits multiple scores to leaderboards.
@@ -1421,7 +1497,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    submitMultiple(params, options, callback) {
+    submitMultiple(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1441,7 +1519,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1459,7 +1537,8 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1479,7 +1558,7 @@ function Games(options) {
         pathParams: ['snapshotId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.snapshots.list
         * @desc Retrieves a list of snapshots created by your application for
@@ -1496,7 +1575,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1516,7 +1597,7 @@ function Games(options) {
         pathParams: ['playerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1533,7 +1614,9 @@ function Games(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1553,7 +1636,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.create
         * @desc Create a turn-based match.
@@ -1567,7 +1650,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1587,7 +1672,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.decline
         * @desc Decline an invitation to play a turn-based match.
@@ -1601,7 +1686,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    decline(params, options, callback) {
+    decline(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1621,7 +1708,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.dismiss
         * @desc Dismiss a turn-based match from the match list. The match will
@@ -1635,7 +1722,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    dismiss(params, options, callback) {
+    dismiss(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1655,7 +1744,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.finish
         * @desc Finish a turn-based match. Each player should make this call
@@ -1672,7 +1761,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    finish(params, options, callback) {
+    finish(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1692,7 +1783,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.get
         * @desc Get the data for a turn-based match.
@@ -1707,7 +1798,8 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1727,7 +1819,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.join
         * @desc Join a turn-based match.
@@ -1741,7 +1833,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    join(params, options, callback) {
+    join(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1761,7 +1855,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.leave
         * @desc Leave a turn-based match when it is not the current player's
@@ -1776,7 +1870,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    leave(params, options, callback) {
+    leave(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1796,7 +1892,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.leaveTurn
         * @desc Leave a turn-based match during the current player's turn,
@@ -1813,7 +1909,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    leaveTurn(params, options, callback) {
+    leaveTurn(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1833,7 +1931,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.list
         * @desc Returns turn-based matches the player is or was involved in.
@@ -1850,7 +1948,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1870,7 +1970,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.rematch
         * @desc Create a rematch of a match that was previously completed, with
@@ -1888,7 +1988,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    rematch(params, options, callback) {
+    rematch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1908,7 +2010,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.sync
         * @desc Returns turn-based matches the player is or was involved in that
@@ -1928,7 +2030,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    sync(params, options, callback) {
+    sync(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1948,7 +2052,7 @@ function Games(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * games.turnBasedMatches.takeTurn
         * @desc Commit the results of a player turn.
@@ -1963,7 +2067,9 @@ function Games(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    takeTurn(params, options, callback) {
+    takeTurn(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1983,7 +2089,7 @@ function Games(options) {
         pathParams: ['matchId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/gamesConfiguration/v1configuration.ts
+++ b/src/apis/gamesConfiguration/v1configuration.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play Game Services Publishing API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1configuration
  * @param {object=} options Options for Gamesconfiguration
  */
-function Gamesconfiguration(options) {
+function Gamesconfiguration(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.achievementConfigurations = {
@@ -47,7 +54,9 @@ function Gamesconfiguration(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Gamesconfiguration(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.achievementConfigurations.get
         * @desc Retrieves the metadata of the achievement configuration with the
@@ -82,7 +91,8 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -103,7 +113,7 @@ function Gamesconfiguration(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.achievementConfigurations.insert
         * @desc Insert a new achievement configuration in this application.
@@ -117,7 +127,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +151,7 @@ function Gamesconfiguration(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.achievementConfigurations.list
         * @desc Returns a list of the achievement configurations in this
@@ -155,7 +167,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -177,7 +191,7 @@ function Gamesconfiguration(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.achievementConfigurations.patch
         * @desc Update the metadata of the achievement configuration with the
@@ -192,7 +206,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -213,7 +229,7 @@ function Gamesconfiguration(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.achievementConfigurations.update
         * @desc Update the metadata of the achievement configuration with the
@@ -228,7 +244,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -249,7 +267,7 @@ function Gamesconfiguration(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -270,7 +288,9 @@ function Gamesconfiguration(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    upload(params, options, callback) {
+    upload(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -296,7 +316,7 @@ function Gamesconfiguration(options) {
         pathParams: ['imageType', 'resourceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -313,7 +333,9 @@ function Gamesconfiguration(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -334,7 +356,7 @@ function Gamesconfiguration(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.leaderboardConfigurations.get
         * @desc Retrieves the metadata of the leaderboard configuration with the
@@ -348,7 +370,8 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -369,7 +392,7 @@ function Gamesconfiguration(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.leaderboardConfigurations.insert
         * @desc Insert a new leaderboard configuration in this application.
@@ -383,7 +406,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -405,7 +430,7 @@ function Gamesconfiguration(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.leaderboardConfigurations.list
         * @desc Returns a list of the leaderboard configurations in this
@@ -421,7 +446,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -443,7 +470,7 @@ function Gamesconfiguration(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.leaderboardConfigurations.patch
         * @desc Update the metadata of the leaderboard configuration with the
@@ -458,7 +485,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -479,7 +508,7 @@ function Gamesconfiguration(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesConfiguration.leaderboardConfigurations.update
         * @desc Update the metadata of the leaderboard configuration with the
@@ -494,7 +523,9 @@ function Gamesconfiguration(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -515,7 +546,7 @@ function Gamesconfiguration(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/gamesManagement/v1management.ts
+++ b/src/apis/gamesManagement/v1management.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play Game Services Management API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1management
  * @param {object=} options Options for Gamesmanagement
  */
-function Gamesmanagement(options) {
+function Gamesmanagement(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.achievements = {
@@ -49,7 +56,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    reset(params, options, callback) {
+    reset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Gamesmanagement(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.achievements.resetAll
         * @desc Resets all achievements for the currently authenticated player
@@ -84,7 +93,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAll(params, options, callback) {
+    resetAll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +115,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.achievements.resetAllForAllPlayers
         * @desc Resets all draft achievements for all players. This method is
@@ -117,7 +128,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAllForAllPlayers(params, options, callback) {
+    resetAllForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +151,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.achievements.resetForAllPlayers
         * @desc Resets the achievement with the given ID for all players. This
@@ -153,7 +166,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetForAllPlayers(params, options, callback) {
+    resetForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -175,7 +190,7 @@ function Gamesmanagement(options) {
         pathParams: ['achievementId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.achievements.resetMultipleForAllPlayers
         * @desc Resets achievements with the given IDs for all players. This
@@ -190,7 +205,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetMultipleForAllPlayers(params, options, callback) {
+    resetMultipleForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -212,7 +229,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -232,7 +249,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    listHidden(params, options, callback) {
+    listHidden(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -254,7 +273,7 @@ function Gamesmanagement(options) {
         pathParams: ['applicationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -274,7 +293,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    reset(params, options, callback) {
+    reset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -294,7 +315,7 @@ function Gamesmanagement(options) {
         pathParams: ['eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.events.resetAll
         * @desc Resets all player progress on all events for the currently
@@ -309,7 +330,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAll(params, options, callback) {
+    resetAll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -329,7 +352,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.events.resetAllForAllPlayers
         * @desc Resets all draft events for all players. This method is only
@@ -343,7 +366,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAllForAllPlayers(params, options, callback) {
+    resetAllForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -364,7 +389,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.events.resetForAllPlayers
         * @desc Resets the event with the given ID for all players. This method
@@ -380,7 +405,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetForAllPlayers(params, options, callback) {
+    resetForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -401,7 +428,7 @@ function Gamesmanagement(options) {
         pathParams: ['eventId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.events.resetMultipleForAllPlayers
         * @desc Resets events with the given IDs for all players. This method is
@@ -417,7 +444,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetMultipleForAllPlayers(params, options, callback) {
+    resetMultipleForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -438,7 +467,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -458,7 +487,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    hide(params, options, callback) {
+    hide(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -480,7 +511,7 @@ function Gamesmanagement(options) {
         pathParams: ['applicationId', 'playerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.players.unhide
         * @desc Unhide the given player's leaderboard scores from the given
@@ -496,7 +527,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    unhide(params, options, callback) {
+    unhide(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -518,7 +551,7 @@ function Gamesmanagement(options) {
         pathParams: ['applicationId', 'playerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -537,7 +570,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    reset(params, options, callback) {
+    reset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -557,7 +592,7 @@ function Gamesmanagement(options) {
         pathParams: ['questId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.quests.resetAll
         * @desc Resets all player progress on all quests for the currently
@@ -571,7 +606,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAll(params, options, callback) {
+    resetAll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -591,7 +628,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.quests.resetAllForAllPlayers
         * @desc Resets all draft quests for all players. This method is only
@@ -604,7 +641,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAllForAllPlayers(params, options, callback) {
+    resetAllForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -625,7 +664,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.quests.resetForAllPlayers
         * @desc Resets all player progress on the quest with the given ID for
@@ -640,7 +679,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetForAllPlayers(params, options, callback) {
+    resetForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -661,7 +702,7 @@ function Gamesmanagement(options) {
         pathParams: ['questId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.quests.resetMultipleForAllPlayers
         * @desc Resets quests with the given IDs for all players. This method is
@@ -676,7 +717,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetMultipleForAllPlayers(params, options, callback) {
+    resetMultipleForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -697,7 +740,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -715,7 +758,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    reset(params, options, callback) {
+    reset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -735,7 +780,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.rooms.resetForAllPlayers
         * @desc Deletes rooms where the only room participants are from
@@ -749,7 +794,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetForAllPlayers(params, options, callback) {
+    resetForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -769,7 +816,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -788,7 +835,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    reset(params, options, callback) {
+    reset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -810,7 +859,7 @@ function Gamesmanagement(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.scores.resetAll
         * @desc Resets all scores for all leaderboards for the currently
@@ -824,7 +873,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAll(params, options, callback) {
+    resetAll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -844,7 +895,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.scores.resetAllForAllPlayers
         * @desc Resets scores for all draft leaderboards for all players. This
@@ -857,7 +908,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetAllForAllPlayers(params, options, callback) {
+    resetAllForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -878,7 +931,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.scores.resetForAllPlayers
         * @desc Resets scores for the leaderboard with the given ID for all
@@ -893,7 +946,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetForAllPlayers(params, options, callback) {
+    resetForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -915,7 +970,7 @@ function Gamesmanagement(options) {
         pathParams: ['leaderboardId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.scores.resetMultipleForAllPlayers
         * @desc Resets scores for the leaderboards with the given IDs for all
@@ -930,7 +985,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetMultipleForAllPlayers(params, options, callback) {
+    resetMultipleForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -951,7 +1008,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -968,7 +1025,9 @@ function Gamesmanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    reset(params, options, callback) {
+    reset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -988,7 +1047,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * gamesManagement.turnBasedMatches.resetForAllPlayers
         * @desc Deletes turn-based matches where the only match participants are
@@ -1002,7 +1061,9 @@ function Gamesmanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetForAllPlayers(params, options, callback) {
+    resetForAllPlayers(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1023,7 +1084,7 @@ function Gamesmanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/genomics/v1.ts
+++ b/src/apis/genomics/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Genomics API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Genomics
  */
-function Genomics(options) {
+function Genomics(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.annotations = {
@@ -110,7 +117,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchCreate(params, options, callback) {
+    batchCreate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -130,7 +139,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotations.create
         * @desc Creates a new annotation. Caller must have WRITE permission for
@@ -205,7 +214,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -224,7 +235,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotations.delete
         * @desc Deletes an annotation. Caller must have WRITE permission for the
@@ -289,7 +300,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -309,7 +322,7 @@ function Genomics(options) {
         pathParams: ['annotationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotations.get
         * @desc Gets an annotation. Caller must have READ permission for the
@@ -377,7 +390,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -397,7 +411,7 @@ function Genomics(options) {
         pathParams: ['annotationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotations.search
         * @desc Searches for annotations that match the given criteria. Results
@@ -485,7 +499,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -505,7 +521,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotations.update
         * @desc Updates an annotation. Caller must have WRITE permission for the
@@ -581,7 +597,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -601,7 +619,7 @@ function Genomics(options) {
         pathParams: ['annotationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -676,7 +694,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -696,7 +716,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotationsets.delete
         * @desc Deletes an annotation set. Caller must have WRITE permission for
@@ -761,7 +781,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -781,7 +803,7 @@ function Genomics(options) {
         pathParams: ['annotationSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotationsets.get
         * @desc Gets an annotation set. Caller must have READ permission for the
@@ -849,7 +871,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -869,7 +892,7 @@ function Genomics(options) {
         pathParams: ['annotationSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotationsets.search
         * @desc Searches for annotation sets that match the given criteria.
@@ -955,7 +978,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -975,7 +1000,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.annotationsets.update
         * @desc Updates an annotation set. The update must respect all
@@ -1053,7 +1078,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1073,7 +1100,7 @@ function Genomics(options) {
         pathParams: ['annotationSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1146,7 +1173,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1165,7 +1194,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.callsets.delete
         * @desc Deletes a call set.  For the definitions of call sets and other
@@ -1230,7 +1259,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1250,7 +1281,7 @@ function Genomics(options) {
         pathParams: ['callSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.callsets.get
         * @desc Gets a call set by ID.  For the definitions of call sets and
@@ -1318,7 +1349,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1338,7 +1370,7 @@ function Genomics(options) {
         pathParams: ['callSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.callsets.patch
         * @desc Updates a call set.  For the definitions of call sets and other
@@ -1415,7 +1447,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1435,7 +1469,7 @@ function Genomics(options) {
         pathParams: ['callSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.callsets.search
         * @desc Gets a list of call sets matching the criteria.  For the
@@ -1520,7 +1554,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1540,7 +1576,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1613,7 +1649,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1632,7 +1670,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.delete
         * @desc Deletes a dataset and all of its contents (all read group sets,
@@ -1700,7 +1738,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1720,7 +1760,7 @@ function Genomics(options) {
         pathParams: ['datasetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.get
         * @desc Gets a dataset by ID.  For the definitions of datasets and other
@@ -1788,7 +1828,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1808,7 +1849,7 @@ function Genomics(options) {
         pathParams: ['datasetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.getIamPolicy
         * @desc Gets the access control policy for the dataset. This is empty if
@@ -1887,7 +1928,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1907,7 +1950,7 @@ function Genomics(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.list
         * @desc Lists datasets within a project.  For the definitions of
@@ -1987,7 +2030,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2006,7 +2051,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.patch
         * @desc Updates a dataset.  For the definitions of datasets and other
@@ -2083,7 +2128,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2103,7 +2150,7 @@ function Genomics(options) {
         pathParams: ['datasetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.setIamPolicy
         * @desc Sets the access control policy on the specified dataset.
@@ -2182,7 +2229,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2202,7 +2251,7 @@ function Genomics(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -2278,7 +2327,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2298,7 +2349,7 @@ function Genomics(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.datasets.undelete
         * @desc Undeletes a dataset by restoring a dataset which was deleted via
@@ -2374,7 +2425,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    undelete(params, options, callback) {
+    undelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2394,7 +2447,7 @@ function Genomics(options) {
         pathParams: ['datasetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2470,7 +2523,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2490,7 +2545,7 @@ function Genomics(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.operations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -2559,7 +2614,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2578,7 +2634,7 @@ function Genomics(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -2661,7 +2717,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2680,7 +2738,7 @@ function Genomics(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2752,7 +2810,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2772,7 +2832,7 @@ function Genomics(options) {
         pathParams: ['readGroupSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.readgroupsets.export
         * @desc Exports a read group set to a BAM file in Google Cloud Storage.
@@ -2852,7 +2912,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    export(params, options, callback) {
+    export(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2872,7 +2934,7 @@ function Genomics(options) {
         pathParams: ['readGroupSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.readgroupsets.get
         * @desc Gets a read group set by ID.  For the definitions of read group
@@ -2941,7 +3003,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2961,7 +3024,7 @@ function Genomics(options) {
         pathParams: ['readGroupSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.readgroupsets.import
         * @desc Creates read group sets by asynchronously importing the provided
@@ -3040,7 +3103,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    import(params, options, callback) {
+    import(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3060,7 +3125,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.readgroupsets.patch
         * @desc Updates a read group set.  For the definitions of read group
@@ -3140,7 +3205,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3160,7 +3227,7 @@ function Genomics(options) {
         pathParams: ['readGroupSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.readgroupsets.search
         * @desc Searches for read group sets matching the criteria.  For the
@@ -3246,7 +3313,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3266,7 +3335,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     coveragebuckets: {
       /**
@@ -3365,7 +3434,9 @@ function Genomics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3386,7 +3457,7 @@ function Genomics(options) {
           pathParams: ['readGroupSetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -3488,7 +3559,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3507,7 +3580,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3581,7 +3654,8 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3601,7 +3675,7 @@ function Genomics(options) {
         pathParams: ['referenceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.references.search
         * @desc Searches for references which match the given criteria.  For the
@@ -3687,7 +3761,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3707,7 +3783,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     bases: {
       /**
@@ -3795,7 +3871,9 @@ function Genomics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -3815,7 +3893,7 @@ function Genomics(options) {
           pathParams: ['referenceId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -3891,7 +3969,8 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3911,7 +3990,7 @@ function Genomics(options) {
         pathParams: ['referenceSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.referencesets.search
         * @desc Searches for reference sets which match the given criteria.  For
@@ -3997,7 +4076,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4017,7 +4098,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4090,7 +4171,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4109,7 +4192,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variants.delete
         * @desc Deletes a variant.  For the definitions of variants and other
@@ -4174,7 +4257,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4194,7 +4279,7 @@ function Genomics(options) {
         pathParams: ['variantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variants.get
         * @desc Gets a variant by ID.  For the definitions of variants and other
@@ -4262,7 +4347,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4282,7 +4368,7 @@ function Genomics(options) {
         pathParams: ['variantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variants.import
         * @desc Creates variant data by asynchronously importing the provided
@@ -4362,7 +4448,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    import(params, options, callback) {
+    import(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4382,7 +4470,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variants.merge
         * @desc Merges the given variants with existing variants.  For the
@@ -4483,7 +4571,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    merge(params, options, callback) {
+    merge(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4503,7 +4593,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variants.patch
         * @desc Updates a variant.  For the definitions of variants and other
@@ -4581,7 +4671,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4601,7 +4693,7 @@ function Genomics(options) {
         pathParams: ['variantId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variants.search
         * @desc Gets a list of variants matching the criteria.  For the
@@ -4686,7 +4778,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4706,7 +4800,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -4782,7 +4876,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4801,7 +4897,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variantsets.delete
         * @desc Deletes a variant set including all variants, call sets, and
@@ -4868,7 +4964,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4888,7 +4986,7 @@ function Genomics(options) {
         pathParams: ['variantSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variantsets.export
         * @desc Exports variant set data to an external destination.  For the
@@ -4965,7 +5063,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    export(params, options, callback) {
+    export(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -4985,7 +5085,7 @@ function Genomics(options) {
         pathParams: ['variantSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variantsets.get
         * @desc Gets a variant set by ID.  For the definitions of variant sets
@@ -5054,7 +5154,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5074,7 +5175,7 @@ function Genomics(options) {
         pathParams: ['variantSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variantsets.patch
         * @desc Updates a variant set using patch semantics.  For the
@@ -5152,7 +5253,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5172,7 +5275,7 @@ function Genomics(options) {
         pathParams: ['variantSetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.variantsets.search
         * @desc Returns a list of all variant sets matching search criteria.
@@ -5258,7 +5361,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -5278,7 +5383,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/genomics/v1alpha2.ts
+++ b/src/apis/genomics/v1alpha2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Genomics API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1alpha2
  * @param {object=} options Options for Genomics
  */
-function Genomics(options) {
+function Genomics(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -106,7 +113,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -126,7 +135,7 @@ function Genomics(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.operations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -195,7 +204,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -214,7 +224,7 @@ function Genomics(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -297,7 +307,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -316,7 +328,7 @@ function Genomics(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -390,7 +402,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -410,7 +424,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.pipelines.delete
         * @desc Deletes a pipeline based on ID.  Caller must have WRITE
@@ -476,7 +490,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -496,7 +512,7 @@ function Genomics(options) {
         pathParams: ['pipelineId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.pipelines.get
         * @desc Retrieves a pipeline based on ID.  Caller must have READ
@@ -565,7 +581,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -585,7 +602,7 @@ function Genomics(options) {
         pathParams: ['pipelineId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.pipelines.getControllerConfig
         * @desc Gets controller configuration information. Should only be called
@@ -648,7 +665,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getControllerConfig(params, options, callback) {
+    getControllerConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -668,7 +687,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.pipelines.list
         * @desc Lists pipelines.  Caller must have READ permission to the
@@ -749,7 +768,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -769,7 +790,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.pipelines.run
         * @desc Runs a pipeline. If `pipelineId` is specified in the request,
@@ -842,7 +863,8 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    run(params, options, callback) {
+    run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -862,7 +884,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * genomics.pipelines.setOperationStatus
         * @desc Sets status of a given operation. Any new timestamps (as
@@ -931,7 +953,9 @@ function Genomics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setOperationStatus(params, options, callback) {
+    setOperationStatus(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -951,7 +975,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/genomics/v2alpha1.ts
+++ b/src/apis/genomics/v2alpha1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Genomics API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2alpha1
  * @param {object=} options Options for Genomics
  */
-function Genomics(options) {
+function Genomics(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.pipelines = {
@@ -52,7 +59,8 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    run(params, options, callback) {
+    run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +80,7 @@ function Genomics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -95,7 +103,9 @@ function Genomics(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -115,7 +125,7 @@ function Genomics(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * genomics.projects.operations.get
           * @desc Gets the latest state of a long-running operation.  Clients
@@ -130,7 +140,8 @@ function Genomics(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -150,7 +161,7 @@ function Genomics(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * genomics.projects.operations.list
           * @desc Lists operations that match the specified filter in the
@@ -167,7 +178,9 @@ function Genomics(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -187,7 +200,7 @@ function Genomics(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -207,7 +220,9 @@ function Genomics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    checkIn(params, options, callback) {
+    checkIn(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -227,7 +242,7 @@ function Genomics(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/gmail/v1.ts
+++ b/src/apis/gmail/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Gmail API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Gmail
  */
-function Gmail(options) {
+function Gmail(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.users =
@@ -48,7 +55,9 @@ function Gmail(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        getProfile(params, options, callback) {
+        getProfile(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -68,7 +77,7 @@ function Gmail(options) {
             pathParams: ['userId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * gmail.users.stop
             * @desc Stop receiving push notifications for the given user
@@ -82,7 +91,9 @@ function Gmail(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        stop(params, options, callback) {
+        stop(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -102,7 +113,7 @@ function Gmail(options) {
             pathParams: ['userId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * gmail.users.watch
             * @desc Set up or update a push notification watch on the given user
@@ -117,7 +128,9 @@ function Gmail(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        watch(params, options, callback) {
+        watch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -137,7 +150,7 @@ function Gmail(options) {
             pathParams: ['userId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         drafts: {
           /**
@@ -156,7 +169,9 @@ function Gmail(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -178,7 +193,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.drafts.delete
               * @desc Immediately and permanently deletes the specified draft.
@@ -193,7 +208,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -213,7 +230,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.drafts.get
               * @desc Gets the specified draft.
@@ -228,7 +245,8 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -248,7 +266,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.drafts.list
               * @desc Lists the drafts in the user's mailbox.
@@ -265,7 +283,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -285,7 +305,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.drafts.send
               * @desc Sends the specified, existing draft to the recipients in
@@ -303,7 +323,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          send(params, options, callback) {
+          send(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -326,7 +348,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.drafts.update
               * @desc Replaces a draft's content.
@@ -344,7 +366,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -367,7 +391,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -391,7 +415,9 @@ function Gmail(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -411,7 +437,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -429,7 +455,9 @@ function Gmail(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -449,7 +477,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.labels.delete
               * @desc Immediately and permanently deletes the specified label
@@ -465,7 +493,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -485,7 +515,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.labels.get
               * @desc Gets the specified label.
@@ -499,7 +529,8 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -519,7 +550,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.labels.list
               * @desc Lists all labels in the user's mailbox.
@@ -532,7 +563,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -552,7 +585,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.labels.patch
               * @desc Updates the specified label. This method supports patch
@@ -568,7 +601,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -588,7 +623,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.labels.update
               * @desc Updates the specified label.
@@ -603,7 +638,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -623,7 +660,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -642,7 +679,9 @@ function Gmail(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          batchDelete(params, options, callback) {
+          batchDelete(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -663,7 +702,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.batchModify
               * @desc Modifies the labels on the specified messages.
@@ -677,7 +716,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          batchModify(params, options, callback) {
+          batchModify(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -698,7 +739,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.delete
               * @desc Immediately and permanently deletes the specified message.
@@ -713,7 +754,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -733,7 +776,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.get
               * @desc Gets the specified message.
@@ -749,7 +792,8 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -769,7 +813,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.import
               * @desc Imports a message into only this user's mailbox, with
@@ -792,7 +836,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          import(params, options, callback) {
+          import(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -815,7 +861,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.insert
               * @desc Directly inserts a message into only this user's mailbox
@@ -836,7 +882,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          insert(params, options, callback) {
+          insert(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -858,7 +906,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.list
               * @desc Lists the messages in the user's mailbox.
@@ -876,7 +924,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -896,7 +946,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.modify
               * @desc Modifies the labels on the specified message.
@@ -911,7 +961,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          modify(params, options, callback) {
+          modify(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -932,7 +984,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.send
               * @desc Sends the specified message to the recipients in the To,
@@ -950,7 +1002,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          send(params, options, callback) {
+          send(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -973,7 +1027,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.trash
               * @desc Moves the specified message to the trash.
@@ -987,7 +1041,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          trash(params, options, callback) {
+          trash(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1008,7 +1064,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.messages.untrash
               * @desc Removes the specified message from the trash.
@@ -1022,7 +1078,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          untrash(params, options, callback) {
+          untrash(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1043,7 +1101,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           attachments: {
             /**
@@ -1060,7 +1118,8 @@ function Gmail(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1082,7 +1141,7 @@ function Gmail(options) {
                 pathParams: ['id', 'messageId', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -1100,7 +1159,9 @@ function Gmail(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          getAutoForwarding(params, options, callback) {
+          getAutoForwarding(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1121,7 +1182,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.settings.getImap
               * @desc Gets IMAP settings.
@@ -1134,7 +1195,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          getImap(params, options, callback) {
+          getImap(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1154,7 +1217,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.settings.getPop
               * @desc Gets POP settings.
@@ -1167,7 +1230,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          getPop(params, options, callback) {
+          getPop(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1187,7 +1252,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.settings.getVacation
               * @desc Gets vacation responder settings.
@@ -1200,7 +1265,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          getVacation(params, options, callback) {
+          getVacation(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1221,7 +1288,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.settings.updateAutoForwarding
               * @desc Updates the auto-forwarding setting for the specified
@@ -1239,7 +1306,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          updateAutoForwarding(params, options, callback) {
+          updateAutoForwarding(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1260,7 +1329,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.settings.updateImap
               * @desc Updates IMAP settings.
@@ -1274,7 +1343,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          updateImap(params, options, callback) {
+          updateImap(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1294,7 +1365,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.settings.updatePop
               * @desc Updates POP settings.
@@ -1308,7 +1379,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          updatePop(params, options, callback) {
+          updatePop(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1328,7 +1401,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.settings.updateVacation
               * @desc Updates vacation responder settings.
@@ -1342,7 +1415,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          updateVacation(params, options, callback) {
+          updateVacation(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1363,7 +1438,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           filters: {
             /**
@@ -1379,7 +1454,9 @@ function Gmail(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1400,7 +1477,7 @@ function Gmail(options) {
                 pathParams: ['userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.filters.delete
                 * @desc Deletes a filter.
@@ -1414,7 +1491,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1435,7 +1514,7 @@ function Gmail(options) {
                 pathParams: ['id', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.filters.get
                 * @desc Gets a filter.
@@ -1449,7 +1528,8 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1470,7 +1550,7 @@ function Gmail(options) {
                 pathParams: ['id', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.filters.list
                 * @desc Lists the message filters of a Gmail user.
@@ -1483,7 +1563,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1504,7 +1586,7 @@ function Gmail(options) {
                 pathParams: ['userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -1527,7 +1609,9 @@ function Gmail(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1549,7 +1633,7 @@ function Gmail(options) {
                 pathParams: ['userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.forwardingAddresses.delete
                 * @desc Deletes the specified forwarding address and revokes any
@@ -1566,7 +1650,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1588,7 +1674,7 @@ function Gmail(options) {
                 pathParams: ['forwardingEmail', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.forwardingAddresses.get
                 * @desc Gets the specified forwarding address.
@@ -1602,7 +1688,8 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1624,7 +1711,7 @@ function Gmail(options) {
                 pathParams: ['forwardingEmail', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.forwardingAddresses.list
                 * @desc Lists the forwarding addresses for the specified
@@ -1638,7 +1725,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1660,7 +1749,7 @@ function Gmail(options) {
                 pathParams: ['userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -1687,7 +1776,9 @@ function Gmail(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1708,7 +1799,7 @@ function Gmail(options) {
                 pathParams: ['userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.sendAs.delete
                 * @desc Deletes the specified send-as alias. Revokes any
@@ -1725,7 +1816,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1747,7 +1840,7 @@ function Gmail(options) {
                 pathParams: ['sendAsEmail', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.sendAs.get
                 * @desc Gets the specified send-as alias. Fails with an HTTP 404
@@ -1763,7 +1856,8 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1785,7 +1879,7 @@ function Gmail(options) {
                 pathParams: ['sendAsEmail', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.sendAs.list
                 * @desc Lists the send-as aliases for the specified account. The
@@ -1800,7 +1894,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1821,7 +1917,7 @@ function Gmail(options) {
                 pathParams: ['userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.sendAs.patch
                 * @desc Updates a send-as alias. If a signature is provided,
@@ -1841,7 +1937,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1863,7 +1961,7 @@ function Gmail(options) {
                 pathParams: ['sendAsEmail', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.sendAs.update
                 * @desc Updates a send-as alias. If a signature is provided,
@@ -1882,7 +1980,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            update(params, options, callback) {
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1904,7 +2004,7 @@ function Gmail(options) {
                 pathParams: ['sendAsEmail', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * gmail.users.settings.sendAs.verify
                 * @desc Sends a verification email to the specified send-as
@@ -1921,7 +2021,9 @@ function Gmail(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            verify(params, options, callback) {
+            verify(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1943,7 +2045,7 @@ function Gmail(options) {
                 pathParams: ['sendAsEmail', 'userId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             },
             smimeInfo: {
               /**
@@ -1961,7 +2063,9 @@ function Gmail(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -1984,7 +2088,7 @@ function Gmail(options) {
                   pathParams: ['id', 'sendAsEmail', 'userId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * gmail.users.settings.sendAs.smimeInfo.get
                   * @desc Gets the specified S/MIME config for the specified
@@ -2000,7 +2104,8 @@ function Gmail(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2023,7 +2128,7 @@ function Gmail(options) {
                   pathParams: ['id', 'sendAsEmail', 'userId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * gmail.users.settings.sendAs.smimeInfo.insert
                   * @desc Insert (upload) the given S/MIME config for the
@@ -2040,7 +2145,9 @@ function Gmail(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              insert(params, options, callback) {
+              insert(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2063,7 +2170,7 @@ function Gmail(options) {
                   pathParams: ['sendAsEmail', 'userId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * gmail.users.settings.sendAs.smimeInfo.list
                   * @desc Lists S/MIME configs for the specified send-as alias.
@@ -2077,7 +2184,9 @@ function Gmail(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2100,7 +2209,7 @@ function Gmail(options) {
                   pathParams: ['sendAsEmail', 'userId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * gmail.users.settings.sendAs.smimeInfo.setDefault
                   * @desc Sets the default S/MIME config for the specified
@@ -2116,7 +2225,9 @@ function Gmail(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              setDefault(params, options, callback) {
+              setDefault(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -2139,7 +2250,7 @@ function Gmail(options) {
                   pathParams: ['id', 'sendAsEmail', 'userId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }
 
             }
@@ -2160,7 +2271,9 @@ function Gmail(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2180,7 +2293,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.threads.get
               * @desc Gets the specified thread.
@@ -2196,7 +2309,8 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2216,7 +2330,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.threads.list
               * @desc Lists the threads in the user's mailbox.
@@ -2234,7 +2348,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2254,7 +2370,7 @@ function Gmail(options) {
               pathParams: ['userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.threads.modify
               * @desc Modifies the labels applied to the thread. This applies to
@@ -2270,7 +2386,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          modify(params, options, callback) {
+          modify(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2291,7 +2409,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.threads.trash
               * @desc Moves the specified thread to the trash.
@@ -2305,7 +2423,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          trash(params, options, callback) {
+          trash(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2326,7 +2446,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * gmail.users.threads.untrash
               * @desc Removes the specified thread from the trash.
@@ -2340,7 +2460,9 @@ function Gmail(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          untrash(params, options, callback) {
+          untrash(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2361,7 +2483,7 @@ function Gmail(options) {
               pathParams: ['id', 'userId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }

--- a/src/apis/groupsmigration/v1.ts
+++ b/src/apis/groupsmigration/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Groups Migration API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Groupsmigration
  */
-function Groupsmigration(options) {
+function Groupsmigration(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.archive = {
@@ -50,7 +57,9 @@ function Groupsmigration(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Groupsmigration(options) {
         pathParams: ['groupId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/groupssettings/v1.ts
+++ b/src/apis/groupssettings/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Groups Settings API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Groupssettings
  */
-function Groupssettings(options) {
+function Groupssettings(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.groups = {
@@ -47,7 +54,8 @@ function Groupssettings(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Groupssettings(options) {
         pathParams: ['groupUniqueId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * groupsSettings.groups.patch
         * @desc Updates an existing resource. This method supports patch
@@ -82,7 +90,9 @@ function Groupssettings(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +112,7 @@ function Groupssettings(options) {
         pathParams: ['groupUniqueId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * groupsSettings.groups.update
         * @desc Updates an existing resource.
@@ -116,7 +126,9 @@ function Groupssettings(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -136,7 +148,7 @@ function Groupssettings(options) {
         pathParams: ['groupUniqueId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/iam/v1.ts
+++ b/src/apis/iam/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Identity and Access Management (IAM) API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Iam
  */
-function Iam(options) {
+function Iam(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.iamPolicies = {
@@ -50,7 +57,9 @@ function Iam(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    queryAuditableServices(params, options, callback) {
+    queryAuditableServices(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Iam(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -89,7 +98,9 @@ function Iam(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -109,7 +120,7 @@ function Iam(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * iam.organizations.roles.delete
           * @desc Soft deletes a role. The role is suspended and cannot be used
@@ -129,7 +140,9 @@ function Iam(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -148,7 +161,7 @@ function Iam(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * iam.organizations.roles.get
           * @desc Gets a Role definition.
@@ -161,7 +174,8 @@ function Iam(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -180,7 +194,7 @@ function Iam(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * iam.organizations.roles.list
           * @desc Lists the Roles defined on a resource.
@@ -197,7 +211,9 @@ function Iam(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -217,7 +233,7 @@ function Iam(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * iam.organizations.roles.patch
           * @desc Updates a Role definition.
@@ -232,7 +248,9 @@ function Iam(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -251,7 +269,7 @@ function Iam(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * iam.organizations.roles.undelete
           * @desc Undelete a Role, bringing it back in its previous state.
@@ -265,7 +283,9 @@ function Iam(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      undelete(params, options, callback) {
+      undelete(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -285,7 +305,7 @@ function Iam(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -304,7 +324,9 @@ function Iam(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    queryTestablePermissions(params, options, callback) {
+    queryTestablePermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -324,7 +346,7 @@ function Iam(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -344,7 +366,9 @@ function Iam(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -364,7 +388,7 @@ function Iam(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.roles.delete
               * @desc Soft deletes a role. The role is suspended and cannot be
@@ -384,7 +408,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -403,7 +429,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.roles.get
               * @desc Gets a Role definition.
@@ -416,7 +442,8 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -435,7 +462,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.roles.list
               * @desc Lists the Roles defined on a resource.
@@ -452,7 +479,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -472,7 +501,7 @@ function Iam(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.roles.patch
               * @desc Updates a Role definition.
@@ -487,7 +516,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -506,7 +537,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.roles.undelete
               * @desc Undelete a Role, bringing it back in its previous state.
@@ -520,7 +551,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          undelete(params, options, callback) {
+          undelete(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -540,7 +573,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -558,7 +591,9 @@ function Iam(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -578,7 +613,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.delete
               * @desc Deletes a ServiceAccount.
@@ -591,7 +626,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -610,7 +647,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.get
               * @desc Gets a ServiceAccount.
@@ -623,7 +660,8 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -642,7 +680,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.getIamPolicy
               * @desc Returns the IAM access control policy for a
@@ -656,7 +694,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          getIamPolicy(params, options, callback) {
+          getIamPolicy(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -676,7 +716,7 @@ function Iam(options) {
               pathParams: ['resource'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.list
               * @desc Lists ServiceAccounts for a project.
@@ -691,7 +731,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -711,7 +753,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.setIamPolicy
               * @desc Sets the IAM access control policy for a ServiceAccount.
@@ -725,7 +767,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          setIamPolicy(params, options, callback) {
+          setIamPolicy(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -745,7 +789,7 @@ function Iam(options) {
               pathParams: ['resource'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.signBlob
               * @desc Signs a blob using a service account's system-managed
@@ -760,7 +804,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          signBlob(params, options, callback) {
+          signBlob(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -780,7 +826,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.signJwt
               * @desc Signs a JWT using a service account's system-managed
@@ -798,7 +844,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          signJwt(params, options, callback) {
+          signJwt(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -818,7 +866,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.testIamPermissions
               * @desc Tests the specified permissions against the IAM access
@@ -833,7 +881,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          testIamPermissions(params, options, callback) {
+          testIamPermissions(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -853,7 +903,7 @@ function Iam(options) {
               pathParams: ['resource'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * iam.projects.serviceAccounts.update
               * @desc Updates a ServiceAccount.  Currently, only the following
@@ -868,7 +918,9 @@ function Iam(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -887,7 +939,7 @@ function Iam(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           keys: {
             /**
@@ -903,7 +955,9 @@ function Iam(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -923,7 +977,7 @@ function Iam(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * iam.projects.serviceAccounts.keys.delete
                 * @desc Deletes a ServiceAccountKey.
@@ -936,7 +990,9 @@ function Iam(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -956,7 +1012,7 @@ function Iam(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * iam.projects.serviceAccounts.keys.get
                 * @desc Gets the ServiceAccountKey by key id.
@@ -970,7 +1026,8 @@ function Iam(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -990,7 +1047,7 @@ function Iam(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * iam.projects.serviceAccounts.keys.list
                 * @desc Lists ServiceAccountKeys.
@@ -1004,7 +1061,9 @@ function Iam(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1024,7 +1083,7 @@ function Iam(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -1043,7 +1102,8 @@ function Iam(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1062,7 +1122,7 @@ function Iam(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * iam.roles.list
         * @desc Lists the Roles defined on a resource.
@@ -1079,7 +1139,9 @@ function Iam(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1098,7 +1160,7 @@ function Iam(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * iam.roles.queryGrantableRoles
         * @desc Queries roles that can be granted on a particular resource. A
@@ -1113,7 +1175,9 @@ function Iam(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    queryGrantableRoles(params, options, callback) {
+    queryGrantableRoles(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1133,7 +1197,7 @@ function Iam(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/identitytoolkit/v3.ts
+++ b/src/apis/identitytoolkit/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Identity Toolkit API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Identitytoolkit
  */
-function Identitytoolkit(options) {
+function Identitytoolkit(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.relyingparty = {
@@ -47,7 +54,9 @@ function Identitytoolkit(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    createAuthUri(params, options, callback) {
+    createAuthUri(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +76,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.deleteAccount
         * @desc Delete user account.
@@ -80,7 +89,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteAccount(params, options, callback) {
+    deleteAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -100,7 +111,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.downloadAccount
         * @desc Batch download user accounts.
@@ -113,7 +124,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    downloadAccount(params, options, callback) {
+    downloadAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -134,7 +147,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.emailLinkSignin
         * @desc Reset password for a user.
@@ -147,7 +160,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    emailLinkSignin(params, options, callback) {
+    emailLinkSignin(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -168,7 +183,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.getAccountInfo
         * @desc Returns the account info.
@@ -181,7 +196,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getAccountInfo(params, options, callback) {
+    getAccountInfo(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -201,7 +218,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.getOobConfirmationCode
         * @desc Get a code for user action confirmation.
@@ -214,7 +231,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getOobConfirmationCode(params, options, callback) {
+    getOobConfirmationCode(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -235,7 +254,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.getProjectConfig
         * @desc Get project configuration.
@@ -249,7 +268,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getProjectConfig(params, options, callback) {
+    getProjectConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -270,7 +291,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.getPublicKeys
         * @desc Get token signing public key.
@@ -282,7 +303,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getPublicKeys(params, options, callback) {
+    getPublicKeys(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -302,7 +325,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.getRecaptchaParam
         * @desc Get recaptcha secure param.
@@ -314,7 +337,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getRecaptchaParam(params, options, callback) {
+    getRecaptchaParam(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -335,7 +360,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.resetPassword
         * @desc Reset password for a user.
@@ -348,7 +373,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetPassword(params, options, callback) {
+    resetPassword(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -368,7 +395,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.sendVerificationCode
         * @desc Send SMS verification code.
@@ -381,7 +408,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    sendVerificationCode(params, options, callback) {
+    sendVerificationCode(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -402,7 +431,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.setAccountInfo
         * @desc Set account info for a user.
@@ -415,7 +444,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setAccountInfo(params, options, callback) {
+    setAccountInfo(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -435,7 +466,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.setProjectConfig
         * @desc Set project configuration.
@@ -448,7 +479,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setProjectConfig(params, options, callback) {
+    setProjectConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -469,7 +502,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.signOutUser
         * @desc Sign out user.
@@ -482,7 +515,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    signOutUser(params, options, callback) {
+    signOutUser(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -502,7 +537,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.signupNewUser
         * @desc Signup new user.
@@ -515,7 +550,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    signupNewUser(params, options, callback) {
+    signupNewUser(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -535,7 +572,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.uploadAccount
         * @desc Batch upload existing user accounts.
@@ -548,7 +585,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    uploadAccount(params, options, callback) {
+    uploadAccount(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -568,7 +607,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.verifyAssertion
         * @desc Verifies the assertion returned by the IdP.
@@ -581,7 +620,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    verifyAssertion(params, options, callback) {
+    verifyAssertion(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -602,7 +643,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.verifyCustomToken
         * @desc Verifies the developer asserted ID token.
@@ -615,7 +656,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    verifyCustomToken(params, options, callback) {
+    verifyCustomToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -636,7 +679,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.verifyPassword
         * @desc Verifies the user entered password.
@@ -649,7 +692,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    verifyPassword(params, options, callback) {
+    verifyPassword(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -669,7 +714,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * identitytoolkit.relyingparty.verifyPhoneNumber
         * @desc Verifies ownership of a phone number and creates/updates the
@@ -683,7 +728,9 @@ function Identitytoolkit(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    verifyPhoneNumber(params, options, callback) {
+    verifyPhoneNumber(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -704,7 +751,7 @@ function Identitytoolkit(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/kgsearch/v1.ts
+++ b/src/apis/kgsearch/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Knowledge Graph Search API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Kgsearch
  */
-function Kgsearch(options) {
+function Kgsearch(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.entities = {
@@ -55,7 +62,9 @@ function Kgsearch(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -75,7 +84,7 @@ function Kgsearch(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/language/v1.ts
+++ b/src/apis/language/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Natural Language API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Language
  */
-function Language(options) {
+function Language(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.documents = {
@@ -51,7 +58,9 @@ function Language(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    analyzeEntities(params, options, callback) {
+    analyzeEntities(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeEntitySentiment
         * @desc Finds entities, similar to AnalyzeEntities in the text and
@@ -85,7 +94,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeEntitySentiment(params, options, callback) {
+    analyzeEntitySentiment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +116,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeSentiment
         * @desc Analyzes the sentiment of the provided text.
@@ -118,7 +129,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeSentiment(params, options, callback) {
+    analyzeSentiment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +151,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeSyntax
         * @desc Analyzes the syntax of the text and provides sentence boundaries
@@ -153,7 +166,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeSyntax(params, options, callback) {
+    analyzeSyntax(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +188,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.annotateText
         * @desc A convenience method that provides all the features that
@@ -188,7 +203,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    annotateText(params, options, callback) {
+    annotateText(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -208,7 +225,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.classifyText
         * @desc Classifies a document into categories.
@@ -221,7 +238,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    classifyText(params, options, callback) {
+    classifyText(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -241,7 +260,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/language/v1beta1.ts
+++ b/src/apis/language/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Natural Language API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Language
  */
-function Language(options) {
+function Language(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.documents = {
@@ -51,7 +58,9 @@ function Language(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    analyzeEntities(params, options, callback) {
+    analyzeEntities(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeSentiment
         * @desc Analyzes the sentiment of the provided text.
@@ -84,7 +93,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeSentiment(params, options, callback) {
+    analyzeSentiment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +115,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeSyntax
         * @desc Analyzes the syntax of the text and provides sentence boundaries
@@ -119,7 +130,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeSyntax(params, options, callback) {
+    analyzeSyntax(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +152,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.annotateText
         * @desc A convenience method that provides all the features that
@@ -154,7 +167,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    annotateText(params, options, callback) {
+    annotateText(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -174,7 +189,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/language/v1beta2.ts
+++ b/src/apis/language/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Natural Language API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Language
  */
-function Language(options) {
+function Language(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.documents = {
@@ -51,7 +58,9 @@ function Language(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    analyzeEntities(params, options, callback) {
+    analyzeEntities(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeEntitySentiment
         * @desc Finds entities, similar to AnalyzeEntities in the text and
@@ -85,7 +94,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeEntitySentiment(params, options, callback) {
+    analyzeEntitySentiment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +116,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeSentiment
         * @desc Analyzes the sentiment of the provided text.
@@ -118,7 +129,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeSentiment(params, options, callback) {
+    analyzeSentiment(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +151,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.analyzeSyntax
         * @desc Analyzes the syntax of the text and provides sentence boundaries
@@ -153,7 +166,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    analyzeSyntax(params, options, callback) {
+    analyzeSyntax(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +188,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.annotateText
         * @desc A convenience method that provides all syntax, sentiment,
@@ -187,7 +202,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    annotateText(params, options, callback) {
+    annotateText(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +224,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.documents.classifyText
         * @desc Classifies a document into categories.
@@ -220,7 +237,9 @@ function Language(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    classifyText(params, options, callback) {
+    classifyText(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -240,7 +259,7 @@ function Language(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/licensing/v1.ts
+++ b/src/apis/licensing/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Enterprise License Manager API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Licensing
  */
-function Licensing(options) {
+function Licensing(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.licenseAssignments = {
@@ -49,7 +56,9 @@ function Licensing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Licensing(options) {
         pathParams: ['productId', 'skuId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * licensing.licenseAssignments.get
         * @desc Get license assignment of a particular product and sku for a
@@ -87,7 +96,8 @@ function Licensing(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -109,7 +119,7 @@ function Licensing(options) {
         pathParams: ['productId', 'skuId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * licensing.licenseAssignments.insert
         * @desc Assign License.
@@ -124,7 +134,9 @@ function Licensing(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -145,7 +157,7 @@ function Licensing(options) {
         pathParams: ['productId', 'skuId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * licensing.licenseAssignments.listForProduct
         * @desc List license assignments for given product of the customer.
@@ -161,7 +173,9 @@ function Licensing(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listForProduct(params, options, callback) {
+    listForProduct(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -181,7 +195,7 @@ function Licensing(options) {
         pathParams: ['productId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * licensing.licenseAssignments.listForProductAndSku
         * @desc List license assignments for given product and sku of the
@@ -199,7 +213,9 @@ function Licensing(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listForProductAndSku(params, options, callback) {
+    listForProductAndSku(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -220,7 +236,7 @@ function Licensing(options) {
         pathParams: ['productId', 'skuId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * licensing.licenseAssignments.patch
         * @desc Assign License. This method supports patch semantics.
@@ -236,7 +252,9 @@ function Licensing(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -258,7 +276,7 @@ function Licensing(options) {
         pathParams: ['productId', 'skuId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * licensing.licenseAssignments.update
         * @desc Assign License.
@@ -274,7 +292,9 @@ function Licensing(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -296,7 +316,7 @@ function Licensing(options) {
         pathParams: ['productId', 'skuId', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/logging/v2.ts
+++ b/src/apis/logging/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Stackdriver Logging API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Logging
  */
-function Logging(options) {
+function Logging(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.billingAccounts = {
@@ -51,7 +58,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -71,7 +80,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.exclusions.delete
           * @desc Deletes an exclusion.
@@ -84,7 +93,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -103,7 +114,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.exclusions.get
           * @desc Gets the description of an exclusion.
@@ -116,7 +127,8 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -135,7 +147,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.exclusions.list
           * @desc Lists all the exclusions in a parent resource.
@@ -150,7 +162,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -170,7 +184,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.exclusions.patch
           * @desc Changes one or more properties of an existing exclusion.
@@ -185,7 +199,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -204,7 +220,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -223,7 +239,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -242,7 +260,7 @@ function Logging(options) {
           pathParams: ['logName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.logs.list
           * @desc Lists the logs in projects, organizations, folders, or billing
@@ -258,7 +276,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -278,7 +298,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -301,7 +321,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -321,7 +343,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.sinks.delete
           * @desc Deletes a sink. If the sink has a unique writer_identity, then
@@ -335,7 +357,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -354,7 +378,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.sinks.get
           * @desc Gets a sink.
@@ -367,7 +391,8 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -386,7 +411,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.sinks.list
           * @desc Lists sinks.
@@ -401,7 +426,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -421,7 +448,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.sinks.patch
           * @desc Updates a sink. This method replaces the following fields in
@@ -440,7 +467,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -459,7 +488,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.sinks.update
           * @desc Updates a sink. This method replaces the following fields in
@@ -478,7 +507,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -497,7 +528,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -516,7 +547,9 @@ function Logging(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -535,7 +568,7 @@ function Logging(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.entries.write
         * @desc Log entry resourcesWrites log entries to Stackdriver Logging.
@@ -552,7 +585,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    write(params, options, callback) {
+    write(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -572,7 +607,7 @@ function Logging(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -592,7 +627,9 @@ function Logging(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -612,7 +649,7 @@ function Logging(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.exclusions.delete
         * @desc Deletes an exclusion.
@@ -625,7 +662,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -644,7 +683,7 @@ function Logging(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.exclusions.get
         * @desc Gets the description of an exclusion.
@@ -657,7 +696,8 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -676,7 +716,7 @@ function Logging(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.exclusions.list
         * @desc Lists all the exclusions in a parent resource.
@@ -691,7 +731,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -711,7 +753,7 @@ function Logging(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.exclusions.patch
         * @desc Changes one or more properties of an existing exclusion.
@@ -726,7 +768,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -745,7 +789,7 @@ function Logging(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -766,7 +810,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -786,7 +832,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.exclusions.delete
           * @desc Deletes an exclusion.
@@ -799,7 +845,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -818,7 +866,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.exclusions.get
           * @desc Gets the description of an exclusion.
@@ -831,7 +879,8 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -850,7 +899,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.exclusions.list
           * @desc Lists all the exclusions in a parent resource.
@@ -865,7 +914,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -885,7 +936,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.exclusions.patch
           * @desc Changes one or more properties of an existing exclusion.
@@ -900,7 +951,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -919,7 +972,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -938,7 +991,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -957,7 +1012,7 @@ function Logging(options) {
           pathParams: ['logName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.logs.list
           * @desc Lists the logs in projects, organizations, folders, or billing
@@ -973,7 +1028,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -993,7 +1050,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1016,7 +1073,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1036,7 +1095,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.sinks.delete
           * @desc Deletes a sink. If the sink has a unique writer_identity, then
@@ -1050,7 +1109,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1069,7 +1130,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.sinks.get
           * @desc Gets a sink.
@@ -1082,7 +1143,8 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1101,7 +1163,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.sinks.list
           * @desc Lists sinks.
@@ -1116,7 +1178,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1136,7 +1200,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.sinks.patch
           * @desc Updates a sink. This method replaces the following fields in
@@ -1155,7 +1219,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1174,7 +1240,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.folders.sinks.update
           * @desc Updates a sink. This method replaces the following fields in
@@ -1193,7 +1259,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1212,7 +1280,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1232,7 +1300,9 @@ function Logging(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1251,7 +1321,7 @@ function Logging(options) {
         pathParams: ['logName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.logs.list
         * @desc Lists the logs in projects, organizations, folders, or billing
@@ -1267,7 +1337,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1287,7 +1359,7 @@ function Logging(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1306,7 +1378,9 @@ function Logging(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1326,7 +1400,7 @@ function Logging(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1347,7 +1421,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1367,7 +1443,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.exclusions.delete
           * @desc Deletes an exclusion.
@@ -1380,7 +1456,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1399,7 +1477,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.exclusions.get
           * @desc Gets the description of an exclusion.
@@ -1412,7 +1490,8 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1431,7 +1510,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.exclusions.list
           * @desc Lists all the exclusions in a parent resource.
@@ -1446,7 +1525,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1466,7 +1547,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.exclusions.patch
           * @desc Changes one or more properties of an existing exclusion.
@@ -1481,7 +1562,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1500,7 +1583,7 @@ function Logging(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1519,7 +1602,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1538,7 +1623,7 @@ function Logging(options) {
           pathParams: ['logName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.logs.list
           * @desc Lists the logs in projects, organizations, folders, or billing
@@ -1554,7 +1639,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1574,7 +1661,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1597,7 +1684,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1617,7 +1706,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.sinks.delete
           * @desc Deletes a sink. If the sink has a unique writer_identity, then
@@ -1631,7 +1720,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1650,7 +1741,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.sinks.get
           * @desc Gets a sink.
@@ -1663,7 +1754,8 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1682,7 +1774,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.sinks.list
           * @desc Lists sinks.
@@ -1697,7 +1789,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1717,7 +1811,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.sinks.patch
           * @desc Updates a sink. This method replaces the following fields in
@@ -1736,7 +1830,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1755,7 +1851,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.sinks.update
           * @desc Updates a sink. This method replaces the following fields in
@@ -1774,7 +1870,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1793,7 +1891,7 @@ function Logging(options) {
           pathParams: ['sinkName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -1816,7 +1914,9 @@ function Logging(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1837,7 +1937,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.exclusions.delete
               * @desc Deletes an exclusion.
@@ -1850,7 +1950,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1870,7 +1972,7 @@ function Logging(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.exclusions.get
               * @desc Gets the description of an exclusion.
@@ -1883,7 +1985,8 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1903,7 +2006,7 @@ function Logging(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.exclusions.list
               * @desc Lists all the exclusions in a parent resource.
@@ -1918,7 +2021,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1939,7 +2044,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.exclusions.patch
               * @desc Changes one or more properties of an existing exclusion.
@@ -1954,7 +2059,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1974,7 +2081,7 @@ function Logging(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1993,7 +2100,9 @@ function Logging(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2014,7 +2123,7 @@ function Logging(options) {
               pathParams: ['logName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.logs.list
               * @desc Lists the logs in projects, organizations, folders, or
@@ -2030,7 +2139,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2051,7 +2162,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -2069,7 +2180,9 @@ function Logging(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2090,7 +2203,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.delete
               * @desc Deletes a logs-based metric.
@@ -2103,7 +2216,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2124,7 +2239,7 @@ function Logging(options) {
               pathParams: ['metricName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.get
               * @desc Gets a logs-based metric.
@@ -2137,7 +2252,8 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2158,7 +2274,7 @@ function Logging(options) {
               pathParams: ['metricName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.list
               * @desc Lists logs-based metrics.
@@ -2173,7 +2289,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2194,7 +2312,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.update
               * @desc Creates or updates a logs-based metric.
@@ -2208,7 +2326,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2229,7 +2349,7 @@ function Logging(options) {
               pathParams: ['metricName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -2252,7 +2372,9 @@ function Logging(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2273,7 +2395,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.delete
               * @desc Deletes a sink. If the sink has a unique writer_identity,
@@ -2287,7 +2409,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2308,7 +2432,7 @@ function Logging(options) {
               pathParams: ['sinkName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.get
               * @desc Gets a sink.
@@ -2321,7 +2445,8 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2342,7 +2467,7 @@ function Logging(options) {
               pathParams: ['sinkName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.list
               * @desc Lists sinks.
@@ -2357,7 +2482,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2378,7 +2505,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.patch
               * @desc Updates a sink. This method replaces the following fields
@@ -2397,7 +2524,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2418,7 +2547,7 @@ function Logging(options) {
               pathParams: ['sinkName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.update
               * @desc Updates a sink. This method replaces the following fields
@@ -2437,7 +2566,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2458,7 +2589,7 @@ function Logging(options) {
               pathParams: ['sinkName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }
@@ -2481,7 +2612,9 @@ function Logging(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2501,7 +2634,7 @@ function Logging(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.sinks.delete
         * @desc Deletes a sink. If the sink has a unique writer_identity, then
@@ -2515,7 +2648,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2534,7 +2669,7 @@ function Logging(options) {
         pathParams: ['sinkName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.sinks.get
         * @desc Gets a sink.
@@ -2547,7 +2682,8 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2566,7 +2702,7 @@ function Logging(options) {
         pathParams: ['sinkName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.sinks.list
         * @desc Lists sinks.
@@ -2581,7 +2717,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2601,7 +2739,7 @@ function Logging(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.sinks.update
         * @desc Updates a sink. This method replaces the following fields in the
@@ -2620,7 +2758,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2639,7 +2779,7 @@ function Logging(options) {
         pathParams: ['sinkName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/logging/v2beta1.ts
+++ b/src/apis/logging/v2beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Stackdriver Logging API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2beta1
  * @param {object=} options Options for Logging
  */
-function Logging(options) {
+function Logging(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.billingAccounts = {
@@ -111,7 +118,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -131,7 +140,7 @@ function Logging(options) {
           pathParams: ['logName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.billingAccounts.logs.list
           * @desc Lists the logs in projects, organizations, folders, or billing
@@ -219,7 +228,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -239,7 +250,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -325,7 +336,9 @@ function Logging(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -345,7 +358,7 @@ function Logging(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * logging.entries.write
         * @desc Log entry resourcesWrites log entries to Stackdriver Logging.
@@ -416,7 +429,9 @@ function Logging(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    write(params, options, callback) {
+    write(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -436,7 +451,7 @@ function Logging(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -519,7 +534,9 @@ function Logging(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -539,7 +556,7 @@ function Logging(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -620,7 +637,9 @@ function Logging(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -640,7 +659,7 @@ function Logging(options) {
           pathParams: ['logName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * logging.organizations.logs.list
           * @desc Lists the logs in projects, organizations, folders, or billing
@@ -728,7 +747,9 @@ function Logging(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -748,7 +769,7 @@ function Logging(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -831,7 +852,9 @@ function Logging(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -852,7 +875,7 @@ function Logging(options) {
               pathParams: ['logName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.logs.list
               * @desc Lists the logs in projects, organizations, folders, or
@@ -940,7 +963,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -961,7 +986,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1038,7 +1063,9 @@ function Logging(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1059,7 +1086,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.delete
               * @desc Deletes a logs-based metric.
@@ -1124,7 +1151,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1145,7 +1174,7 @@ function Logging(options) {
               pathParams: ['metricName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.get
               * @desc Gets a logs-based metric.
@@ -1211,7 +1240,8 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1232,7 +1262,7 @@ function Logging(options) {
               pathParams: ['metricName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.list
               * @desc Lists logs-based metrics.
@@ -1316,7 +1346,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1337,7 +1369,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.metrics.update
               * @desc Creates or updates a logs-based metric.
@@ -1414,7 +1446,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1435,7 +1469,7 @@ function Logging(options) {
               pathParams: ['metricName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1521,7 +1555,9 @@ function Logging(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1542,7 +1578,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.delete
               * @desc Deletes a sink. If the sink has a unique writer_identity,
@@ -1614,7 +1650,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1635,7 +1673,7 @@ function Logging(options) {
               pathParams: ['sinkName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.get
               * @desc Gets a sink.
@@ -1707,7 +1745,8 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1728,7 +1767,7 @@ function Logging(options) {
               pathParams: ['sinkName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.list
               * @desc Lists sinks.
@@ -1815,7 +1854,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1836,7 +1877,7 @@ function Logging(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * logging.projects.sinks.update
               * @desc Updates a sink. This method replaces the following fields
@@ -1920,7 +1961,9 @@ function Logging(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1941,7 +1984,7 @@ function Logging(options) {
               pathParams: ['sinkName'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }

--- a/src/apis/manufacturers/v1.ts
+++ b/src/apis/manufacturers/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Manufacturer Center API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Manufacturers
  */
-function Manufacturers(options) {
+function Manufacturers(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -49,7 +56,9 @@ function Manufacturers(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -70,7 +79,7 @@ function Manufacturers(options) {
           pathParams: ['name', 'parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * manufacturers.accounts.products.get
           * @desc Gets the product from a Manufacturer Center account, including
@@ -88,7 +97,8 @@ function Manufacturers(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -109,7 +119,7 @@ function Manufacturers(options) {
           pathParams: ['name', 'parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * manufacturers.accounts.products.list
           * @desc Lists all the products in a Manufacturer Center account.
@@ -124,7 +134,9 @@ function Manufacturers(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -145,7 +157,7 @@ function Manufacturers(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * manufacturers.accounts.products.update
           * @desc Inserts or updates the attributes of the product in a
@@ -172,7 +184,9 @@ function Manufacturers(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -193,7 +207,7 @@ function Manufacturers(options) {
           pathParams: ['name', 'parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/mirror/v1.ts
+++ b/src/apis/mirror/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Mirror API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Mirror
  */
-function Mirror(options) {
+function Mirror(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -50,7 +57,9 @@ function Mirror(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Mirror(options) {
         pathParams: ['accountName', 'accountType', 'userToken'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -89,7 +98,9 @@ function Mirror(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -109,7 +120,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.contacts.get
         * @desc Gets a single contact by ID.
@@ -122,7 +133,8 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -142,7 +154,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.contacts.insert
         * @desc Inserts a new contact.
@@ -155,7 +167,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -175,7 +189,7 @@ function Mirror(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.contacts.list
         * @desc Retrieves a list of contacts for the authenticated user.
@@ -187,7 +201,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +223,7 @@ function Mirror(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.contacts.patch
         * @desc Updates a contact in place. This method supports patch
@@ -222,7 +238,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -242,7 +260,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.contacts.update
         * @desc Updates a contact in place.
@@ -256,7 +274,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -276,7 +296,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -293,7 +313,8 @@ function Mirror(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -313,7 +334,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.locations.list
         * @desc Retrieves a list of locations for the user.
@@ -325,7 +346,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -345,7 +368,7 @@ function Mirror(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -362,7 +385,8 @@ function Mirror(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -382,7 +406,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -399,7 +423,9 @@ function Mirror(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -419,7 +445,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.subscriptions.insert
         * @desc Creates a new subscription.
@@ -432,7 +458,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -452,7 +480,7 @@ function Mirror(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.subscriptions.list
         * @desc Retrieves a list of subscriptions for the authenticated user and
@@ -465,7 +493,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -485,7 +515,7 @@ function Mirror(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.subscriptions.update
         * @desc Updates an existing subscription in place.
@@ -499,7 +529,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -519,7 +551,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -536,7 +568,9 @@ function Mirror(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -556,7 +590,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.timeline.get
         * @desc Gets a single timeline item by ID.
@@ -569,7 +603,8 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -589,7 +624,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.timeline.insert
         * @desc Inserts a new item into the timeline.
@@ -605,7 +640,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -627,7 +664,7 @@ function Mirror(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.timeline.list
         * @desc Retrieves a list of timeline items for the authenticated user.
@@ -646,7 +683,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -666,7 +705,7 @@ function Mirror(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.timeline.patch
         * @desc Updates a timeline item in place. This method supports patch
@@ -681,7 +720,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -701,7 +742,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * mirror.timeline.update
         * @desc Updates a timeline item in place.
@@ -718,7 +759,9 @@ function Mirror(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -740,7 +783,7 @@ function Mirror(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     attachments: {
       /**
@@ -756,7 +799,9 @@ function Mirror(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -777,7 +822,7 @@ function Mirror(options) {
           pathParams: ['attachmentId', 'itemId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * mirror.timeline.attachments.get
           * @desc Retrieves an attachment on a timeline item by item ID and
@@ -792,7 +837,8 @@ function Mirror(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -813,7 +859,7 @@ function Mirror(options) {
           pathParams: ['attachmentId', 'itemId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * mirror.timeline.attachments.insert
           * @desc Adds a new attachment to a timeline item.
@@ -829,7 +875,9 @@ function Mirror(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      insert(params, options, callback) {
+      insert(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -852,7 +900,7 @@ function Mirror(options) {
           pathParams: ['itemId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * mirror.timeline.attachments.list
           * @desc Returns a list of attachments for a timeline item.
@@ -865,7 +913,9 @@ function Mirror(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -885,7 +935,7 @@ function Mirror(options) {
           pathParams: ['itemId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/ml/v1.ts
+++ b/src/apis/ml/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Machine Learning Engine
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Ml
  */
-function Ml(options) {
+function Ml(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -51,7 +58,9 @@ function Ml(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getConfig(params, options, callback) {
+    getConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Ml(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * ml.projects.predict
         * @desc Performs prediction on the data in the request. Cloud ML Engine
@@ -88,7 +97,9 @@ function Ml(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -108,7 +119,7 @@ function Ml(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     jobs: {
       /**
@@ -124,7 +135,9 @@ function Ml(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -144,7 +157,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.jobs.create
           * @desc Creates a training or a batch prediction job.
@@ -158,7 +171,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -178,7 +193,7 @@ function Ml(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.jobs.get
           * @desc Describes a job.
@@ -191,7 +206,8 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -210,7 +226,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.jobs.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -224,7 +240,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -244,7 +262,7 @@ function Ml(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.jobs.list
           * @desc Lists the jobs in the project.  If there are no jobs that
@@ -262,7 +280,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -282,7 +302,7 @@ function Ml(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.jobs.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -297,7 +317,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -317,7 +339,7 @@ function Ml(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.jobs.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -336,7 +358,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -356,7 +380,7 @@ function Ml(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -374,7 +398,8 @@ function Ml(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -393,7 +418,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.locations.list
           * @desc List all locations that provides at least one type of CMLE
@@ -409,7 +434,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -429,7 +456,7 @@ function Ml(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -450,7 +477,9 @@ function Ml(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -470,7 +499,7 @@ function Ml(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.models.delete
           * @desc Deletes a model.  You can only delete a model if there are no
@@ -485,7 +514,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -504,7 +535,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.models.get
           * @desc Gets information about a model, including its name, the
@@ -519,7 +550,8 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -538,7 +570,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.models.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -552,7 +584,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -572,7 +606,7 @@ function Ml(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.models.list
           * @desc Lists the models in a project.  Each project can contain
@@ -591,7 +625,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -611,7 +647,7 @@ function Ml(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.models.patch
           * @desc Updates a specific model resource.  Currently the only
@@ -628,7 +664,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -647,7 +685,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.models.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -662,7 +700,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -682,7 +722,7 @@ function Ml(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.models.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -701,7 +741,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -721,7 +763,7 @@ function Ml(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       versions: {
         /**
@@ -743,7 +785,9 @@ function Ml(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -763,7 +807,7 @@ function Ml(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * ml.projects.models.versions.delete
             * @desc Deletes a model version.  Each model can have multiple
@@ -780,7 +824,9 @@ function Ml(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -799,7 +845,7 @@ function Ml(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * ml.projects.models.versions.get
             * @desc Gets information about a model version.  Models can have
@@ -816,7 +862,8 @@ function Ml(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -835,7 +882,7 @@ function Ml(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * ml.projects.models.versions.list
             * @desc Gets basic information about all the versions of a model.
@@ -856,7 +903,9 @@ function Ml(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -876,7 +925,7 @@ function Ml(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * ml.projects.models.versions.patch
             * @desc Updates the specified Version resource.  Currently the only
@@ -892,7 +941,9 @@ function Ml(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -911,7 +962,7 @@ function Ml(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * ml.projects.models.versions.setDefault
             * @desc Designates a version to be the default for the model.  The
@@ -930,7 +981,9 @@ function Ml(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setDefault(params, options, callback) {
+        setDefault(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -950,7 +1003,7 @@ function Ml(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -976,7 +1029,9 @@ function Ml(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -996,7 +1051,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.operations.delete
           * @desc Deletes a long-running operation. This method indicates that
@@ -1012,7 +1067,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1031,7 +1088,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.operations.get
           * @desc Gets the latest state of a long-running operation.  Clients
@@ -1046,7 +1103,8 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1065,7 +1123,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * ml.projects.operations.list
           * @desc Lists operations that match the specified filter in the
@@ -1090,7 +1148,9 @@ function Ml(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1110,7 +1170,7 @@ function Ml(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/monitoring/v3.ts
+++ b/src/apis/monitoring/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Stackdriver Monitoring API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Monitoring
  */
-function Monitoring(options) {
+function Monitoring(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects =
@@ -100,7 +107,9 @@ function Monitoring(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -121,7 +130,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -184,7 +193,9 @@ function Monitoring(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -205,7 +216,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.groups.delete
               * @desc Deletes an existing group.
@@ -263,7 +274,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -283,7 +296,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.groups.get
               * @desc Gets a single group.
@@ -340,7 +353,8 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -360,7 +374,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.groups.list
               * @desc Lists the existing groups.
@@ -432,7 +446,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -453,7 +469,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.groups.update
               * @desc Updates an existing group. You can change any group
@@ -520,7 +536,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -540,7 +558,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           members: {
             /**
@@ -614,7 +632,9 @@ function Monitoring(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -635,7 +655,7 @@ function Monitoring(options) {
                 pathParams: ['name'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }
@@ -700,7 +720,9 @@ function Monitoring(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -721,7 +743,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.metricDescriptors.delete
               * @desc Deletes a metric descriptor. Only user-created custom
@@ -784,7 +806,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -804,7 +828,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.metricDescriptors.get
               * @desc Gets a single metric descriptor. This method does not
@@ -868,7 +892,8 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -888,7 +913,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.metricDescriptors.list
               * @desc Lists metric descriptors that match a filter. This method
@@ -960,7 +985,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -981,7 +1008,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1048,7 +1075,8 @@ function Monitoring(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1068,7 +1096,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.monitoredResourceDescriptors.list
               * @desc Lists monitored resource descriptors that match a filter.
@@ -1141,7 +1169,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1162,7 +1192,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1228,7 +1258,9 @@ function Monitoring(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1249,7 +1281,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.timeSeries.list
               * @desc Lists time series that match a filter. This method does
@@ -1328,7 +1360,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1349,7 +1383,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -1367,7 +1401,9 @@ function Monitoring(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1388,7 +1424,7 @@ function Monitoring(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.uptimeCheckConfigs.delete
               * @desc Deletes an uptime check configuration. Note that this
@@ -1404,7 +1440,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1424,7 +1462,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.uptimeCheckConfigs.get
               * @desc Gets a single uptime check configuration.
@@ -1437,7 +1475,8 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1457,7 +1496,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.uptimeCheckConfigs.list
               * @desc Lists the existing valid uptime check configurations for
@@ -1473,7 +1512,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1494,7 +1535,7 @@ function Monitoring(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * monitoring.projects.uptimeCheckConfigs.patch
               * @desc Updates an uptime check configuration. You can either
@@ -1513,7 +1554,9 @@ function Monitoring(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -1533,7 +1576,7 @@ function Monitoring(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }
@@ -1552,7 +1595,9 @@ function Monitoring(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1572,7 +1617,7 @@ function Monitoring(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/oauth2/v1.ts
+++ b/src/apis/oauth2/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google OAuth2 API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Oauth2
  */
-function Oauth2(options) {
+function Oauth2(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   /**
@@ -44,27 +51,30 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.getCertForOpenIdConnect = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/oauth2/v1/certs').replace(/([^:]\/)\/+/g, '$1'),
-            method: 'GET'
-          },
-          options),
-      params,
-      requiredParams: [],
-      pathParams: [],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.getCertForOpenIdConnect =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/oauth2/v1/certs')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   /**
    * oauth2.getCertForOpenIdConnectRaw
    * @alias oauth2.getCertForOpenIdConnectRaw
@@ -75,28 +85,30 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.getCertForOpenIdConnectRaw = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/oauth2/v1/raw_public_keys')
-                     .replace(/([^:]\/)\/+/g, '$1'),
-            method: 'GET'
-          },
-          options),
-      params,
-      requiredParams: [],
-      pathParams: [],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.getCertForOpenIdConnectRaw =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/oauth2/v1/raw_public_keys')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   /**
    * oauth2.getRobotJwk
    * @alias oauth2.getRobotJwk
@@ -108,28 +120,30 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.getRobotJwk = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/service_accounts/v1/jwk/{robotEmail}')
-                     .replace(/([^:]\/)\/+/g, '$1'),
-            method: 'GET'
-          },
-          options),
-      params,
-      requiredParams: ['robotEmail'],
-      pathParams: ['robotEmail'],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.getRobotJwk =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/service_accounts/v1/jwk/{robotEmail}')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['robotEmail'],
+          pathParams: ['robotEmail'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   /**
    * oauth2.getRobotMetadataRaw
    * @alias oauth2.getRobotMetadataRaw
@@ -141,28 +155,31 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.getRobotMetadataRaw = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/service_accounts/v1/metadata/raw/{robotEmail}')
-                     .replace(/([^:]\/)\/+/g, '$1'),
-            method: 'GET'
-          },
-          options),
-      params,
-      requiredParams: ['robotEmail'],
-      pathParams: ['robotEmail'],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.getRobotMetadataRaw =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl + '/service_accounts/v1/metadata/raw/{robotEmail}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['robotEmail'],
+          pathParams: ['robotEmail'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   /**
    * oauth2.getRobotMetadataX509
    * @alias oauth2.getRobotMetadataX509
@@ -174,28 +191,31 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.getRobotMetadataX509 = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/service_accounts/v1/metadata/x509/{robotEmail}')
-                     .replace(/([^:]\/)\/+/g, '$1'),
-            method: 'GET'
-          },
-          options),
-      params,
-      requiredParams: ['robotEmail'],
-      pathParams: ['robotEmail'],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.getRobotMetadataX509 =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl +
+                      '/service_accounts/v1/metadata/x509/{robotEmail}')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['robotEmail'],
+          pathParams: ['robotEmail'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   /**
    * oauth2.tokeninfo
    * @desc Get token info
@@ -209,28 +229,30 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.tokeninfo = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/oauth2/v1/tokeninfo')
-                     .replace(/([^:]\/)\/+/g, '$1'),
-            method: 'POST'
-          },
-          options),
-      params,
-      requiredParams: [],
-      pathParams: [],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.tokeninfo =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/oauth2/v1/tokeninfo')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   self.userinfo = {
     /**
      * oauth2.userinfo.get
@@ -243,7 +265,8 @@ function Oauth2(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -263,7 +286,7 @@ function Oauth2(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     v2: {
       me: {
@@ -278,7 +301,8 @@ function Oauth2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -298,7 +322,7 @@ function Oauth2(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/oauth2/v2.ts
+++ b/src/apis/oauth2/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google OAuth2 API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Oauth2
  */
-function Oauth2(options) {
+function Oauth2(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   /**
@@ -44,27 +51,30 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.getCertForOpenIdConnect = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/oauth2/v2/certs').replace(/([^:]\/)\/+/g, '$1'),
-            method: 'GET'
-          },
-          options),
-      params,
-      requiredParams: [],
-      pathParams: [],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.getCertForOpenIdConnect =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/oauth2/v2/certs')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   /**
    * oauth2.tokeninfo
    * @alias oauth2.tokeninfo
@@ -78,28 +88,30 @@ function Oauth2(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.tokeninfo = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/oauth2/v2/tokeninfo')
-                     .replace(/([^:]\/)\/+/g, '$1'),
-            method: 'POST'
-          },
-          options),
-      params,
-      requiredParams: [],
-      pathParams: [],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.tokeninfo =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/oauth2/v2/tokeninfo')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: [],
+          pathParams: [],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   self.userinfo = {
     /**
      * oauth2.userinfo.get
@@ -111,7 +123,8 @@ function Oauth2(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -131,7 +144,7 @@ function Oauth2(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     v2: {
       me: {
@@ -145,7 +158,8 @@ function Oauth2(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -165,7 +179,7 @@ function Oauth2(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/oslogin/v1.ts
+++ b/src/apis/oslogin/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud OS Login API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Oslogin
  */
-function Oslogin(options) {
+function Oslogin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.users = {
@@ -48,7 +55,9 @@ function Oslogin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getLoginProfile(params, options, callback) {
+    getLoginProfile(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Oslogin(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * oslogin.users.importSshPublicKey
         * @desc Adds an SSH public key and returns the profile information.
@@ -85,7 +94,9 @@ function Oslogin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    importSshPublicKey(params, options, callback) {
+    importSshPublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +116,7 @@ function Oslogin(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     projects: {
       /**
@@ -120,7 +131,9 @@ function Oslogin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -139,7 +152,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -156,7 +169,9 @@ function Oslogin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -175,7 +190,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * oslogin.users.sshPublicKeys.get
           * @desc Retrieves an SSH public key.
@@ -188,7 +203,8 @@ function Oslogin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -207,7 +223,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * oslogin.users.sshPublicKeys.patch
           * @desc Updates an SSH public key and returns the profile information.
@@ -223,7 +239,9 @@ function Oslogin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -242,7 +260,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/oslogin/v1alpha.ts
+++ b/src/apis/oslogin/v1alpha.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud OS Login API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1alpha
  * @param {object=} options Options for Oslogin
  */
-function Oslogin(options) {
+function Oslogin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.users = {
@@ -48,7 +55,9 @@ function Oslogin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getLoginProfile(params, options, callback) {
+    getLoginProfile(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Oslogin(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * oslogin.users.importSshPublicKey
         * @desc Adds an SSH public key and returns the profile information.
@@ -85,7 +94,9 @@ function Oslogin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    importSshPublicKey(params, options, callback) {
+    importSshPublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +116,7 @@ function Oslogin(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     projects: {
       /**
@@ -120,7 +131,9 @@ function Oslogin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -140,7 +153,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -157,7 +170,9 @@ function Oslogin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -177,7 +192,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * oslogin.users.sshPublicKeys.get
           * @desc Retrieves an SSH public key.
@@ -190,7 +205,8 @@ function Oslogin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -210,7 +226,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * oslogin.users.sshPublicKeys.patch
           * @desc Updates an SSH public key and returns the profile information.
@@ -226,7 +242,9 @@ function Oslogin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -246,7 +264,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/oslogin/v1beta.ts
+++ b/src/apis/oslogin/v1beta.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud OS Login API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta
  * @param {object=} options Options for Oslogin
  */
-function Oslogin(options) {
+function Oslogin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.users = {
@@ -48,7 +55,9 @@ function Oslogin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getLoginProfile(params, options, callback) {
+    getLoginProfile(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Oslogin(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * oslogin.users.importSshPublicKey
         * @desc Adds an SSH public key and returns the profile information.
@@ -85,7 +94,9 @@ function Oslogin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    importSshPublicKey(params, options, callback) {
+    importSshPublicKey(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +116,7 @@ function Oslogin(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     projects: {
       /**
@@ -120,7 +131,9 @@ function Oslogin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -139,7 +152,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -156,7 +169,9 @@ function Oslogin(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -175,7 +190,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * oslogin.users.sshPublicKeys.get
           * @desc Retrieves an SSH public key.
@@ -188,7 +203,8 @@ function Oslogin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -207,7 +223,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * oslogin.users.sshPublicKeys.patch
           * @desc Updates an SSH public key and returns the profile information.
@@ -223,7 +239,9 @@ function Oslogin(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -242,7 +260,7 @@ function Oslogin(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/pagespeedonline/v1.ts
+++ b/src/apis/pagespeedonline/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * PageSpeed Insights API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Pagespeedonline
  */
-function Pagespeedonline(options) {
+function Pagespeedonline(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.pagespeedapi = {
@@ -55,7 +62,9 @@ function Pagespeedonline(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    runpagespeed(params, options, callback) {
+    runpagespeed(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -75,7 +84,7 @@ function Pagespeedonline(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/pagespeedonline/v2.ts
+++ b/src/apis/pagespeedonline/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * PageSpeed Insights API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Pagespeedonline
  */
-function Pagespeedonline(options) {
+function Pagespeedonline(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.pagespeedapi = {
@@ -55,7 +62,9 @@ function Pagespeedonline(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    runpagespeed(params, options, callback) {
+    runpagespeed(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -75,7 +84,7 @@ function Pagespeedonline(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/partners/v2.ts
+++ b/src/apis/partners/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Partners API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Partners
  */
-function Partners(options) {
+function Partners(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.analytics = {
@@ -57,7 +64,9 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -76,7 +85,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -95,7 +104,8 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    log(params, options, callback) {
+    log(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -115,7 +125,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -143,7 +153,8 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -163,7 +174,7 @@ function Partners(options) {
         pathParams: ['companyId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * partners.companies.list
         * @desc Lists companies.
@@ -200,7 +211,9 @@ function Partners(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +232,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     leads: {
       /**
@@ -235,7 +248,9 @@ function Partners(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -255,7 +270,7 @@ function Partners(options) {
           pathParams: ['companyId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -283,7 +298,9 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -302,7 +319,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -325,7 +342,9 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -344,7 +363,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     history: {
       /**
@@ -370,7 +389,9 @@ function Partners(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -390,7 +411,7 @@ function Partners(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -408,7 +429,8 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    log(params, options, callback) {
+    log(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -428,7 +450,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -454,7 +476,9 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    createCompanyRelation(params, options, callback) {
+    createCompanyRelation(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -474,7 +498,7 @@ function Partners(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * partners.users.deleteCompanyRelation
         * @desc Deletes a user's company relation. Unaffiliaites the user from a
@@ -495,7 +519,9 @@ function Partners(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteCompanyRelation(params, options, callback) {
+    deleteCompanyRelation(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -515,7 +541,7 @@ function Partners(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * partners.users.get
         * @desc Gets a user.
@@ -536,7 +562,8 @@ function Partners(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -556,7 +583,7 @@ function Partners(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * partners.users.updateProfile
         * @desc Updates a user's profile. A user can only update their own
@@ -578,7 +605,9 @@ function Partners(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateProfile(params, options, callback) {
+    updateProfile(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -598,7 +627,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -621,7 +650,9 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -640,7 +671,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -664,7 +695,9 @@ function Partners(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getPartnersstatus(params, options, callback) {
+    getPartnersstatus(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -684,7 +717,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * partners.updateCompanies
         * @desc Update company. Should only be called within the context of an
@@ -706,7 +739,9 @@ function Partners(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateCompanies(params, options, callback) {
+    updateCompanies(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -725,7 +760,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * partners.updateLeads
         * @desc Updates the specified lead.
@@ -746,7 +781,9 @@ function Partners(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateLeads(params, options, callback) {
+    updateLeads(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -765,7 +802,7 @@ function Partners(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/people/v1.ts
+++ b/src/apis/people/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * People API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for People
  */
-function People(options) {
+function People(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.contactGroups = {
@@ -49,7 +56,9 @@ function People(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchGet(params, options, callback) {
+    batchGet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function People(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.contactGroups.create
         * @desc Create a new contact group owned by the authenticated user.
@@ -82,7 +91,9 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +113,7 @@ function People(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.contactGroups.delete
         * @desc Delete an existing contact group owned by the authenticated user
@@ -117,7 +128,9 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -137,7 +150,7 @@ function People(options) {
         pathParams: ['resourceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.contactGroups.get
         * @desc Get a specific contact group owned by the authenticated user by
@@ -152,7 +165,8 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -172,7 +186,7 @@ function People(options) {
         pathParams: ['resourceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.contactGroups.list
         * @desc List all contact groups owned by the authenticated user. Members
@@ -188,7 +202,9 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -208,7 +224,7 @@ function People(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.contactGroups.update
         * @desc Update the name of an existing contact group owned by the
@@ -223,7 +239,9 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -243,7 +261,7 @@ function People(options) {
         pathParams: ['resourceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     members: {
       /**
@@ -260,7 +278,9 @@ function People(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      modify(params, options, callback) {
+      modify(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -280,7 +300,7 @@ function People(options) {
           pathParams: ['resourceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -300,7 +320,9 @@ function People(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    createContact(params, options, callback) {
+    createContact(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -320,7 +342,7 @@ function People(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.people.deleteContact
         * @desc Delete a contact person. Any non-contact data will not be
@@ -334,7 +356,9 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteContact(params, options, callback) {
+    deleteContact(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -354,7 +378,7 @@ function People(options) {
         pathParams: ['resourceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.people.get
         * @desc Provides information about a person by specifying a resource
@@ -371,7 +395,8 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -391,7 +416,7 @@ function People(options) {
         pathParams: ['resourceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.people.getBatchGet
         * @desc Provides information about a list of specific people by
@@ -409,7 +434,9 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getBatchGet(params, options, callback) {
+    getBatchGet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -429,7 +456,7 @@ function People(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * people.people.updateContact
         * @desc Update contact data for an existing contact person. Any
@@ -452,7 +479,9 @@ function People(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateContact(params, options, callback) {
+    updateContact(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -472,7 +501,7 @@ function People(options) {
         pathParams: ['resourceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     connections: {
       /**
@@ -496,7 +525,9 @@ function People(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -516,7 +547,7 @@ function People(options) {
           pathParams: ['resourceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/playcustomapp/v1.ts
+++ b/src/apis/playcustomapp/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Play Custom App Publishing API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Playcustomapp
  */
-function Playcustomapp(options) {
+function Playcustomapp(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts = {
@@ -52,7 +59,9 @@ function Playcustomapp(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -76,7 +85,7 @@ function Playcustomapp(options) {
           pathParams: ['account'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/plus/v1.ts
+++ b/src/apis/plus/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google+ API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Plus
  */
-function Plus(options) {
+function Plus(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.activities = {
@@ -47,7 +54,8 @@ function Plus(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Plus(options) {
         pathParams: ['activityId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plus.activities.list
         * @desc List all of the activities in the specified collection for a
@@ -84,7 +92,9 @@ function Plus(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +115,7 @@ function Plus(options) {
         pathParams: ['collection', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plus.activities.search
         * @desc Search public activities.
@@ -122,7 +132,9 @@ function Plus(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -142,7 +154,7 @@ function Plus(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -159,7 +171,8 @@ function Plus(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -179,7 +192,7 @@ function Plus(options) {
         pathParams: ['commentId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plus.comments.list
         * @desc List all of the comments for an activity.
@@ -195,7 +208,9 @@ function Plus(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -215,7 +230,7 @@ function Plus(options) {
         pathParams: ['activityId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -234,7 +249,8 @@ function Plus(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -254,7 +270,7 @@ function Plus(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plus.people.list
         * @desc List all of the people in the specified collection.
@@ -271,7 +287,9 @@ function Plus(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -291,7 +309,7 @@ function Plus(options) {
         pathParams: ['collection', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plus.people.listByActivity
         * @desc List all of the people in the specified collection for a
@@ -308,7 +326,9 @@ function Plus(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listByActivity(params, options, callback) {
+    listByActivity(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -329,7 +349,7 @@ function Plus(options) {
         pathParams: ['activityId', 'collection'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plus.people.search
         * @desc Search all public profiles.
@@ -345,7 +365,9 @@ function Plus(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -364,7 +386,7 @@ function Plus(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/plusDomains/v1.ts
+++ b/src/apis/plusDomains/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google+ Domains API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Plusdomains
  */
-function Plusdomains(options) {
+function Plusdomains(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.activities = {
@@ -47,7 +54,8 @@ function Plusdomains(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Plusdomains(options) {
         pathParams: ['activityId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.activities.insert
         * @desc Create a new activity for the authenticated user.
@@ -82,7 +90,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +112,7 @@ function Plusdomains(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.activities.list
         * @desc List all of the activities in the specified collection for a
@@ -119,7 +129,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +152,7 @@ function Plusdomains(options) {
         pathParams: ['collection', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -159,7 +171,9 @@ function Plusdomains(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -179,7 +193,7 @@ function Plusdomains(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -199,7 +213,9 @@ function Plusdomains(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addPeople(params, options, callback) {
+    addPeople(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +235,7 @@ function Plusdomains(options) {
         pathParams: ['circleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.circles.get
         * @desc Get a circle.
@@ -232,7 +248,8 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -252,7 +269,7 @@ function Plusdomains(options) {
         pathParams: ['circleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.circles.insert
         * @desc Create a new circle for the authenticated user.
@@ -266,7 +283,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -286,7 +305,7 @@ function Plusdomains(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.circles.list
         * @desc List all of the circles for a user.
@@ -301,7 +320,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -321,7 +342,7 @@ function Plusdomains(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.circles.patch
         * @desc Update a circle's description. This method supports patch
@@ -336,7 +357,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -356,7 +379,7 @@ function Plusdomains(options) {
         pathParams: ['circleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.circles.remove
         * @desc Delete a circle.
@@ -369,7 +392,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    remove(params, options, callback) {
+    remove(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -389,7 +414,7 @@ function Plusdomains(options) {
         pathParams: ['circleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.circles.removePeople
         * @desc Remove a person from a circle.
@@ -404,7 +429,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removePeople(params, options, callback) {
+    removePeople(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -424,7 +451,7 @@ function Plusdomains(options) {
         pathParams: ['circleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.circles.update
         * @desc Update a circle's description.
@@ -438,7 +465,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -458,7 +487,7 @@ function Plusdomains(options) {
         pathParams: ['circleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -475,7 +504,8 @@ function Plusdomains(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -495,7 +525,7 @@ function Plusdomains(options) {
         pathParams: ['commentId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.comments.insert
         * @desc Create a new comment in reply to an activity.
@@ -509,7 +539,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -530,7 +562,7 @@ function Plusdomains(options) {
         pathParams: ['activityId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.comments.list
         * @desc List all of the comments for an activity.
@@ -546,7 +578,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -567,7 +601,7 @@ function Plusdomains(options) {
         pathParams: ['activityId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -592,7 +626,9 @@ function Plusdomains(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -616,7 +652,7 @@ function Plusdomains(options) {
         pathParams: ['collection', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -633,7 +669,8 @@ function Plusdomains(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -653,7 +690,7 @@ function Plusdomains(options) {
         pathParams: ['userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.people.list
         * @desc List all of the people in the specified collection.
@@ -670,7 +707,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -691,7 +730,7 @@ function Plusdomains(options) {
         pathParams: ['collection', 'userId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.people.listByActivity
         * @desc List all of the people in the specified collection for a
@@ -708,7 +747,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listByActivity(params, options, callback) {
+    listByActivity(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -730,7 +771,7 @@ function Plusdomains(options) {
         pathParams: ['activityId', 'collection'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * plusDomains.people.listByCircle
         * @desc List all of the people who are members of a circle.
@@ -745,7 +786,9 @@ function Plusdomains(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listByCircle(params, options, callback) {
+    listByCircle(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -765,7 +808,7 @@ function Plusdomains(options) {
         pathParams: ['circleId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/poly/v1.ts
+++ b/src/apis/poly/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Poly API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Poly
  */
-function Poly(options) {
+function Poly(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.assets = {
@@ -50,7 +57,8 @@ function Poly(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Poly(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * poly.assets.list
         * @desc Lists all public, remixable assets. These are assets with an
@@ -90,7 +98,9 @@ function Poly(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -109,7 +119,7 @@ function Poly(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -135,7 +145,9 @@ function Poly(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -155,7 +167,7 @@ function Poly(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -178,7 +190,9 @@ function Poly(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -198,7 +212,7 @@ function Poly(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/prediction/v1.2.ts
+++ b/src/apis/prediction/v1.2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Prediction API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.2
  * @param {object=} options Options for Prediction
  */
-function Prediction(options) {
+function Prediction(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   /**
@@ -48,28 +55,30 @@ function Prediction(options) {
    * @param {callback} callback The callback that handles the response.
    * @return {object} Request object
    */
-  this.predict = (params, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    options = options || {};
-    const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-    const parameters = {
-      options: Object.assign(
-          {
-            url: (rootUrl + '/prediction/v1.2/training/{data}/predict')
-                     .replace(/([^:]\/)\/+/g, '$1'),
-            method: 'POST'
-          },
-          options),
-      params,
-      requiredParams: ['data'],
-      pathParams: ['data'],
-      context: self
-    };
-    return createAPIRequest(parameters, callback);
-  };
+  this.predict =
+      (params: any, options: MethodOptions|BodyResponseCallback<any>,
+       callback?: BodyResponseCallback<any>) => {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl + '/prediction/v1.2/training/{data}/predict')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['data'],
+          pathParams: ['data'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      };
   self.hostedmodels = {
     /**
      * prediction.hostedmodels.predict
@@ -84,7 +93,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -105,7 +116,7 @@ function Prediction(options) {
         pathParams: ['hostedModelName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -122,7 +133,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -142,7 +155,7 @@ function Prediction(options) {
         pathParams: ['data'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.training.get
         * @desc Check training status of your model
@@ -155,7 +168,8 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -175,7 +189,7 @@ function Prediction(options) {
         pathParams: ['data'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.training.insert
         * @desc Begin training your model
@@ -189,7 +203,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -209,7 +225,7 @@ function Prediction(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.training.update
         * @desc Add new data to a trained model
@@ -223,7 +239,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -243,7 +261,7 @@ function Prediction(options) {
         pathParams: ['data'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/prediction/v1.3.ts
+++ b/src/apis/prediction/v1.3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Prediction API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.3
  * @param {object=} options Options for Prediction
  */
-function Prediction(options) {
+function Prediction(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.hostedmodels = {
@@ -49,7 +56,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Prediction(options) {
         pathParams: ['hostedModelName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -87,7 +96,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +118,7 @@ function Prediction(options) {
         pathParams: ['data'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.training.get
         * @desc Check training status of your model
@@ -120,7 +131,8 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +152,7 @@ function Prediction(options) {
         pathParams: ['data'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.training.insert
         * @desc Begin training your model
@@ -153,7 +165,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +187,7 @@ function Prediction(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.training.predict
         * @desc Submit data and request a prediction
@@ -187,7 +201,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +223,7 @@ function Prediction(options) {
         pathParams: ['data'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.training.update
         * @desc Add new data to a trained model
@@ -221,7 +237,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -241,7 +259,7 @@ function Prediction(options) {
         pathParams: ['data'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/prediction/v1.4.ts
+++ b/src/apis/prediction/v1.4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Prediction API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.4
  * @param {object=} options Options for Prediction
  */
-function Prediction(options) {
+function Prediction(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.hostedmodels = {
@@ -49,7 +56,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Prediction(options) {
         pathParams: ['hostedModelName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -87,7 +96,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +118,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.get
         * @desc Check training status of your model.
@@ -120,7 +131,8 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +152,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.insert
         * @desc Begin training your model.
@@ -153,7 +165,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +187,7 @@ function Prediction(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.predict
         * @desc Submit model id and request a prediction
@@ -187,7 +201,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +223,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.update
         * @desc Add new data to a trained model.
@@ -221,7 +237,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -241,7 +259,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/prediction/v1.5.ts
+++ b/src/apis/prediction/v1.5.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Prediction API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.5
  * @param {object=} options Options for Prediction
  */
-function Prediction(options) {
+function Prediction(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.hostedmodels = {
@@ -49,7 +56,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Prediction(options) {
         pathParams: ['hostedModelName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -87,7 +96,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    analyze(params, options, callback) {
+    analyze(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +118,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.delete
         * @desc Delete a trained model.
@@ -120,7 +131,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -140,7 +153,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.get
         * @desc Check training status of your model.
@@ -153,7 +166,8 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +187,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.insert
         * @desc Begin training your model.
@@ -186,7 +200,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -206,7 +222,7 @@ function Prediction(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.list
         * @desc List available models.
@@ -220,7 +236,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -240,7 +258,7 @@ function Prediction(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.predict
         * @desc Submit model id and request a prediction.
@@ -254,7 +272,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -274,7 +294,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.update
         * @desc Add new data to a trained model.
@@ -288,7 +308,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -308,7 +330,7 @@ function Prediction(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/prediction/v1.6.ts
+++ b/src/apis/prediction/v1.6.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Prediction API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1.6
  * @param {object=} options Options for Prediction
  */
-function Prediction(options) {
+function Prediction(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.hostedmodels = {
@@ -111,7 +118,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -133,7 +142,7 @@ function Prediction(options) {
         pathParams: ['hostedModelName', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -207,7 +216,9 @@ function Prediction(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    analyze(params, options, callback) {
+    analyze(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -229,7 +240,7 @@ function Prediction(options) {
         pathParams: ['id', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.delete
         * @desc Delete a trained model.
@@ -296,7 +307,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -317,7 +330,7 @@ function Prediction(options) {
         pathParams: ['id', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.get
         * @desc Check training status of your model.
@@ -387,7 +400,8 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -408,7 +422,7 @@ function Prediction(options) {
         pathParams: ['id', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.insert
         * @desc Train a Prediction API model.
@@ -479,7 +493,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -500,7 +516,7 @@ function Prediction(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.list
         * @desc List available models.
@@ -581,7 +597,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -602,7 +620,7 @@ function Prediction(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.predict
         * @desc Submit model id and request a prediction.
@@ -677,7 +695,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    predict(params, options, callback) {
+    predict(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -699,7 +719,7 @@ function Prediction(options) {
         pathParams: ['id', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * prediction.trainedmodels.update
         * @desc Add new data to a trained model.
@@ -776,7 +796,9 @@ function Prediction(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -797,7 +819,7 @@ function Prediction(options) {
         pathParams: ['id', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/proximitybeacon/v1beta1.ts
+++ b/src/apis/proximitybeacon/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Proximity Beacon API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Proximitybeacon
  */
-function Proximitybeacon(options) {
+function Proximitybeacon(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.beaconinfo = {
@@ -51,7 +58,9 @@ function Proximitybeacon(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getforobserved(params, options, callback) {
+    getforobserved(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Proximitybeacon(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -96,7 +105,9 @@ function Proximitybeacon(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    activate(params, options, callback) {
+    activate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -117,7 +128,7 @@ function Proximitybeacon(options) {
         pathParams: ['beaconName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.beacons.deactivate
         * @desc Deactivates a beacon. Once deactivated, the API will not return
@@ -138,7 +149,9 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deactivate(params, options, callback) {
+    deactivate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -159,7 +172,7 @@ function Proximitybeacon(options) {
         pathParams: ['beaconName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.beacons.decommission
         * @desc Decommissions the specified beacon in the service. This beacon
@@ -179,7 +192,9 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    decommission(params, options, callback) {
+    decommission(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -200,7 +215,7 @@ function Proximitybeacon(options) {
         pathParams: ['beaconName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.beacons.delete
         * @desc Deletes the specified beacon including all diagnostics data for
@@ -220,7 +235,9 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -241,7 +258,7 @@ function Proximitybeacon(options) {
         pathParams: ['beaconName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.beacons.get
         * @desc Returns detailed information about the specified beacon.
@@ -264,7 +281,8 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -285,7 +303,7 @@ function Proximitybeacon(options) {
         pathParams: ['beaconName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.beacons.list
         * @desc Searches the beacon registry for beacons that match the given
@@ -306,7 +324,9 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -326,7 +346,7 @@ function Proximitybeacon(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.beacons.register
         * @desc Registers a previously unregistered beacon given its
@@ -345,7 +365,9 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    register(params, options, callback) {
+    register(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -366,7 +388,7 @@ function Proximitybeacon(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.beacons.update
         * @desc Updates the information about the specified beacon. **Any field
@@ -390,7 +412,9 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -411,7 +435,7 @@ function Proximitybeacon(options) {
         pathParams: ['beaconName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     attachments: {
       /**
@@ -436,7 +460,9 @@ function Proximitybeacon(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      batchDelete(params, options, callback) {
+      batchDelete(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -457,7 +483,7 @@ function Proximitybeacon(options) {
           pathParams: ['beaconName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * proximitybeacon.beacons.attachments.create
           * @desc Associates the given data with the specified beacon.
@@ -483,7 +509,9 @@ function Proximitybeacon(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -504,7 +532,7 @@ function Proximitybeacon(options) {
           pathParams: ['beaconName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * proximitybeacon.beacons.attachments.delete
           * @desc Deletes the specified attachment for the given beacon. Each
@@ -526,7 +554,9 @@ function Proximitybeacon(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -547,7 +577,7 @@ function Proximitybeacon(options) {
           pathParams: ['attachmentName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * proximitybeacon.beacons.attachments.list
           * @desc Returns the attachments for the specified beacon that match
@@ -570,7 +600,9 @@ function Proximitybeacon(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -591,7 +623,7 @@ function Proximitybeacon(options) {
           pathParams: ['beaconName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -618,7 +650,9 @@ function Proximitybeacon(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -639,7 +673,7 @@ function Proximitybeacon(options) {
           pathParams: ['beaconName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -663,7 +697,9 @@ function Proximitybeacon(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -684,7 +720,7 @@ function Proximitybeacon(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * proximitybeacon.namespaces.update
         * @desc Updates the information about the specified namespace. Only the
@@ -700,7 +736,9 @@ function Proximitybeacon(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -721,7 +759,7 @@ function Proximitybeacon(options) {
         pathParams: ['namespaceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -743,7 +781,9 @@ function Proximitybeacon(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getEidparams(params, options, callback) {
+    getEidparams(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -764,7 +804,7 @@ function Proximitybeacon(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/pubsub/v1.ts
+++ b/src/apis/pubsub/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Pub/Sub API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Pubsub
  */
-function Pubsub(options) {
+function Pubsub(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -59,7 +66,9 @@ function Pubsub(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -78,7 +87,7 @@ function Pubsub(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.snapshots.delete
           * @desc Removes an existing snapshot. All messages retained in the
@@ -95,7 +104,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -114,7 +125,7 @@ function Pubsub(options) {
           pathParams: ['snapshot'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.snapshots.get
           * @desc Gets the configuration details of a snapshot.
@@ -127,7 +138,8 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -146,7 +158,7 @@ function Pubsub(options) {
           pathParams: ['snapshot'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.snapshots.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -214,7 +226,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -234,7 +248,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.snapshots.list
           * @desc Lists the existing snapshots.
@@ -249,7 +263,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -269,7 +285,7 @@ function Pubsub(options) {
           pathParams: ['project'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.snapshots.patch
           * @desc Updates an existing snapshot. Note that certain properties of
@@ -284,7 +300,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -303,7 +321,7 @@ function Pubsub(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.snapshots.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -376,7 +394,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -396,7 +416,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.snapshots.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -473,7 +493,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -493,7 +515,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -572,7 +594,9 @@ function Pubsub(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      acknowledge(params, options, callback) {
+      acknowledge(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -592,7 +616,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.create
           * @desc Creates a subscription to a given topic. If the subscription
@@ -682,7 +706,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -701,7 +727,7 @@ function Pubsub(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.delete
           * @desc Deletes an existing subscription. All messages retained in the
@@ -772,7 +798,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -792,7 +820,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.get
           * @desc Gets the configuration details of a subscription.
@@ -859,7 +887,8 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -879,7 +908,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -948,7 +977,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -968,7 +999,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.list
           * @desc Lists matching subscriptions.
@@ -1052,7 +1083,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1072,7 +1105,7 @@ function Pubsub(options) {
           pathParams: ['project'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.modifyAckDeadline
           * @desc Modifies the ack deadline for a specific message. This method
@@ -1146,7 +1179,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      modifyAckDeadline(params, options, callback) {
+      modifyAckDeadline(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1166,7 +1201,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.modifyPushConfig
           * @desc Modifies the `PushConfig` for a specified subscription.  This
@@ -1240,7 +1275,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      modifyPushConfig(params, options, callback) {
+      modifyPushConfig(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1260,7 +1297,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.patch
           * @desc Updates an existing subscription. Note that certain properties
@@ -1275,7 +1312,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      patch(params, options, callback) {
+      patch(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1294,7 +1333,7 @@ function Pubsub(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.pull
           * @desc Pulls messages from the server. Returns an empty list if there
@@ -1369,7 +1408,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      pull(params, options, callback) {
+      pull(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1389,7 +1430,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.seek
           * @desc Seeks an existing subscription to a point in time or to a
@@ -1404,7 +1445,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      seek(params, options, callback) {
+      seek(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1424,7 +1467,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -1498,7 +1541,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1518,7 +1563,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -1596,7 +1641,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1616,7 +1663,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -1703,7 +1750,9 @@ function Pubsub(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1722,7 +1771,7 @@ function Pubsub(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.delete
           * @desc Deletes the topic with the given name. Returns `NOT_FOUND` if
@@ -1792,7 +1841,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1811,7 +1862,7 @@ function Pubsub(options) {
           pathParams: ['topic'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.get
           * @desc Gets the configuration of a topic.
@@ -1879,7 +1930,8 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1898,7 +1950,7 @@ function Pubsub(options) {
           pathParams: ['topic'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -1966,7 +2018,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1986,7 +2040,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.list
           * @desc Lists matching topics.
@@ -2069,7 +2123,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2089,7 +2145,7 @@ function Pubsub(options) {
           pathParams: ['project'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.publish
           * @desc Adds one or more messages to the topic. Returns `NOT_FOUND` if
@@ -2165,7 +2221,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      publish(params, options, callback) {
+      publish(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2185,7 +2243,7 @@ function Pubsub(options) {
           pathParams: ['topic'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -2258,7 +2316,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2278,7 +2338,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -2355,7 +2415,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -2375,7 +2437,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       snapshots: {
         /**
@@ -2392,7 +2454,9 @@ function Pubsub(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2412,7 +2476,7 @@ function Pubsub(options) {
             pathParams: ['topic'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -2500,7 +2564,9 @@ function Pubsub(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -2520,7 +2586,7 @@ function Pubsub(options) {
             pathParams: ['topic'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/pubsub/v1beta1a.ts
+++ b/src/apis/pubsub/v1beta1a.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Pub/Sub API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1a
  * @param {object=} options Options for Pubsub
  */
-function Pubsub(options) {
+function Pubsub(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.subscriptions = {
@@ -51,7 +58,9 @@ function Pubsub(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    acknowledge(params, options, callback) {
+    acknowledge(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.create
         * @desc Creates a subscription on a given topic for a given subscriber.
@@ -88,7 +97,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -108,7 +119,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.delete
         * @desc Deletes an existing subscription. All pending messages in the
@@ -123,7 +134,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -143,7 +156,7 @@ function Pubsub(options) {
         pathParams: ['subscription'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.get
         * @desc Gets the configuration details of a subscription.
@@ -156,7 +169,8 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -176,7 +190,7 @@ function Pubsub(options) {
         pathParams: ['subscription'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.list
         * @desc Lists matching subscriptions.
@@ -191,7 +205,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -211,7 +227,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.modifyAckDeadline
         * @desc Modifies the Ack deadline for a message received from a pull
@@ -225,7 +241,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    modifyAckDeadline(params, options, callback) {
+    modifyAckDeadline(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -245,7 +263,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.modifyPushConfig
         * @desc Modifies the <code>PushConfig</code> for a specified
@@ -262,7 +280,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    modifyPushConfig(params, options, callback) {
+    modifyPushConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -282,7 +302,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.pull
         * @desc Pulls a single message from the server. If return_immediately is
@@ -299,7 +319,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    pull(params, options, callback) {
+    pull(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -319,7 +341,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.subscriptions.pullBatch
         * @desc Pulls messages from the server. Returns an empty list if there
@@ -335,7 +357,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    pullBatch(params, options, callback) {
+    pullBatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -355,7 +379,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -372,7 +396,9 @@ function Pubsub(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -391,7 +417,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.topics.delete
         * @desc Deletes the topic with the given name. Returns NOT_FOUND if the
@@ -406,7 +432,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -426,7 +454,7 @@ function Pubsub(options) {
         pathParams: ['topic'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.topics.get
         * @desc Gets the configuration of a topic. Since the topic only has the
@@ -442,7 +470,8 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -462,7 +491,7 @@ function Pubsub(options) {
         pathParams: ['topic'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.topics.list
         * @desc Lists matching topics.
@@ -477,7 +506,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -496,7 +527,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.topics.publish
         * @desc Adds a message to the topic.  Returns NOT_FOUND if the topic
@@ -510,7 +541,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    publish(params, options, callback) {
+    publish(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -530,7 +563,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * pubsub.topics.publishBatch
         * @desc Adds one or more messages to the topic. Returns NOT_FOUND if the
@@ -544,7 +577,9 @@ function Pubsub(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    publishBatch(params, options, callback) {
+    publishBatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -564,7 +599,7 @@ function Pubsub(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/pubsub/v1beta2.ts
+++ b/src/apis/pubsub/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Pub/Sub API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Pubsub
  */
-function Pubsub(options) {
+function Pubsub(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -54,7 +61,9 @@ function Pubsub(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      acknowledge(params, options, callback) {
+      acknowledge(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -74,7 +83,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.create
           * @desc Creates a subscription to a given topic. If the subscription
@@ -93,7 +102,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -113,7 +124,7 @@ function Pubsub(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.delete
           * @desc Deletes an existing subscription. All pending messages in the
@@ -131,7 +142,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -151,7 +164,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.get
           * @desc Gets the configuration details of a subscription.
@@ -164,7 +177,8 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -184,7 +198,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -198,7 +212,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -218,7 +234,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.list
           * @desc Lists matching subscriptions.
@@ -233,7 +249,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -253,7 +271,7 @@ function Pubsub(options) {
           pathParams: ['project'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.modifyAckDeadline
           * @desc Modifies the ack deadline for a specific message. This method
@@ -272,7 +290,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      modifyAckDeadline(params, options, callback) {
+      modifyAckDeadline(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -292,7 +312,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.modifyPushConfig
           * @desc Modifies the `PushConfig` for a specified subscription.  This
@@ -311,7 +331,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      modifyPushConfig(params, options, callback) {
+      modifyPushConfig(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -331,7 +353,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.pull
           * @desc Pulls messages from the server. Returns an empty list if there
@@ -348,7 +370,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      pull(params, options, callback) {
+      pull(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -368,7 +392,7 @@ function Pubsub(options) {
           pathParams: ['subscription'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -383,7 +407,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -403,7 +429,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.subscriptions.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -422,7 +448,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -442,7 +470,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -460,7 +488,9 @@ function Pubsub(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -480,7 +510,7 @@ function Pubsub(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.delete
           * @desc Deletes the topic with the given name. Returns `NOT_FOUND` if
@@ -498,7 +528,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -518,7 +550,7 @@ function Pubsub(options) {
           pathParams: ['topic'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.get
           * @desc Gets the configuration of a topic.
@@ -531,7 +563,8 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -551,7 +584,7 @@ function Pubsub(options) {
           pathParams: ['topic'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -565,7 +598,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -585,7 +620,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.list
           * @desc Lists matching topics.
@@ -600,7 +635,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -620,7 +657,7 @@ function Pubsub(options) {
           pathParams: ['project'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.publish
           * @desc Adds one or more messages to the topic. Returns `NOT_FOUND` if
@@ -637,7 +674,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      publish(params, options, callback) {
+      publish(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -657,7 +696,7 @@ function Pubsub(options) {
           pathParams: ['topic'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -672,7 +711,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -692,7 +733,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * pubsub.projects.topics.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -711,7 +752,9 @@ function Pubsub(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -731,7 +774,7 @@ function Pubsub(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       subscriptions: {
         /**
@@ -748,7 +791,9 @@ function Pubsub(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -768,7 +813,7 @@ function Pubsub(options) {
             pathParams: ['topic'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/replicapool/v1beta1.ts
+++ b/src/apis/replicapool/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Replica Pool API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Replicapool
  */
-function Replicapool(options) {
+function Replicapool(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.pools = {
@@ -51,7 +58,9 @@ function Replicapool(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -73,7 +82,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.pools.get
         * @desc Gets information about a single replica pool.
@@ -88,7 +97,8 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +120,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.pools.insert
         * @desc Inserts a new replica pool.
@@ -125,7 +135,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +159,7 @@ function Replicapool(options) {
         pathParams: ['projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.pools.list
         * @desc List all replica pools.
@@ -163,7 +175,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -185,7 +199,7 @@ function Replicapool(options) {
         pathParams: ['projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.pools.resize
         * @desc Resize a pool. This is an asynchronous operation, and multiple
@@ -203,7 +217,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resize(params, options, callback) {
+    resize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -225,7 +241,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.pools.updatetemplate
         * @desc Update the template used by the pool.
@@ -241,7 +257,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updatetemplate(params, options, callback) {
+    updatetemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -263,7 +281,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -284,7 +302,9 @@ function Replicapool(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -306,7 +326,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.replicas.get
         * @desc Gets information about a specific replica.
@@ -322,7 +342,8 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -344,7 +365,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.replicas.list
         * @desc Lists all replicas in a pool.
@@ -361,7 +382,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -383,7 +406,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.replicas.restart
         * @desc Restarts a replica in a pool.
@@ -399,7 +422,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    restart(params, options, callback) {
+    restart(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -421,7 +446,7 @@ function Replicapool(options) {
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/replicapool/v1beta2.ts
+++ b/src/apis/replicapool/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Compute Engine Instance Group Manager API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Replicapool
  */
-function Replicapool(options) {
+function Replicapool(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.instanceGroupManagers = {
@@ -53,7 +60,9 @@ function Replicapool(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    abandonInstances(params, options, callback) {
+    abandonInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -75,7 +84,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.delete
         * @desc Deletes the instance group manager and all instances contained
@@ -93,7 +102,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -115,7 +126,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.deleteInstances
         * @desc Deletes the specified instances. The instances are deleted, then
@@ -134,7 +145,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    deleteInstances(params, options, callback) {
+    deleteInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -156,7 +169,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.get
         * @desc Returns the specified Instance Group Manager resource.
@@ -171,7 +184,8 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -193,7 +207,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.insert
         * @desc Creates an instance group manager, as well as the instance group
@@ -210,7 +224,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -232,7 +248,7 @@ function Replicapool(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.list
         * @desc Retrieves the list of Instance Group Manager resources contained
@@ -250,7 +266,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -272,7 +290,7 @@ function Replicapool(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.recreateInstances
         * @desc Recreates the specified instances. The instances are deleted,
@@ -290,7 +308,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    recreateInstances(params, options, callback) {
+    recreateInstances(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -312,7 +332,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.resize
         * @desc Resizes the managed instance group up or down. If resized up,
@@ -331,7 +351,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resize(params, options, callback) {
+    resize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -353,7 +375,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.setInstanceTemplate
         * @desc Sets the instance template to use when creating new instances in
@@ -370,7 +392,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setInstanceTemplate(params, options, callback) {
+    setInstanceTemplate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -392,7 +416,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.instanceGroupManagers.setTargetPools
         * @desc Modifies the target pools to which all new instances in this
@@ -409,7 +433,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setTargetPools(params, options, callback) {
+    setTargetPools(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -431,7 +457,7 @@ function Replicapool(options) {
         pathParams: ['instanceGroupManager', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -450,7 +476,8 @@ function Replicapool(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -472,7 +499,7 @@ function Replicapool(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapool.zoneOperations.list
         * @desc Retrieves the list of operation resources contained within the
@@ -490,7 +517,9 @@ function Replicapool(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -512,7 +541,7 @@ function Replicapool(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/replicapoolupdater/v1beta1.ts
+++ b/src/apis/replicapoolupdater/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Compute Engine Instance Group Updater API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Replicapoolupdater
  */
-function Replicapoolupdater(options) {
+function Replicapoolupdater(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.rollingUpdates = {
@@ -52,7 +59,9 @@ function Replicapoolupdater(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -74,7 +83,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'rollingUpdate', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.rollingUpdates.get
         * @desc Returns information about an update.
@@ -89,7 +98,8 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -111,7 +121,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'rollingUpdate', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.rollingUpdates.insert
         * @desc Inserts and starts a new update.
@@ -126,7 +136,9 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -148,7 +160,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.rollingUpdates.list
         * @desc Lists recent updates for a given managed instance group, in
@@ -166,7 +178,9 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -188,7 +202,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.rollingUpdates.listInstanceUpdates
         * @desc Lists the current status for each instance within a given
@@ -207,7 +221,9 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listInstanceUpdates(params, options, callback) {
+    listInstanceUpdates(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -229,7 +245,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'rollingUpdate', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.rollingUpdates.pause
         * @desc Pauses the update in state from ROLLING_FORWARD or ROLLING_BACK.
@@ -245,7 +261,9 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    pause(params, options, callback) {
+    pause(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -267,7 +285,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'rollingUpdate', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.rollingUpdates.resume
         * @desc Continues an update in PAUSED state. Has no effect if invoked
@@ -283,7 +301,9 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resume(params, options, callback) {
+    resume(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -305,7 +325,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'rollingUpdate', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.rollingUpdates.rollback
         * @desc Rolls back the update in state from ROLLING_FORWARD or PAUSED.
@@ -321,7 +341,9 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    rollback(params, options, callback) {
+    rollback(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -343,7 +365,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'rollingUpdate', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -362,7 +384,8 @@ function Replicapoolupdater(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -384,7 +407,7 @@ function Replicapoolupdater(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * replicapoolupdater.zoneOperations.list
         * @desc Retrieves the list of Operation resources contained within the
@@ -402,7 +425,9 @@ function Replicapoolupdater(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -424,7 +449,7 @@ function Replicapoolupdater(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/reseller/v1.ts
+++ b/src/apis/reseller/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Enterprise Apps Reseller API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Reseller
  */
-function Reseller(options) {
+function Reseller(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.customers = {
@@ -47,7 +54,8 @@ function Reseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +75,7 @@ function Reseller(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * reseller.customers.insert
         * @desc Order a new customer's account.
@@ -81,7 +89,9 @@ function Reseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -101,7 +111,7 @@ function Reseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * reseller.customers.patch
         * @desc Update a customer account's settings. This method supports patch
@@ -116,7 +126,9 @@ function Reseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -136,7 +148,7 @@ function Reseller(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * reseller.customers.update
         * @desc Update a customer account's settings.
@@ -150,7 +162,9 @@ function Reseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -170,7 +184,7 @@ function Reseller(options) {
         pathParams: ['customerId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -186,7 +200,9 @@ function Reseller(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getwatchdetails(params, options, callback) {
+    getwatchdetails(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +223,7 @@ function Reseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * reseller.resellernotify.register
         * @desc Registers a Reseller for receiving notifications.
@@ -220,7 +236,9 @@ function Reseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    register(params, options, callback) {
+    register(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -240,7 +258,7 @@ function Reseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * reseller.resellernotify.unregister
         * @desc Unregisters a Reseller for receiving notifications.
@@ -253,7 +271,9 @@ function Reseller(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    unregister(params, options, callback) {
+    unregister(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -273,7 +293,7 @@ function Reseller(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -292,7 +312,9 @@ function Reseller(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        activate(params, options, callback) {
+        activate(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -314,7 +336,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.changePlan
             * @desc Update a subscription plan. Use this method to update a plan
@@ -331,7 +353,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        changePlan(params, options, callback) {
+        changePlan(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -353,7 +377,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.changeRenewalSettings
             * @desc Update a user license's renewal settings. This is applicable
@@ -369,7 +393,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        changeRenewalSettings(params, options, callback) {
+        changeRenewalSettings(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -391,7 +417,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.changeSeats
             * @desc Update a subscription's user license settings.
@@ -406,7 +432,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        changeSeats(params, options, callback) {
+        changeSeats(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -428,7 +456,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.delete
             * @desc Cancel, suspend or transfer a subscription to direct.
@@ -443,7 +471,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -465,7 +495,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.get
             * @desc Get a specific subscription.
@@ -479,7 +509,8 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -501,7 +532,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.insert
             * @desc Create or transfer a subscription.
@@ -516,7 +547,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -538,7 +571,7 @@ function Reseller(options) {
             pathParams: ['customerId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.list
             * @desc List of subscriptions managed by the reseller. The list can
@@ -557,7 +590,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -577,7 +612,7 @@ function Reseller(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.startPaidService
             * @desc Immediately move a 30-day free trial subscription to a paid
@@ -592,7 +627,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        startPaidService(params, options, callback) {
+        startPaidService(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -614,7 +651,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * reseller.subscriptions.suspend
             * @desc Suspends an active subscription.
@@ -628,7 +665,9 @@ function Reseller(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        suspend(params, options, callback) {
+        suspend(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -650,7 +689,7 @@ function Reseller(options) {
             pathParams: ['customerId', 'subscriptionId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };

--- a/src/apis/resourceviews/v1beta1.ts
+++ b/src/apis/resourceviews/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Resource Views API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Resourceviews
  */
-function Resourceviews(options) {
+function Resourceviews(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.regionViews = {
@@ -51,7 +58,9 @@ function Resourceviews(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addresources(params, options, callback) {
+    addresources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -73,7 +82,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'region', 'resourceViewName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.regionViews.delete
         * @desc Delete a resource view.
@@ -88,7 +97,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +121,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'region', 'resourceViewName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.regionViews.get
         * @desc Get the information of a resource view.
@@ -125,7 +136,8 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +159,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'region', 'resourceViewName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.regionViews.insert
         * @desc Create a resource view.
@@ -162,7 +174,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -184,7 +198,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.regionViews.list
         * @desc List resource views.
@@ -200,7 +214,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -222,7 +238,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'region'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.regionViews.listresources
         * @desc List the resources in the view.
@@ -239,7 +255,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listresources(params, options, callback) {
+    listresources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -261,7 +279,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'region', 'resourceViewName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.regionViews.removeresources
         * @desc Remove resources from the view.
@@ -277,7 +295,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeresources(params, options, callback) {
+    removeresources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -299,7 +319,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'region', 'resourceViewName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -319,7 +339,9 @@ function Resourceviews(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addresources(params, options, callback) {
+    addresources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -341,7 +363,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'resourceViewName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.delete
         * @desc Delete a resource view.
@@ -356,7 +378,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -378,7 +402,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'resourceViewName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.get
         * @desc Get the information of a zonal resource view.
@@ -393,7 +417,8 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -415,7 +440,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'resourceViewName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.insert
         * @desc Create a resource view.
@@ -430,7 +455,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -452,7 +479,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.list
         * @desc List resource views.
@@ -468,7 +495,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -490,7 +519,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.listresources
         * @desc List the resources of the resource view.
@@ -507,7 +536,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listresources(params, options, callback) {
+    listresources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -529,7 +560,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'resourceViewName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.removeresources
         * @desc Remove resources from the view.
@@ -545,7 +576,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeresources(params, options, callback) {
+    removeresources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -567,7 +600,7 @@ function Resourceviews(options) {
         pathParams: ['projectName', 'resourceViewName', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/resourceviews/v1beta2.ts
+++ b/src/apis/resourceviews/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Compute Engine Instance Groups API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Resourceviews
  */
-function Resourceviews(options) {
+function Resourceviews(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.zoneOperations = {
@@ -50,7 +57,8 @@ function Resourceviews(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +80,7 @@ function Resourceviews(options) {
         pathParams: ['operation', 'project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneOperations.list
         * @desc Retrieves the list of operation resources contained within the
@@ -90,7 +98,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -112,7 +122,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -132,7 +142,9 @@ function Resourceviews(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addResources(params, options, callback) {
+    addResources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -154,7 +166,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'resourceView', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.delete
         * @desc Delete a resource view.
@@ -169,7 +181,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -191,7 +205,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'resourceView', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.get
         * @desc Get the information of a zonal resource view.
@@ -206,7 +220,8 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -228,7 +243,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'resourceView', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.getService
         * @desc Get the service information of a resource view or a resource.
@@ -244,7 +259,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getService(params, options, callback) {
+    getService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -266,7 +283,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'resourceView', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.insert
         * @desc Create a resource view.
@@ -281,7 +298,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -303,7 +322,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.list
         * @desc List resource views.
@@ -319,7 +338,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -341,7 +362,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.listResources
         * @desc List the resources of the resource view.
@@ -361,7 +382,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listResources(params, options, callback) {
+    listResources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -383,7 +406,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'resourceView', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.removeResources
         * @desc Remove resources from the view.
@@ -399,7 +422,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removeResources(params, options, callback) {
+    removeResources(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -421,7 +446,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'resourceView', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * resourceviews.zoneViews.setService
         * @desc Update the service information of a resource view or a resource.
@@ -437,7 +462,9 @@ function Resourceviews(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setService(params, options, callback) {
+    setService(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -459,7 +486,7 @@ function Resourceviews(options) {
         pathParams: ['project', 'resourceView', 'zone'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/runtimeconfig/v1.ts
+++ b/src/apis/runtimeconfig/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Runtime Configuration API
@@ -34,7 +41,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Runtimeconfig
  */
-function Runtimeconfig(options) {
+function Runtimeconfig(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -59,7 +66,9 @@ function Runtimeconfig(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -80,7 +89,7 @@ function Runtimeconfig(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * runtimeconfig.operations.delete
         * @desc Deletes a long-running operation. This method indicates that the
@@ -96,7 +105,9 @@ function Runtimeconfig(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -116,7 +127,7 @@ function Runtimeconfig(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * runtimeconfig.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -140,7 +151,9 @@ function Runtimeconfig(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -160,7 +173,7 @@ function Runtimeconfig(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/runtimeconfig/v1beta1.ts
+++ b/src/apis/runtimeconfig/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Runtime Configuration API
@@ -34,7 +41,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Runtimeconfig
  */
-function Runtimeconfig(options) {
+function Runtimeconfig(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -54,7 +61,9 @@ function Runtimeconfig(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -75,7 +84,7 @@ function Runtimeconfig(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * runtimeconfig.projects.configs.delete
           * @desc Deletes a RuntimeConfig resource.
@@ -88,7 +97,9 @@ function Runtimeconfig(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -109,7 +120,7 @@ function Runtimeconfig(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * runtimeconfig.projects.configs.get
           * @desc Gets information about a RuntimeConfig resource.
@@ -122,7 +133,8 @@ function Runtimeconfig(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -143,7 +155,7 @@ function Runtimeconfig(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * runtimeconfig.projects.configs.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -157,7 +169,9 @@ function Runtimeconfig(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -178,7 +192,7 @@ function Runtimeconfig(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * runtimeconfig.projects.configs.list
           * @desc Lists all the RuntimeConfig resources within project.
@@ -193,7 +207,9 @@ function Runtimeconfig(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -214,7 +230,7 @@ function Runtimeconfig(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * runtimeconfig.projects.configs.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -229,7 +245,9 @@ function Runtimeconfig(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -250,7 +268,7 @@ function Runtimeconfig(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * runtimeconfig.projects.configs.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -269,7 +287,9 @@ function Runtimeconfig(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -290,7 +310,7 @@ function Runtimeconfig(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * runtimeconfig.projects.configs.update
           * @desc Updates a RuntimeConfig resource. The configuration must exist
@@ -305,7 +325,9 @@ function Runtimeconfig(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -326,7 +348,7 @@ function Runtimeconfig(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       operations: {
         /**
@@ -343,7 +365,8 @@ function Runtimeconfig(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -364,7 +387,7 @@ function Runtimeconfig(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.operations.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -384,7 +407,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -405,7 +430,7 @@ function Runtimeconfig(options) {
             pathParams: ['resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -430,7 +455,9 @@ function Runtimeconfig(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -451,7 +478,7 @@ function Runtimeconfig(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.variables.delete
             * @desc Deletes a variable or multiple variables.  If you specify a
@@ -469,7 +496,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -490,7 +519,7 @@ function Runtimeconfig(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.variables.get
             * @desc Gets information about a single variable.
@@ -503,7 +532,8 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -524,7 +554,7 @@ function Runtimeconfig(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.variables.list
             * @desc Lists variables within given a configuration, matching any
@@ -544,7 +574,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -565,7 +597,7 @@ function Runtimeconfig(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.variables.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -584,7 +616,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -605,7 +639,7 @@ function Runtimeconfig(options) {
             pathParams: ['resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.variables.update
             * @desc Updates an existing variable with a new value.
@@ -619,7 +653,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -640,7 +676,7 @@ function Runtimeconfig(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.variables.watch
             * @desc Watches a specific variable and waits for a change in the
@@ -664,7 +700,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        watch(params, options, callback) {
+        watch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -685,7 +723,7 @@ function Runtimeconfig(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -709,7 +747,9 @@ function Runtimeconfig(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -730,7 +770,7 @@ function Runtimeconfig(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.waiters.delete
             * @desc Deletes the waiter with the specified name.
@@ -743,7 +783,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -764,7 +806,7 @@ function Runtimeconfig(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.waiters.get
             * @desc Gets information about a single waiter.
@@ -777,7 +819,8 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -798,7 +841,7 @@ function Runtimeconfig(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.waiters.list
             * @desc List waiters within the given configuration.
@@ -813,7 +856,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -834,7 +879,7 @@ function Runtimeconfig(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * runtimeconfig.projects.configs.waiters.testIamPermissions
             * @desc Returns permissions that a caller has on the specified
@@ -853,7 +898,9 @@ function Runtimeconfig(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -874,7 +921,7 @@ function Runtimeconfig(options) {
             pathParams: ['resource'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/safebrowsing/v4.ts
+++ b/src/apis/safebrowsing/v4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Safe Browsing API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v4
  * @param {object=} options Options for Safebrowsing
  */
-function Safebrowsing(options) {
+function Safebrowsing(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.encodedFullHashes = {
@@ -49,7 +56,8 @@ function Safebrowsing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Safebrowsing(options) {
         pathParams: ['encodedRequest'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -87,7 +95,8 @@ function Safebrowsing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -107,7 +116,7 @@ function Safebrowsing(options) {
         pathParams: ['encodedRequest'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -124,7 +133,9 @@ function Safebrowsing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    find(params, options, callback) {
+    find(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -144,7 +155,7 @@ function Safebrowsing(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -162,7 +173,9 @@ function Safebrowsing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -181,7 +194,7 @@ function Safebrowsing(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -197,7 +210,9 @@ function Safebrowsing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -216,7 +231,7 @@ function Safebrowsing(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -234,7 +249,9 @@ function Safebrowsing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    fetch(params, options, callback) {
+    fetch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -254,7 +271,7 @@ function Safebrowsing(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -271,7 +288,9 @@ function Safebrowsing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    find(params, options, callback) {
+    find(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -291,7 +310,7 @@ function Safebrowsing(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/script/v1.ts
+++ b/src/apis/script/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Apps Script API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Script
  */
-function Script(options) {
+function Script(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.processes = {
@@ -58,7 +65,9 @@ function Script(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -77,7 +86,7 @@ function Script(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * script.processes.listScriptProcesses
         * @desc List information about a script's executed processes, such as
@@ -100,7 +109,9 @@ function Script(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listScriptProcesses(params, options, callback) {
+    listScriptProcesses(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -120,7 +131,7 @@ function Script(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -138,7 +149,9 @@ function Script(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -157,7 +170,7 @@ function Script(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * script.projects.get
         * @desc Gets a script project's metadata.
@@ -170,7 +183,8 @@ function Script(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -190,7 +204,7 @@ function Script(options) {
         pathParams: ['scriptId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * script.projects.getContent
         * @desc Gets the content of the script project, including the code
@@ -205,7 +219,9 @@ function Script(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getContent(params, options, callback) {
+    getContent(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -225,7 +241,7 @@ function Script(options) {
         pathParams: ['scriptId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * script.projects.getMetrics
         * @desc Get metrics data for scripts, such as number of executions and
@@ -241,7 +257,9 @@ function Script(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getMetrics(params, options, callback) {
+    getMetrics(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -261,7 +279,7 @@ function Script(options) {
         pathParams: ['scriptId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * script.projects.updateContent
         * @desc Updates the content of the specified script project. This
@@ -279,7 +297,9 @@ function Script(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    updateContent(params, options, callback) {
+    updateContent(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -299,7 +319,7 @@ function Script(options) {
         pathParams: ['scriptId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     deployments: {
       /**
@@ -315,7 +335,9 @@ function Script(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -335,7 +357,7 @@ function Script(options) {
           pathParams: ['scriptId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * script.projects.deployments.delete
           * @desc Deletes a deployment of an Apps Script project.
@@ -349,7 +371,9 @@ function Script(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -370,7 +394,7 @@ function Script(options) {
           pathParams: ['deploymentId', 'scriptId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * script.projects.deployments.get
           * @desc Gets a deployment of an Apps Script project.
@@ -384,7 +408,8 @@ function Script(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -405,7 +430,7 @@ function Script(options) {
           pathParams: ['deploymentId', 'scriptId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * script.projects.deployments.list
           * @desc Lists the deployments of an Apps Script project.
@@ -420,7 +445,9 @@ function Script(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -440,7 +467,7 @@ function Script(options) {
           pathParams: ['scriptId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * script.projects.deployments.update
           * @desc Updates a deployment of an Apps Script project.
@@ -455,7 +482,9 @@ function Script(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -476,7 +505,7 @@ function Script(options) {
           pathParams: ['deploymentId', 'scriptId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -495,7 +524,9 @@ function Script(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -515,7 +546,7 @@ function Script(options) {
           pathParams: ['scriptId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * script.projects.versions.get
           * @desc Gets a version of a script project.
@@ -529,7 +560,8 @@ function Script(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -550,7 +582,7 @@ function Script(options) {
           pathParams: ['scriptId', 'versionNumber'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * script.projects.versions.list
           * @desc List the versions of a script project.
@@ -565,7 +597,9 @@ function Script(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -585,7 +619,7 @@ function Script(options) {
           pathParams: ['scriptId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -611,7 +645,8 @@ function Script(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    run(params, options, callback) {
+    run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -631,7 +666,7 @@ function Script(options) {
         pathParams: ['scriptId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/searchconsole/v1.ts
+++ b/src/apis/searchconsole/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Search Console URL Testing Tools API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Searchconsole
  */
-function Searchconsole(options) {
+function Searchconsole(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.urlTestingTools = {
@@ -48,7 +55,8 @@ function Searchconsole(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      run(params, options, callback) {
+      run(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -69,7 +77,7 @@ function Searchconsole(options) {
           pathParams: [],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/serviceconsumermanagement/v1.ts
+++ b/src/apis/serviceconsumermanagement/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Service Consumer Management API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Serviceconsumermanagement
  */
-function Serviceconsumermanagement(options) {
+function Serviceconsumermanagement(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -57,7 +64,9 @@ function Serviceconsumermanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -78,7 +87,7 @@ function Serviceconsumermanagement(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceconsumermanagement.operations.delete
         * @desc Deletes a long-running operation. This method indicates that the
@@ -94,7 +103,9 @@ function Serviceconsumermanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -114,7 +125,7 @@ function Serviceconsumermanagement(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceconsumermanagement.operations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -129,7 +140,8 @@ function Serviceconsumermanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -149,7 +161,7 @@ function Serviceconsumermanagement(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceconsumermanagement.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -173,7 +185,9 @@ function Serviceconsumermanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -193,7 +207,7 @@ function Serviceconsumermanagement(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -213,7 +227,9 @@ function Serviceconsumermanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -234,7 +250,7 @@ function Serviceconsumermanagement(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     tenancyUnits: {
       /**
@@ -254,7 +270,9 @@ function Serviceconsumermanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      addProject(params, options, callback) {
+      addProject(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -275,7 +293,7 @@ function Serviceconsumermanagement(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * serviceconsumermanagement.services.tenancyUnits.create
           * @desc Creates a tenancy unit with no tenant resources.
@@ -289,7 +307,9 @@ function Serviceconsumermanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -310,7 +330,7 @@ function Serviceconsumermanagement(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * serviceconsumermanagement.services.tenancyUnits.delete
           * @desc Delete tenancy unit.  Before the tenancy unit is deleted,
@@ -325,7 +345,9 @@ function Serviceconsumermanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -345,7 +367,7 @@ function Serviceconsumermanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * serviceconsumermanagement.services.tenancyUnits.list
           * @desc Find tenancy unit for a service and consumer. This method
@@ -364,7 +386,9 @@ function Serviceconsumermanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -385,7 +409,7 @@ function Serviceconsumermanagement(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * serviceconsumermanagement.services.tenancyUnits.removeProject
           * @desc Removes specified project resource identified by tenant
@@ -403,7 +427,9 @@ function Serviceconsumermanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      removeProject(params, options, callback) {
+      removeProject(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -424,7 +450,7 @@ function Serviceconsumermanagement(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/servicecontrol/v1.ts
+++ b/src/apis/servicecontrol/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Service Control API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Servicecontrol
  */
-function Servicecontrol(options) {
+function Servicecontrol(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.services = {
@@ -56,7 +63,9 @@ function Servicecontrol(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    allocateQuota(params, options, callback) {
+    allocateQuota(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -77,7 +86,7 @@ function Servicecontrol(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicecontrol.services.check
         * @desc Checks an operation with Google Service Control to decide
@@ -99,7 +108,9 @@ function Servicecontrol(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    check(params, options, callback) {
+    check(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -120,7 +131,7 @@ function Servicecontrol(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicecontrol.services.endReconciliation
         * @desc Signals the quota controller that service ends the ongoing usage
@@ -138,7 +149,9 @@ function Servicecontrol(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    endReconciliation(params, options, callback) {
+    endReconciliation(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -159,7 +172,7 @@ function Servicecontrol(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicecontrol.services.releaseQuota
         * @desc Releases previously allocated quota done through AllocateQuota
@@ -180,7 +193,9 @@ function Servicecontrol(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    releaseQuota(params, options, callback) {
+    releaseQuota(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -201,7 +216,7 @@ function Servicecontrol(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicecontrol.services.report
         * @desc Reports operation results to Google Service Control, such as
@@ -225,7 +240,9 @@ function Servicecontrol(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    report(params, options, callback) {
+    report(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -246,7 +263,7 @@ function Servicecontrol(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicecontrol.services.startReconciliation
         * @desc Unlike rate quota, allocation quota does not get refilled
@@ -281,7 +298,9 @@ function Servicecontrol(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    startReconciliation(params, options, callback) {
+    startReconciliation(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -302,7 +321,7 @@ function Servicecontrol(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/servicemanagement/v1.ts
+++ b/src/apis/servicemanagement/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Service Management API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Servicemanagement
  */
-function Servicemanagement(options) {
+function Servicemanagement(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -51,7 +58,8 @@ function Servicemanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +79,7 @@ function Servicemanagement(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.operations.list
         * @desc Lists service operations that match the specified filter in the
@@ -88,7 +96,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -108,7 +118,7 @@ function Servicemanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -126,7 +136,9 @@ function Servicemanagement(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -146,7 +158,7 @@ function Servicemanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.delete
         * @desc Deletes a managed service. This method will change the service
@@ -163,7 +175,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -184,7 +198,7 @@ function Servicemanagement(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.disable
         * @desc Disables a service for a project, so it can no longer be be used
@@ -201,7 +215,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    disable(params, options, callback) {
+    disable(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -222,7 +238,7 @@ function Servicemanagement(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.enable
         * @desc Enables a service for a project, so it can be used for the
@@ -239,7 +255,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    enable(params, options, callback) {
+    enable(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -260,7 +278,7 @@ function Servicemanagement(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.generateConfigReport
         * @desc Generates and returns a report (errors, warnings and changes
@@ -282,7 +300,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    generateConfigReport(params, options, callback) {
+    generateConfigReport(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -303,7 +323,7 @@ function Servicemanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.get
         * @desc Gets a managed service. Authentication is required unless the
@@ -317,7 +337,8 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -338,7 +359,7 @@ function Servicemanagement(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.getConfig
         * @desc Gets a service configuration (version) for a managed service.
@@ -353,7 +374,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getConfig(params, options, callback) {
+    getConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -374,7 +397,7 @@ function Servicemanagement(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.getIamPolicy
         * @desc Gets the access control policy for a resource. Returns an empty
@@ -389,7 +412,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -410,7 +435,7 @@ function Servicemanagement(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.list
         * @desc Lists managed services.  Returns all public services. For
@@ -431,7 +456,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -451,7 +478,7 @@ function Servicemanagement(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.setIamPolicy
         * @desc Sets the access control policy on the specified resource.
@@ -466,7 +493,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -487,7 +516,7 @@ function Servicemanagement(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.testIamPermissions
         * @desc Returns permissions that a caller has on the specified resource.
@@ -506,7 +535,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -527,7 +558,7 @@ function Servicemanagement(options) {
         pathParams: ['resource'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * servicemanagement.services.undelete
         * @desc Revives a previously deleted managed service. The method
@@ -543,7 +574,9 @@ function Servicemanagement(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    undelete(params, options, callback) {
+    undelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -564,7 +597,7 @@ function Servicemanagement(options) {
         pathParams: ['serviceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     configs: {
       /**
@@ -583,7 +616,9 @@ function Servicemanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -604,7 +639,7 @@ function Servicemanagement(options) {
           pathParams: ['serviceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * servicemanagement.services.configs.get
           * @desc Gets a service configuration (version) for a managed service.
@@ -619,7 +654,8 @@ function Servicemanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -640,7 +676,7 @@ function Servicemanagement(options) {
           pathParams: ['configId', 'serviceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * servicemanagement.services.configs.list
           * @desc Lists the history of the service configuration for a managed
@@ -656,7 +692,9 @@ function Servicemanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -677,7 +715,7 @@ function Servicemanagement(options) {
           pathParams: ['serviceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * servicemanagement.services.configs.submit
           * @desc Creates a new service configuration (version) for a managed
@@ -697,7 +735,9 @@ function Servicemanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      submit(params, options, callback) {
+      submit(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -718,7 +758,7 @@ function Servicemanagement(options) {
           pathParams: ['serviceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -737,7 +777,9 @@ function Servicemanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -758,7 +800,7 @@ function Servicemanagement(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * servicemanagement.services.consumers.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -773,7 +815,9 @@ function Servicemanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -794,7 +838,7 @@ function Servicemanagement(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * servicemanagement.services.consumers.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -813,7 +857,9 @@ function Servicemanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -834,7 +880,7 @@ function Servicemanagement(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -858,7 +904,9 @@ function Servicemanagement(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -879,7 +927,7 @@ function Servicemanagement(options) {
           pathParams: ['serviceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * servicemanagement.services.rollouts.get
           * @desc Gets a service configuration rollout.
@@ -893,7 +941,8 @@ function Servicemanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -915,7 +964,7 @@ function Servicemanagement(options) {
           pathParams: ['rolloutId', 'serviceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * servicemanagement.services.rollouts.list
           * @desc Lists the history of the service configuration rollouts for a
@@ -932,7 +981,9 @@ function Servicemanagement(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -953,7 +1004,7 @@ function Servicemanagement(options) {
           pathParams: ['serviceName'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/serviceusage/v1.ts
+++ b/src/apis/serviceusage/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Service Usage API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Serviceusage
  */
-function Serviceusage(options) {
+function Serviceusage(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -58,7 +65,9 @@ function Serviceusage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -78,7 +87,7 @@ function Serviceusage(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceusage.operations.delete
         * @desc Deletes a long-running operation. This method indicates that the
@@ -94,7 +103,9 @@ function Serviceusage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -113,7 +124,7 @@ function Serviceusage(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceusage.operations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -128,7 +139,8 @@ function Serviceusage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +159,7 @@ function Serviceusage(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceusage.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -171,7 +183,9 @@ function Serviceusage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -190,7 +204,7 @@ function Serviceusage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -213,7 +227,9 @@ function Serviceusage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    disable(params, options, callback) {
+    disable(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -233,7 +249,7 @@ function Serviceusage(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceusage.services.enable
         * @desc Enable a service so it can be used with a project. See [Cloud
@@ -249,7 +265,9 @@ function Serviceusage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    enable(params, options, callback) {
+    enable(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -269,7 +287,7 @@ function Serviceusage(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceusage.services.get
         * @desc Returns the service definition and EnabledState for a given
@@ -283,7 +301,8 @@ function Serviceusage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -302,7 +321,7 @@ function Serviceusage(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceusage.services.listEnabled
         * @desc List enabled services.
@@ -317,7 +336,9 @@ function Serviceusage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    listEnabled(params, options, callback) {
+    listEnabled(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -337,7 +358,7 @@ function Serviceusage(options) {
         pathParams: ['parent'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * serviceusage.services.search
         * @desc Search available services.  When no filter is specified, returns
@@ -354,7 +375,9 @@ function Serviceusage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -374,7 +397,7 @@ function Serviceusage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/serviceuser/v1.ts
+++ b/src/apis/serviceuser/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Service User API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Serviceuser
  */
-function Serviceuser(options) {
+function Serviceuser(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -53,7 +60,9 @@ function Serviceuser(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      disable(params, options, callback) {
+      disable(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -74,7 +83,7 @@ function Serviceuser(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * serviceuser.projects.services.enable
           * @desc Enable a service so it can be used with a project. See [Cloud
@@ -90,7 +99,9 @@ function Serviceuser(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      enable(params, options, callback) {
+      enable(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -111,7 +122,7 @@ function Serviceuser(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * serviceuser.projects.services.list
           * @desc List enabled services for the specified consumer.
@@ -126,7 +137,9 @@ function Serviceuser(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -147,7 +160,7 @@ function Serviceuser(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -169,7 +182,9 @@ function Serviceuser(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    search(params, options, callback) {
+    search(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -189,7 +204,7 @@ function Serviceuser(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/sheets/v4.ts
+++ b/src/apis/sheets/v4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Sheets API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v4
  * @param {object=} options Options for Sheets
  */
-function Sheets(options) {
+function Sheets(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.spreadsheets = {
@@ -119,7 +126,9 @@ function Sheets(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchUpdate(params, options, callback) {
+    batchUpdate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +148,7 @@ function Sheets(options) {
         pathParams: ['spreadsheetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sheets.spreadsheets.create
         * @desc Creates a spreadsheet, returning the newly created spreadsheet.
@@ -202,7 +211,9 @@ function Sheets(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -221,7 +232,7 @@ function Sheets(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sheets.spreadsheets.get
         * @desc Returns the spreadsheet at the given ID. The caller must specify
@@ -306,7 +317,8 @@ function Sheets(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -326,7 +338,7 @@ function Sheets(options) {
         pathParams: ['spreadsheetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sheets.spreadsheets.getByDataFilter
         * @desc Returns the spreadsheet at the given ID. The caller must specify
@@ -412,7 +424,9 @@ function Sheets(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getByDataFilter(params, options, callback) {
+    getByDataFilter(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -433,7 +447,7 @@ function Sheets(options) {
         pathParams: ['spreadsheetId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     developerMetadata: {
       /**
@@ -502,7 +516,8 @@ function Sheets(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -524,7 +539,7 @@ function Sheets(options) {
           pathParams: ['metadataId', 'spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.developerMetadata.search
           * @desc Returns all developer metadata matching the specified
@@ -596,7 +611,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      search(params, options, callback) {
+      search(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -618,7 +635,7 @@ function Sheets(options) {
           pathParams: ['spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -698,7 +715,9 @@ function Sheets(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      copyTo(params, options, callback) {
+      copyTo(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -720,7 +739,7 @@ function Sheets(options) {
           pathParams: ['sheetId', 'spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     },
@@ -819,7 +838,9 @@ function Sheets(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      append(params, options, callback) {
+      append(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -840,7 +861,7 @@ function Sheets(options) {
           pathParams: ['range', 'spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.batchClear
           * @desc Clears one or more ranges of values from a spreadsheet. The
@@ -912,7 +933,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      batchClear(params, options, callback) {
+      batchClear(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -933,7 +956,7 @@ function Sheets(options) {
           pathParams: ['spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.batchClearByDataFilter
           * @desc Clears one or more ranges of values from a spreadsheet. The
@@ -1006,7 +1029,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      batchClearByDataFilter(params, options, callback) {
+      batchClearByDataFilter(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1028,7 +1053,7 @@ function Sheets(options) {
           pathParams: ['spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.batchGet
           * @desc Returns one or more ranges of values from a spreadsheet. The
@@ -1112,7 +1137,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      batchGet(params, options, callback) {
+      batchGet(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1133,7 +1160,7 @@ function Sheets(options) {
           pathParams: ['spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.batchGetByDataFilter
           * @desc Returns one or more ranges of values that match the specified
@@ -1222,7 +1249,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      batchGetByDataFilter(params, options, callback) {
+      batchGetByDataFilter(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1244,7 +1273,7 @@ function Sheets(options) {
           pathParams: ['spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.batchUpdate
           * @desc Sets values in one or more ranges of a spreadsheet. The caller
@@ -1318,7 +1347,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      batchUpdate(params, options, callback) {
+      batchUpdate(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1339,7 +1370,7 @@ function Sheets(options) {
           pathParams: ['spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.batchUpdateByDataFilter
           * @desc Sets values in one or more ranges of a spreadsheet. The caller
@@ -1417,7 +1448,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      batchUpdateByDataFilter(params, options, callback) {
+      batchUpdateByDataFilter(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1439,7 +1472,7 @@ function Sheets(options) {
           pathParams: ['spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.clear
           * @desc Clears values from a spreadsheet. The caller must specify the
@@ -1512,7 +1545,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      clear(params, options, callback) {
+      clear(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1533,7 +1568,7 @@ function Sheets(options) {
           pathParams: ['range', 'spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.get
           * @desc Returns a range of values from a spreadsheet. The caller must
@@ -1619,7 +1654,8 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1640,7 +1676,7 @@ function Sheets(options) {
           pathParams: ['range', 'spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sheets.spreadsheets.values.update
           * @desc Sets values in a range of a spreadsheet. The caller must
@@ -1720,7 +1756,9 @@ function Sheets(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -1741,7 +1779,7 @@ function Sheets(options) {
           pathParams: ['range', 'spreadsheetId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/siteVerification/v1.ts
+++ b/src/apis/siteVerification/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Site Verification API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Siteverification
  */
-function Siteverification(options) {
+function Siteverification(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.webResource = {
@@ -47,7 +54,9 @@ function Siteverification(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +76,7 @@ function Siteverification(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * siteVerification.webResource.get
         * @desc Get the most current data for a website or domain.
@@ -80,7 +89,8 @@ function Siteverification(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -100,7 +110,7 @@ function Siteverification(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * siteVerification.webResource.getToken
         * @desc Get a verification token for placing on a website or domain.
@@ -113,7 +123,9 @@ function Siteverification(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getToken(params, options, callback) {
+    getToken(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -133,7 +145,7 @@ function Siteverification(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * siteVerification.webResource.insert
         * @desc Attempt verification of a website or domain.
@@ -147,7 +159,9 @@ function Siteverification(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -167,7 +181,7 @@ function Siteverification(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * siteVerification.webResource.list
         * @desc Get the list of your verified websites and domains.
@@ -179,7 +193,9 @@ function Siteverification(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -199,7 +215,7 @@ function Siteverification(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * siteVerification.webResource.patch
         * @desc Modify the list of owners for your website or domain. This
@@ -214,7 +230,9 @@ function Siteverification(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -234,7 +252,7 @@ function Siteverification(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * siteVerification.webResource.update
         * @desc Modify the list of owners for your website or domain.
@@ -248,7 +266,9 @@ function Siteverification(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -268,7 +288,7 @@ function Siteverification(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/slides/v1.ts
+++ b/src/apis/slides/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Slides API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Slides
  */
-function Slides(options) {
+function Slides(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.presentations = {
@@ -61,7 +68,9 @@ function Slides(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchUpdate(params, options, callback) {
+    batchUpdate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -81,7 +90,7 @@ function Slides(options) {
         pathParams: ['presentationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * slides.presentations.create
         * @desc Creates a new presentation using the title given in the request.
@@ -96,7 +105,9 @@ function Slides(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -116,7 +127,7 @@ function Slides(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * slides.presentations.get
         * @desc Gets the latest version of the specified presentation.
@@ -129,7 +140,8 @@ function Slides(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -149,7 +161,7 @@ function Slides(options) {
         pathParams: ['presentationId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     pages: {
       /**
@@ -166,7 +178,8 @@ function Slides(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -187,7 +200,7 @@ function Slides(options) {
           pathParams: ['pageObjectId', 'presentationId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * slides.presentations.pages.getThumbnail
           * @desc Generates a thumbnail of the latest version of the specified
@@ -206,7 +219,9 @@ function Slides(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getThumbnail(params, options, callback) {
+      getThumbnail(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -228,7 +243,7 @@ function Slides(options) {
           pathParams: ['pageObjectId', 'presentationId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/sourcerepo/v1.ts
+++ b/src/apis/sourcerepo/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Source Repositories API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Sourcerepo
  */
-function Sourcerepo(options) {
+function Sourcerepo(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -50,7 +57,9 @@ function Sourcerepo(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -70,7 +79,7 @@ function Sourcerepo(options) {
           pathParams: ['parent'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sourcerepo.projects.repos.delete
           * @desc Deletes a repo.
@@ -83,7 +92,9 @@ function Sourcerepo(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -102,7 +113,7 @@ function Sourcerepo(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sourcerepo.projects.repos.get
           * @desc Returns information about a repo.
@@ -115,7 +126,8 @@ function Sourcerepo(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -134,7 +146,7 @@ function Sourcerepo(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sourcerepo.projects.repos.getIamPolicy
           * @desc Gets the access control policy for a resource. Returns an
@@ -148,7 +160,9 @@ function Sourcerepo(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      getIamPolicy(params, options, callback) {
+      getIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -168,7 +182,7 @@ function Sourcerepo(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sourcerepo.projects.repos.list
           * @desc Returns all repos belonging to a project. The sizes of the
@@ -185,7 +199,9 @@ function Sourcerepo(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -205,7 +221,7 @@ function Sourcerepo(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sourcerepo.projects.repos.setIamPolicy
           * @desc Sets the access control policy on the specified resource.
@@ -220,7 +236,9 @@ function Sourcerepo(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      setIamPolicy(params, options, callback) {
+      setIamPolicy(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -240,7 +258,7 @@ function Sourcerepo(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * sourcerepo.projects.repos.testIamPermissions
           * @desc Returns permissions that a caller has on the specified
@@ -256,7 +274,9 @@ function Sourcerepo(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      testIamPermissions(params, options, callback) {
+      testIamPermissions(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -276,7 +296,7 @@ function Sourcerepo(options) {
           pathParams: ['resource'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/spanner/v1.ts
+++ b/src/apis/spanner/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Spanner API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Spanner
  */
-function Spanner(options) {
+function Spanner(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects =
@@ -50,7 +57,8 @@ function Spanner(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -70,7 +78,7 @@ function Spanner(options) {
               pathParams: ['name'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * spanner.projects.instanceConfigs.list
               * @desc Lists the supported instance configurations for a given
@@ -86,7 +94,9 @@ function Spanner(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -107,7 +117,7 @@ function Spanner(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -147,7 +157,9 @@ function Spanner(options) {
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              create(params, options, callback) {
+              create(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -168,7 +180,7 @@ function Spanner(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * spanner.projects.instances.delete
                   * @desc Deletes an instance.  Immediately upon completion of
@@ -186,7 +198,9 @@ function Spanner(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              delete (params, options, callback) {
+              delete (
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -207,7 +221,7 @@ function Spanner(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * spanner.projects.instances.get
                   * @desc Gets information about a particular instance.
@@ -220,7 +234,8 @@ function Spanner(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              get(params, options, callback) {
+              get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -241,7 +256,7 @@ function Spanner(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * spanner.projects.instances.getIamPolicy
                   * @desc Gets the access control policy for an instance
@@ -258,7 +273,9 @@ function Spanner(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              getIamPolicy(params, options, callback) {
+              getIamPolicy(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -279,7 +296,7 @@ function Spanner(options) {
                   pathParams: ['resource'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * spanner.projects.instances.list
                   * @desc Lists all instances in the given project.
@@ -295,7 +312,9 @@ function Spanner(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              list(params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -316,7 +335,7 @@ function Spanner(options) {
                   pathParams: ['parent'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * spanner.projects.instances.patch
                   * @desc Updates an instance, and begins allocating or
@@ -356,7 +375,9 @@ function Spanner(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              patch(params, options, callback) {
+              patch(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -377,7 +398,7 @@ function Spanner(options) {
                   pathParams: ['name'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * spanner.projects.instances.setIamPolicy
                   * @desc Sets the access control policy on an instance
@@ -393,7 +414,9 @@ function Spanner(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              setIamPolicy(params, options, callback) {
+              setIamPolicy(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -414,7 +437,7 @@ function Spanner(options) {
                   pathParams: ['resource'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               }, /**
                   * spanner.projects.instances.testIamPermissions
                   * @desc Returns permissions that the caller has on the
@@ -433,7 +456,9 @@ function Spanner(options) {
                   * @param {callback} callback The callback that handles the response.
                   * @return {object} Request object
                   */
-              testIamPermissions(params, options, callback) {
+              testIamPermissions(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -454,7 +479,7 @@ function Spanner(options) {
                   pathParams: ['resource'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
+                return createAPIRequest(parameters, callback!);
               },
               databases:
                   {
@@ -477,7 +502,10 @@ function Spanner(options) {
                      * @param {callback} callback The callback that handles the response.
                      * @return {object} Request object
                      */
-                    create(params, options, callback) {
+                    create(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -498,7 +526,7 @@ function Spanner(options) {
                         pathParams: ['parent'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.dropDatabase
                         * @desc Drops (aka deletes) a Cloud Spanner database.
@@ -512,7 +540,10 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    dropDatabase(params, options, callback) {
+                    dropDatabase(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -533,7 +564,7 @@ function Spanner(options) {
                         pathParams: ['database'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.get
                         * @desc Gets the state of a Cloud Spanner database.
@@ -546,7 +577,9 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    get(params, options, callback) {
+                    get(params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -567,7 +600,7 @@ function Spanner(options) {
                         pathParams: ['name'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.getDdl
                         * @desc Returns the schema of a Cloud Spanner database
@@ -583,7 +616,10 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    getDdl(params, options, callback) {
+                    getDdl(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -604,7 +640,7 @@ function Spanner(options) {
                         pathParams: ['database'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.getIamPolicy
                         * @desc Gets the access control policy for a database
@@ -623,7 +659,10 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    getIamPolicy(params, options, callback) {
+                    getIamPolicy(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -644,7 +683,7 @@ function Spanner(options) {
                         pathParams: ['resource'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.list
                         * @desc Lists Cloud Spanner databases.
@@ -659,7 +698,10 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    list(params, options, callback) {
+                    list(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -680,7 +722,7 @@ function Spanner(options) {
                         pathParams: ['parent'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.setIamPolicy
                         * @desc Sets the access control policy on a database
@@ -698,7 +740,10 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    setIamPolicy(params, options, callback) {
+                    setIamPolicy(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -719,7 +764,7 @@ function Spanner(options) {
                         pathParams: ['resource'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.testIamPermissions
                         * @desc Returns permissions that the caller has on the
@@ -740,7 +785,10 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    testIamPermissions(params, options, callback) {
+                    testIamPermissions(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -762,7 +810,7 @@ function Spanner(options) {
                         pathParams: ['resource'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     }, /**
                         * spanner.projects.instances.databases.updateDdl
                         * @desc Updates the schema of a Cloud Spanner database
@@ -783,7 +831,10 @@ function Spanner(options) {
                         * @param {callback} callback The callback that handles the response.
                         * @return {object} Request object
                         */
-                    updateDdl(params, options, callback) {
+                    updateDdl(
+                        params: any,
+                        options: MethodOptions|BodyResponseCallback<any>,
+                        callback?: BodyResponseCallback<any>) {
                       if (typeof options === 'function') {
                         callback = options;
                         options = {};
@@ -804,7 +855,7 @@ function Spanner(options) {
                         pathParams: ['database'],
                         context: self
                       };
-                      return createAPIRequest(parameters, callback);
+                      return createAPIRequest(parameters, callback!);
                     },
                     operations: {
                       /**
@@ -831,7 +882,10 @@ function Spanner(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      cancel(params, options, callback) {
+                      cancel(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -852,7 +906,7 @@ function Spanner(options) {
                           pathParams: ['name'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.operations.delete
                           * @desc Deletes a long-running operation. This method
@@ -870,7 +924,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      delete (params, options, callback) {
+                      delete (
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -891,7 +948,7 @@ function Spanner(options) {
                           pathParams: ['name'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.operations.get
                           * @desc Gets the latest state of a long-running
@@ -908,7 +965,9 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      get(params, options, callback) {
+                      get(params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -929,7 +988,7 @@ function Spanner(options) {
                           pathParams: ['name'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.operations.list
                           * @desc Lists operations that match the specified
@@ -958,7 +1017,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      list(params, options, callback) {
+                      list(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -979,7 +1041,7 @@ function Spanner(options) {
                           pathParams: ['name'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     },
@@ -1000,7 +1062,10 @@ function Spanner(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      beginTransaction(params, options, callback) {
+                      beginTransaction(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1022,7 +1087,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.commit
                           * @desc Commits a transaction. The request includes
@@ -1045,7 +1110,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      commit(params, options, callback) {
+                      commit(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1066,7 +1134,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.create
                           * @desc Creates a new session. A session can be used
@@ -1098,7 +1166,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      create(params, options, callback) {
+                      create(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1119,7 +1190,7 @@ function Spanner(options) {
                           pathParams: ['database'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.delete
                           * @desc Ends a session, releasing server resources
@@ -1134,7 +1205,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      delete (params, options, callback) {
+                      delete (
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1155,7 +1229,7 @@ function Spanner(options) {
                           pathParams: ['name'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.executeSql
                           * @desc Executes an SQL query, returning all rows in a
@@ -1180,7 +1254,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      executeSql(params, options, callback) {
+                      executeSql(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1201,7 +1278,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.executeStreamingSql
                           * @desc Like ExecuteSql, except returns the result set
@@ -1220,7 +1297,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      executeStreamingSql(params, options, callback) {
+                      executeStreamingSql(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1242,7 +1322,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.get
                           * @desc Gets a session. Returns `NOT_FOUND` if the
@@ -1258,7 +1338,9 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      get(params, options, callback) {
+                      get(params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1279,7 +1361,7 @@ function Spanner(options) {
                           pathParams: ['name'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.list
                           * @desc Lists all sessions in a given database.
@@ -1296,7 +1378,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      list(params, options, callback) {
+                      list(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1317,7 +1402,7 @@ function Spanner(options) {
                           pathParams: ['database'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.partitionQuery
                           * @desc Creates a set of partition tokens that can be
@@ -1342,7 +1427,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      partitionQuery(params, options, callback) {
+                      partitionQuery(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1363,7 +1451,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.partitionRead
                           * @desc Creates a set of partition tokens that can be
@@ -1387,7 +1475,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      partitionRead(params, options, callback) {
+                      partitionRead(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1408,7 +1499,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.read
                           * @desc Reads rows from the database using key lookups
@@ -1433,7 +1524,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      read(params, options, callback) {
+                      read(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1454,7 +1548,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.rollback
                           * @desc Rolls back a transaction, releasing any locks
@@ -1476,7 +1570,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      rollback(params, options, callback) {
+                      rollback(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1497,7 +1594,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * spanner.projects.instances.databases.sessions.streamingRead
                           * @desc Like Read, except returns the result set as a
@@ -1516,7 +1613,10 @@ function Spanner(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      streamingRead(params, options, callback) {
+                      streamingRead(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1537,7 +1637,7 @@ function Spanner(options) {
                           pathParams: ['session'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     }
@@ -1565,7 +1665,10 @@ function Spanner(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                cancel(params, options, callback) {
+                cancel(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1586,7 +1689,7 @@ function Spanner(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * spanner.projects.instances.operations.delete
                     * @desc Deletes a long-running operation. This method
@@ -1603,7 +1706,10 @@ function Spanner(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1624,7 +1730,7 @@ function Spanner(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * spanner.projects.instances.operations.get
                     * @desc Gets the latest state of a long-running operation.
@@ -1639,7 +1745,9 @@ function Spanner(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1660,7 +1768,7 @@ function Spanner(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * spanner.projects.instances.operations.list
                     * @desc Lists operations that match the specified filter in
@@ -1686,7 +1794,10 @@ function Spanner(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1707,7 +1818,7 @@ function Spanner(options) {
                     pathParams: ['name'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               }

--- a/src/apis/spectrum/v1explorer.ts
+++ b/src/apis/spectrum/v1explorer.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Spectrum Database API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1explorer
  * @param {object=} options Options for Spectrum
  */
-function Spectrum(options) {
+function Spectrum(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.paws = {
@@ -49,7 +56,9 @@ function Spectrum(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getSpectrum(params, options, callback) {
+    getSpectrum(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Spectrum(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * spectrum.paws.getSpectrumBatch
         * @desc The Google Spectrum Database does not support batch requests, so
@@ -83,7 +92,9 @@ function Spectrum(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getSpectrumBatch(params, options, callback) {
+    getSpectrumBatch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -103,7 +114,7 @@ function Spectrum(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * spectrum.paws.init
         * @desc Initializes the connection between a white space device and the
@@ -117,7 +128,9 @@ function Spectrum(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    init(params, options, callback) {
+    init(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -137,7 +150,7 @@ function Spectrum(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * spectrum.paws.notifySpectrumUse
         * @desc Notifies the database that the device has selected certain
@@ -154,7 +167,9 @@ function Spectrum(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    notifySpectrumUse(params, options, callback) {
+    notifySpectrumUse(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -174,7 +189,7 @@ function Spectrum(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * spectrum.paws.register
         * @desc The Google Spectrum Database implements registration in the
@@ -189,7 +204,9 @@ function Spectrum(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    register(params, options, callback) {
+    register(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -209,7 +226,7 @@ function Spectrum(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * spectrum.paws.verifyDevice
         * @desc Validates a device for white space use in accordance with
@@ -225,7 +242,9 @@ function Spectrum(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    verifyDevice(params, options, callback) {
+    verifyDevice(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -245,7 +264,7 @@ function Spectrum(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/speech/v1.ts
+++ b/src/apis/speech/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Speech API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Speech
  */
-function Speech(options) {
+function Speech(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -49,7 +56,8 @@ function Speech(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Speech(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -89,7 +97,9 @@ function Speech(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    longrunningrecognize(params, options, callback) {
+    longrunningrecognize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -109,7 +119,7 @@ function Speech(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * speech.speech.recognize
         * @desc Performs synchronous speech recognition: receive results after
@@ -123,7 +133,9 @@ function Speech(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    recognize(params, options, callback) {
+    recognize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -143,7 +155,7 @@ function Speech(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/speech/v1beta1.ts
+++ b/src/apis/speech/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Speech API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Speech
  */
-function Speech(options) {
+function Speech(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.operations = {
@@ -49,7 +56,8 @@ function Speech(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Speech(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -90,7 +98,9 @@ function Speech(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    asyncrecognize(params, options, callback) {
+    asyncrecognize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -110,7 +120,7 @@ function Speech(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * speech.speech.syncrecognize
         * @desc Performs synchronous speech recognition: receive results after
@@ -124,7 +134,9 @@ function Speech(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    syncrecognize(params, options, callback) {
+    syncrecognize(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -144,7 +156,7 @@ function Speech(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/sqladmin/v1beta3.ts
+++ b/src/apis/sqladmin/v1beta3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud SQL Administration API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta3
  * @param {object=} options Options for Sqladmin
  */
-function Sqladmin(options) {
+function Sqladmin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.backupRuns = {
@@ -52,7 +59,8 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -75,7 +83,7 @@ function Sqladmin(options) {
         pathParams: ['backupConfiguration', 'instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.backupRuns.list
         * @desc Lists all backup runs associated with a Cloud SQL instance.
@@ -92,7 +100,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -114,7 +124,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -131,7 +141,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -151,7 +163,7 @@ function Sqladmin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -169,7 +181,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clone(params, options, callback) {
+    clone(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -189,7 +203,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.delete
         * @desc Deletes a Cloud SQL instance.
@@ -203,7 +217,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -224,7 +240,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.export
         * @desc Exports data from a Cloud SQL instance to a Google Cloud Storage
@@ -240,7 +256,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    export(params, options, callback) {
+    export(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -262,7 +280,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.get
         * @desc Retrieves information about a Cloud SQL instance.
@@ -276,7 +294,8 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -297,7 +316,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.import
         * @desc Imports data into a Cloud SQL instance from a MySQL dump file
@@ -313,7 +332,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    import(params, options, callback) {
+    import(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -335,7 +356,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.insert
         * @desc Creates a new Cloud SQL instance.
@@ -349,7 +370,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -369,7 +392,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.list
         * @desc Lists instances for a given project, in alphabetical order by
@@ -385,7 +408,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -405,7 +430,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.patch
         * @desc Updates the settings of a Cloud SQL instance. This method
@@ -421,7 +446,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -442,7 +469,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.promoteReplica
         * @desc Promotes the read replica instance to be a stand-alone Cloud SQL
@@ -457,7 +484,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    promoteReplica(params, options, callback) {
+    promoteReplica(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -479,7 +508,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.resetSslConfig
         * @desc Deletes all client certificates and generates a new server SSL
@@ -494,7 +523,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetSslConfig(params, options, callback) {
+    resetSslConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -516,7 +547,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.restart
         * @desc Restarts a Cloud SQL instance.
@@ -530,7 +561,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    restart(params, options, callback) {
+    restart(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -552,7 +585,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.restoreBackup
         * @desc Restores a backup of a Cloud SQL instance.
@@ -568,7 +601,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    restoreBackup(params, options, callback) {
+    restoreBackup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -591,7 +626,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.setRootPassword
         * @desc Sets the password for the root user of the specified Cloud SQL
@@ -607,7 +642,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setRootPassword(params, options, callback) {
+    setRootPassword(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -629,7 +666,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.update
         * @desc Updates the settings of a Cloud SQL instance.
@@ -644,7 +681,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -665,7 +704,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -685,7 +724,8 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -707,7 +747,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.operations.list
         * @desc Lists all operations that have been performed on a Cloud SQL
@@ -724,7 +764,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -746,7 +788,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -765,7 +807,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -787,7 +831,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.sslCerts.get
         * @desc Retrieves an SSL certificate as specified by its SHA-1
@@ -803,7 +847,8 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -825,7 +870,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.sslCerts.insert
         * @desc Creates an SSL certificate and returns the certificate, the
@@ -841,7 +886,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -863,7 +910,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.sslCerts.list
         * @desc Lists all of the current SSL certificates defined for a Cloud
@@ -878,7 +925,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -900,7 +949,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -918,7 +967,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -938,7 +989,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/sqladmin/v1beta4.ts
+++ b/src/apis/sqladmin/v1beta4.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud SQL Administration API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta4
  * @param {object=} options Options for Sqladmin
  */
-function Sqladmin(options) {
+function Sqladmin(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.backupRuns = {
@@ -50,7 +57,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -72,7 +81,7 @@ function Sqladmin(options) {
         pathParams: ['id', 'instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.backupRuns.get
         * @desc Retrieves a resource containing information about a backup run.
@@ -87,7 +96,8 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -109,7 +119,7 @@ function Sqladmin(options) {
         pathParams: ['id', 'instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.backupRuns.insert
         * @desc Creates a new backup run on demand. This method is applicable
@@ -125,7 +135,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -147,7 +159,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.backupRuns.list
         * @desc Lists all backup runs associated with a given instance and
@@ -164,7 +176,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -186,7 +200,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -205,7 +219,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -227,7 +243,7 @@ function Sqladmin(options) {
         pathParams: ['database', 'instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.databases.get
         * @desc Retrieves a resource containing information about a database
@@ -243,7 +259,8 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -265,7 +282,7 @@ function Sqladmin(options) {
         pathParams: ['database', 'instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.databases.insert
         * @desc Inserts a resource containing information about a database
@@ -281,7 +298,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -303,7 +322,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.databases.list
         * @desc Lists databases in the specified Cloud SQL instance.
@@ -317,7 +336,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -339,7 +360,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.databases.patch
         * @desc Updates a resource containing information about a database
@@ -356,7 +377,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -378,7 +401,7 @@ function Sqladmin(options) {
         pathParams: ['database', 'instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.databases.update
         * @desc Updates a resource containing information about a database
@@ -395,7 +418,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -417,7 +442,7 @@ function Sqladmin(options) {
         pathParams: ['database', 'instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -434,7 +459,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -454,7 +481,7 @@ function Sqladmin(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -474,7 +501,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clone(params, options, callback) {
+    clone(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -496,7 +525,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.delete
         * @desc Deletes a Cloud SQL instance.
@@ -510,7 +539,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -531,7 +562,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.demoteMaster
         * @desc Reserved for future use.
@@ -546,7 +577,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    demoteMaster(params, options, callback) {
+    demoteMaster(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -568,7 +601,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.export
         * @desc Exports data from a Cloud SQL instance to a Google Cloud Storage
@@ -584,7 +617,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    export(params, options, callback) {
+    export(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -606,7 +641,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.failover
         * @desc Failover the instance to its failover replica instance.
@@ -621,7 +656,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    failover(params, options, callback) {
+    failover(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -643,7 +680,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.get
         * @desc Retrieves a resource containing information about a Cloud SQL
@@ -658,7 +695,8 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -679,7 +717,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.import
         * @desc Imports data into a Cloud SQL instance from a MySQL dump file in
@@ -695,7 +733,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    import(params, options, callback) {
+    import(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -717,7 +757,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.insert
         * @desc Creates a new Cloud SQL instance.
@@ -731,7 +771,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -751,7 +793,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.list
         * @desc Lists instances under a given project in the alphabetical order
@@ -768,7 +810,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -788,7 +832,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.patch
         * @desc Updates settings of a Cloud SQL instance. Caution: This is not a
@@ -806,7 +850,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -827,7 +873,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.promoteReplica
         * @desc Promotes the read replica instance to be a stand-alone Cloud SQL
@@ -842,7 +888,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    promoteReplica(params, options, callback) {
+    promoteReplica(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -864,7 +912,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.resetSslConfig
         * @desc Deletes all client certificates and generates a new server SSL
@@ -881,7 +929,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resetSslConfig(params, options, callback) {
+    resetSslConfig(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -903,7 +953,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.restart
         * @desc Restarts a Cloud SQL instance.
@@ -917,7 +967,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    restart(params, options, callback) {
+    restart(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -939,7 +991,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.restoreBackup
         * @desc Restores a backup of a Cloud SQL instance.
@@ -954,7 +1006,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    restoreBackup(params, options, callback) {
+    restoreBackup(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -976,7 +1030,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.startReplica
         * @desc Starts the replication in the read replica instance.
@@ -990,7 +1044,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    startReplica(params, options, callback) {
+    startReplica(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1012,7 +1068,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.stopReplica
         * @desc Stops the replication in the read replica instance.
@@ -1026,7 +1082,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    stopReplica(params, options, callback) {
+    stopReplica(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1048,7 +1106,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.truncateLog
         * @desc Truncate MySQL general and slow query log tables
@@ -1063,7 +1121,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    truncateLog(params, options, callback) {
+    truncateLog(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1085,7 +1145,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.instances.update
         * @desc Updates settings of a Cloud SQL instance. Caution: This is not a
@@ -1102,7 +1162,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1123,7 +1185,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1142,7 +1204,8 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1163,7 +1226,7 @@ function Sqladmin(options) {
         pathParams: ['operation', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.operations.list
         * @desc Lists all instance operations that have been performed on the
@@ -1181,7 +1244,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1201,7 +1266,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1223,7 +1288,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    createEphemeral(params, options, callback) {
+    createEphemeral(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1245,7 +1312,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.sslCerts.delete
         * @desc Deletes the SSL certificate. The change will not take effect
@@ -1261,7 +1328,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1283,7 +1352,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.sslCerts.get
         * @desc Retrieves a particular SSL certificate. Does not include the
@@ -1300,7 +1369,8 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1322,7 +1392,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.sslCerts.insert
         * @desc Creates an SSL certificate and returns it along with the private
@@ -1339,7 +1409,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1361,7 +1433,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.sslCerts.list
         * @desc Lists all of the current SSL certificates for the instance.
@@ -1375,7 +1447,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1397,7 +1471,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1415,7 +1489,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1435,7 +1511,7 @@ function Sqladmin(options) {
         pathParams: ['project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1455,7 +1531,9 @@ function Sqladmin(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1477,7 +1555,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.users.insert
         * @desc Creates a new user in a Cloud SQL instance.
@@ -1492,7 +1570,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1514,7 +1594,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.users.list
         * @desc Lists users in the specified Cloud SQL instance.
@@ -1528,7 +1608,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1550,7 +1632,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * sql.users.update
         * @desc Updates an existing user in a Cloud SQL instance.
@@ -1567,7 +1649,9 @@ function Sqladmin(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1589,7 +1673,7 @@ function Sqladmin(options) {
         pathParams: ['instance', 'project'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1726,6 +1810,7 @@ function Sqladmin(options) {
  * @property {string} kind This is always sql#demoteMasterContext.
  * @property {string} masterInstanceName The name of the instance which will act as on-premises master in the replication setup.
  * @property {sqladmin(v1beta4).DemoteMasterConfiguration} replicaConfiguration Configuration specific to read-replicas replicating from the on-premises master.
+ * @property {boolean} verifyGtidConsistency Verify GTID consistency for demote operation. Default value: True. Second Generation instances only. Setting this flag to false enables you to bypass GTID consistency check between on-premises master and Cloud SQL instance during the demotion operation but also exposes you to the risk of future replication failures. Change the value only if you know the reason for the GTID divergence and are confident that doing so will not cause any replication issues.
  */
 /**
  * @typedef DemoteMasterMySqlReplicaConfiguration

--- a/src/apis/storage/v1.ts
+++ b/src/apis/storage/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Storage JSON API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Storage
  */
-function Storage(options) {
+function Storage(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.bucketAccessControls = {
@@ -105,7 +112,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -125,7 +134,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.get
         * @desc Returns the ACL entry for the specified entity on the specified
@@ -199,7 +208,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +229,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.insert
         * @desc Creates a new ACL entry on the specified bucket.
@@ -289,7 +299,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -309,7 +321,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.list
         * @desc Retrieves ACL entries on the specified bucket.
@@ -376,7 +388,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -396,7 +410,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.patch
         * @desc Updates an ACL entry on the specified bucket. This method
@@ -475,7 +489,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -495,7 +511,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.update
         * @desc Updates an ACL entry on the specified bucket.
@@ -573,7 +589,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -593,7 +611,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -663,7 +681,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -683,7 +703,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.get
         * @desc Returns metadata for the specified bucket.
@@ -753,7 +773,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -773,7 +794,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.getIamPolicy
         * @desc Returns an IAM policy for the specified bucket.
@@ -840,7 +861,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getIamPolicy(params, options, callback) {
+    getIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -860,7 +883,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.insert
         * @desc Creates a new bucket.
@@ -935,7 +958,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -954,7 +979,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.list
         * @desc Retrieves a list of buckets for a given project.
@@ -1038,7 +1063,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1057,7 +1084,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.lockRetentionPolicy
         * @desc Locks retention policy on a bucket.
@@ -1072,7 +1099,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    lockRetentionPolicy(params, options, callback) {
+    lockRetentionPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1092,7 +1121,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.patch
         * @desc Updates a bucket. Changes to the bucket will be readable
@@ -1173,7 +1202,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1193,7 +1224,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.setIamPolicy
         * @desc Updates an IAM policy for the specified bucket.
@@ -1267,7 +1298,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setIamPolicy(params, options, callback) {
+    setIamPolicy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1287,7 +1320,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.testIamPermissions
         * @desc Tests a set of permissions on the given bucket to see which, if
@@ -1357,7 +1390,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    testIamPermissions(params, options, callback) {
+    testIamPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1377,7 +1412,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.update
         * @desc Updates a bucket. Changes to the bucket will be readable
@@ -1458,7 +1493,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1478,7 +1515,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1546,7 +1583,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1566,7 +1605,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1641,7 +1680,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1662,7 +1703,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.get
         * @desc Returns the default object ACL entry for the specified entity on
@@ -1734,7 +1775,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1755,7 +1797,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.insert
         * @desc Creates a new default object ACL entry on the specified bucket.
@@ -1825,7 +1867,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1845,7 +1889,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.list
         * @desc Retrieves default object ACL entries on the specified bucket.
@@ -1912,7 +1956,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1932,7 +1978,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.patch
         * @desc Updates a default object ACL entry on the specified bucket. This
@@ -2011,7 +2057,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2032,7 +2080,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.update
         * @desc Updates a default object ACL entry on the specified bucket.
@@ -2110,7 +2158,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2131,7 +2181,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2203,7 +2253,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2224,7 +2276,7 @@ function Storage(options) {
         pathParams: ['bucket', 'notification'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.notifications.get
         * @desc View a notification configuration.
@@ -2296,7 +2348,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2317,7 +2370,7 @@ function Storage(options) {
         pathParams: ['bucket', 'notification'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.notifications.insert
         * @desc Creates a notification subscription for a given bucket.
@@ -2389,7 +2442,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2409,7 +2464,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.notifications.list
         * @desc Retrieves a list of notification subscriptions for a given
@@ -2477,7 +2532,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2497,7 +2554,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2579,7 +2636,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2599,7 +2658,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.get
         * @desc Returns the ACL entry for the specified entity on the specified
@@ -2680,7 +2739,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2700,7 +2760,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.insert
         * @desc Creates a new ACL entry on the specified object.
@@ -2777,7 +2837,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2797,7 +2859,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.list
         * @desc Retrieves ACL entries on the specified object.
@@ -2871,7 +2933,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2891,7 +2955,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.patch
         * @desc Updates an ACL entry on the specified object. This method
@@ -2977,7 +3041,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2997,7 +3063,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.update
         * @desc Updates an ACL entry on the specified object.
@@ -3082,7 +3148,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -3102,7 +3170,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -3192,7 +3260,9 @@ function Storage(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        compose(params, options, callback) {
+        compose(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3214,7 +3284,7 @@ function Storage(options) {
             pathParams: ['destinationBucket', 'destinationObject'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.copy
             * @desc Copies a source object to a destination object. Optionally
@@ -3322,7 +3392,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        copy(params, options, callback) {
+        copy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3350,7 +3422,7 @@ function Storage(options) {
             ],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.delete
             * @desc Deletes an object and its metadata. Deletions are permanent
@@ -3427,7 +3499,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3447,7 +3521,7 @@ function Storage(options) {
             pathParams: ['bucket', 'object'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.get
             * @desc Retrieves an object or its metadata.
@@ -3530,7 +3604,8 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3550,7 +3625,7 @@ function Storage(options) {
             pathParams: ['bucket', 'object'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.getIamPolicy
             * @desc Returns an IAM policy for the specified object.
@@ -3624,7 +3699,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        getIamPolicy(params, options, callback) {
+        getIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3644,7 +3721,7 @@ function Storage(options) {
             pathParams: ['bucket', 'object'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.insert
             * @desc Stores a new object and metadata.
@@ -3738,7 +3815,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        insert(params, options, callback) {
+        insert(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3760,7 +3839,7 @@ function Storage(options) {
             pathParams: ['bucket'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.list
             * @desc Retrieves a list of objects matching the criteria.
@@ -3846,7 +3925,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3866,7 +3947,7 @@ function Storage(options) {
             pathParams: ['bucket'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.patch
             * @desc Patches an object's metadata.
@@ -3953,7 +4034,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -3973,7 +4056,7 @@ function Storage(options) {
             pathParams: ['bucket', 'object'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.rewrite
             * @desc Rewrites a source object to a destination object. Optionally
@@ -4084,7 +4167,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        rewrite(params, options, callback) {
+        rewrite(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4112,7 +4197,7 @@ function Storage(options) {
             ],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.setIamPolicy
             * @desc Updates an IAM policy for the specified object.
@@ -4193,7 +4278,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        setIamPolicy(params, options, callback) {
+        setIamPolicy(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4213,7 +4300,7 @@ function Storage(options) {
             pathParams: ['bucket', 'object'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.testIamPermissions
             * @desc Tests a set of permissions on the given object to see which,
@@ -4290,7 +4377,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        testIamPermissions(params, options, callback) {
+        testIamPermissions(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4311,7 +4400,7 @@ function Storage(options) {
             pathParams: ['bucket', 'object'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.update
             * @desc Updates an object's metadata.
@@ -4398,7 +4487,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4418,7 +4509,7 @@ function Storage(options) {
             pathParams: ['bucket', 'object'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * storage.objects.watchAll
             * @desc Watch for changes on all objects in a bucket.
@@ -4496,7 +4587,9 @@ function Storage(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        watchAll(params, options, callback) {
+        watchAll(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -4516,7 +4609,7 @@ function Storage(options) {
             pathParams: ['bucket'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       };
@@ -4587,7 +4680,8 @@ function Storage(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -4608,7 +4702,7 @@ function Storage(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }

--- a/src/apis/storage/v1beta1.ts
+++ b/src/apis/storage/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Storage JSON API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Storage
  */
-function Storage(options) {
+function Storage(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.bucketAccessControls = {
@@ -49,7 +56,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.get
         * @desc Returns the ACL entry for the specified entity on the specified
@@ -84,7 +93,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +114,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.insert
         * @desc Creates a new ACL entry on the specified bucket.
@@ -118,7 +128,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +150,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.list
         * @desc Retrieves ACL entries on the specified bucket.
@@ -151,7 +163,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -171,7 +185,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.patch
         * @desc Updates an ACL entry on the specified bucket. This method
@@ -187,7 +201,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +223,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.update
         * @desc Updates an ACL entry on the specified bucket.
@@ -222,7 +238,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -242,7 +260,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -259,7 +277,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -279,7 +299,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.get
         * @desc Returns metadata for the specified bucket.
@@ -293,7 +313,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -313,7 +334,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.insert
         * @desc Creates a new bucket.
@@ -327,7 +348,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -347,7 +370,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.list
         * @desc Retrieves a list of buckets for a given project.
@@ -363,7 +386,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -383,7 +408,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.patch
         * @desc Updates a bucket. This method supports patch semantics.
@@ -398,7 +423,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -418,7 +445,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.update
         * @desc Updates a bucket.
@@ -433,7 +460,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -453,7 +482,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -473,7 +502,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -494,7 +525,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.get
         * @desc Returns the ACL entry for the specified entity on the specified
@@ -510,7 +541,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -531,7 +563,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.insert
         * @desc Creates a new ACL entry on the specified object.
@@ -546,7 +578,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -566,7 +600,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.list
         * @desc Retrieves ACL entries on the specified object.
@@ -580,7 +614,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -600,7 +636,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.patch
         * @desc Updates an ACL entry on the specified object. This method
@@ -617,7 +653,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -638,7 +676,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.update
         * @desc Updates an ACL entry on the specified object.
@@ -654,7 +692,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -675,7 +715,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -693,7 +733,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -713,7 +755,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.get
         * @desc Retrieves objects or their associated metadata.
@@ -728,7 +770,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -748,7 +791,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.insert
         * @desc Stores new data blobs and associated metadata.
@@ -767,7 +810,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -789,7 +834,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.list
         * @desc Retrieves a list of objects matching the criteria.
@@ -807,7 +852,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -827,7 +874,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.patch
         * @desc Updates a data blob's associated metadata. This method supports
@@ -844,7 +891,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -864,7 +913,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.update
         * @desc Updates a data blob's associated metadata.
@@ -880,7 +929,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -900,7 +951,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/storage/v1beta2.ts
+++ b/src/apis/storage/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Storage JSON API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Storage
  */
-function Storage(options) {
+function Storage(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.bucketAccessControls = {
@@ -49,7 +56,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.get
         * @desc Returns the ACL entry for the specified entity on the specified
@@ -84,7 +93,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +114,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.insert
         * @desc Creates a new ACL entry on the specified bucket.
@@ -118,7 +128,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -138,7 +150,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.list
         * @desc Retrieves ACL entries on the specified bucket.
@@ -151,7 +163,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -171,7 +185,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.patch
         * @desc Updates an ACL entry on the specified bucket. This method
@@ -187,7 +201,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -207,7 +223,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.bucketAccessControls.update
         * @desc Updates an ACL entry on the specified bucket.
@@ -222,7 +238,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -242,7 +260,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -261,7 +279,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -281,7 +301,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.get
         * @desc Returns metadata for the specified bucket.
@@ -297,7 +317,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -317,7 +338,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.insert
         * @desc Creates a new bucket.
@@ -332,7 +353,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -352,7 +375,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.list
         * @desc Retrieves a list of buckets for a given project.
@@ -368,7 +391,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -388,7 +413,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.patch
         * @desc Updates a bucket. This method supports patch semantics.
@@ -405,7 +430,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -425,7 +452,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.buckets.update
         * @desc Updates a bucket.
@@ -442,7 +469,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -462,7 +491,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -479,7 +508,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -499,7 +530,7 @@ function Storage(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -518,7 +549,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -539,7 +572,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.get
         * @desc Returns the default object ACL entry for the specified entity on
@@ -554,7 +587,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -575,7 +609,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.insert
         * @desc Creates a new default object ACL entry on the specified bucket.
@@ -589,7 +623,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -609,7 +645,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.list
         * @desc Retrieves default object ACL entries on the specified bucket.
@@ -624,7 +660,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -644,7 +682,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.patch
         * @desc Updates a default object ACL entry on the specified bucket. This
@@ -660,7 +698,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -681,7 +721,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.defaultObjectAccessControls.update
         * @desc Updates a default object ACL entry on the specified bucket.
@@ -696,7 +736,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -717,7 +759,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -738,7 +780,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -759,7 +803,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.get
         * @desc Returns the ACL entry for the specified entity on the specified
@@ -776,7 +820,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -797,7 +842,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.insert
         * @desc Creates a new ACL entry on the specified object.
@@ -813,7 +858,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -833,7 +880,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.list
         * @desc Retrieves ACL entries on the specified object.
@@ -848,7 +895,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -868,7 +917,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.patch
         * @desc Updates an ACL entry on the specified object. This method
@@ -886,7 +935,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -907,7 +958,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objectAccessControls.update
         * @desc Updates an ACL entry on the specified object.
@@ -924,7 +975,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -945,7 +998,7 @@ function Storage(options) {
         pathParams: ['bucket', 'entity', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -967,7 +1020,9 @@ function Storage(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    compose(params, options, callback) {
+    compose(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -989,7 +1044,7 @@ function Storage(options) {
         pathParams: ['destinationBucket', 'destinationObject'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.copy
         * @desc Copies an object to a destination in the same location.
@@ -1017,7 +1072,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    copy(params, options, callback) {
+    copy(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1045,7 +1102,7 @@ function Storage(options) {
         ],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.delete
         * @desc Deletes data blobs and associated metadata. Deletions are
@@ -1066,7 +1123,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1086,7 +1145,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.get
         * @desc Retrieves objects or their associated metadata.
@@ -1106,7 +1165,8 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1126,7 +1186,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.insert
         * @desc Stores new data blobs and associated metadata.
@@ -1149,7 +1209,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1171,7 +1233,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.list
         * @desc Retrieves a list of objects matching the criteria.
@@ -1190,7 +1252,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1210,7 +1274,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.patch
         * @desc Updates a data blob's associated metadata. This method supports
@@ -1232,7 +1296,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1252,7 +1318,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.update
         * @desc Updates a data blob's associated metadata.
@@ -1273,7 +1339,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1293,7 +1361,7 @@ function Storage(options) {
         pathParams: ['bucket', 'object'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storage.objects.watchAll
         * @desc Watch for changes on all objects in a bucket.
@@ -1313,7 +1381,9 @@ function Storage(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    watchAll(params, options, callback) {
+    watchAll(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1333,7 +1403,7 @@ function Storage(options) {
         pathParams: ['bucket'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/storagetransfer/v1.ts
+++ b/src/apis/storagetransfer/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Storage Transfer API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Storagetransfer
  */
-function Storagetransfer(options) {
+function Storagetransfer(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.googleServiceAccounts = {
@@ -108,7 +115,8 @@ function Storagetransfer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -129,7 +137,7 @@ function Storagetransfer(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -200,7 +208,9 @@ function Storagetransfer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -220,7 +230,7 @@ function Storagetransfer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferJobs.get
         * @desc Gets a transfer job.
@@ -289,7 +299,8 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -309,7 +320,7 @@ function Storagetransfer(options) {
         pathParams: ['jobName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferJobs.list
         * @desc Lists transfer jobs.
@@ -388,7 +399,9 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -408,7 +421,7 @@ function Storagetransfer(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferJobs.patch
         * @desc Updates a transfer job. Updating a job's transfer spec does not
@@ -483,7 +496,9 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -503,7 +518,7 @@ function Storagetransfer(options) {
         pathParams: ['jobName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -573,7 +588,9 @@ function Storagetransfer(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -594,7 +611,7 @@ function Storagetransfer(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferOperations.delete
         * @desc This method is not supported and the server returns
@@ -659,7 +676,9 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -679,7 +698,7 @@ function Storagetransfer(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferOperations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -746,7 +765,8 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -766,7 +786,7 @@ function Storagetransfer(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferOperations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -857,7 +877,9 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -877,7 +899,7 @@ function Storagetransfer(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferOperations.pause
         * @desc Pauses a transfer operation.
@@ -947,7 +969,9 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    pause(params, options, callback) {
+    pause(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -967,7 +991,7 @@ function Storagetransfer(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * storagetransfer.transferOperations.resume
         * @desc Resumes a transfer operation that is paused.
@@ -1037,7 +1061,9 @@ function Storagetransfer(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    resume(params, options, callback) {
+    resume(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1058,7 +1084,7 @@ function Storagetransfer(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/streetviewpublish/v1.ts
+++ b/src/apis/streetviewpublish/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Street View Publish API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Streetviewpublish
  */
-function Streetviewpublish(options) {
+function Streetviewpublish(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.photo = {
@@ -60,7 +67,9 @@ function Streetviewpublish(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -80,7 +89,7 @@ function Streetviewpublish(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * streetviewpublish.photo.delete
         * @desc Deletes a Photo and its metadata.  This method returns the
@@ -96,7 +105,9 @@ function Streetviewpublish(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -117,7 +128,7 @@ function Streetviewpublish(options) {
         pathParams: ['photoId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * streetviewpublish.photo.get
         * @desc Gets the metadata of the specified Photo.  This method returns
@@ -136,7 +147,8 @@ function Streetviewpublish(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -157,7 +169,7 @@ function Streetviewpublish(options) {
         pathParams: ['photoId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * streetviewpublish.photo.startUpload
         * @desc Creates an upload session to start uploading photo bytes. The
@@ -182,7 +194,9 @@ function Streetviewpublish(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    startUpload(params, options, callback) {
+    startUpload(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -203,7 +217,7 @@ function Streetviewpublish(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * streetviewpublish.photo.update
         * @desc Updates the metadata of a Photo, such as pose, place
@@ -229,7 +243,9 @@ function Streetviewpublish(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -249,7 +265,7 @@ function Streetviewpublish(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -272,7 +288,9 @@ function Streetviewpublish(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    batchDelete(params, options, callback) {
+    batchDelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -293,7 +311,7 @@ function Streetviewpublish(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * streetviewpublish.photos.batchGet
         * @desc Gets the metadata of the specified Photo batch.  Note that if
@@ -313,7 +331,9 @@ function Streetviewpublish(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    batchGet(params, options, callback) {
+    batchGet(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -334,7 +354,7 @@ function Streetviewpublish(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * streetviewpublish.photos.batchUpdate
         * @desc Updates the metadata of Photos, such as pose, place association,
@@ -358,7 +378,9 @@ function Streetviewpublish(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    batchUpdate(params, options, callback) {
+    batchUpdate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -379,7 +401,7 @@ function Streetviewpublish(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * streetviewpublish.photos.list
         * @desc Lists all the Photos that belong to the user.  <aside
@@ -397,7 +419,9 @@ function Streetviewpublish(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -417,7 +441,7 @@ function Streetviewpublish(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/surveys/v2.ts
+++ b/src/apis/surveys/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Surveys API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Surveys
  */
-function Surveys(options) {
+function Surveys(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.mobileapppanels = {
@@ -49,7 +56,8 @@ function Surveys(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +77,7 @@ function Surveys(options) {
         pathParams: ['panelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.mobileapppanels.list
         * @desc Lists the MobileAppPanels available to the authenticated user.
@@ -84,7 +92,9 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -104,7 +114,7 @@ function Surveys(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.mobileapppanels.update
         * @desc Updates a MobileAppPanel. Currently the only property that can
@@ -119,7 +129,9 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +151,7 @@ function Surveys(options) {
         pathParams: ['panelId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -159,7 +171,8 @@ function Surveys(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -179,7 +192,7 @@ function Surveys(options) {
         pathParams: ['surveyUrlId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -196,7 +209,9 @@ function Surveys(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -216,7 +231,7 @@ function Surveys(options) {
         pathParams: ['surveyUrlId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.surveys.get
         * @desc Retrieves information about the specified survey.
@@ -229,7 +244,8 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -249,7 +265,7 @@ function Surveys(options) {
         pathParams: ['surveyUrlId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.surveys.insert
         * @desc Creates a survey.
@@ -262,7 +278,9 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -282,7 +300,7 @@ function Surveys(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.surveys.list
         * @desc Lists the surveys owned by the authenticated user.
@@ -297,7 +315,9 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -317,7 +337,7 @@ function Surveys(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.surveys.start
         * @desc Begins running a survey.
@@ -331,7 +351,9 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    start(params, options, callback) {
+    start(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -351,7 +373,7 @@ function Surveys(options) {
         pathParams: ['resourceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.surveys.stop
         * @desc Stops a running survey.
@@ -364,7 +386,9 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    stop(params, options, callback) {
+    stop(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -384,7 +408,7 @@ function Surveys(options) {
         pathParams: ['resourceId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * surveys.surveys.update
         * @desc Updates a survey. Currently the only property that can be
@@ -399,7 +423,9 @@ function Surveys(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -419,7 +445,7 @@ function Surveys(options) {
         pathParams: ['surveyUrlId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/tagmanager/v1.ts
+++ b/src/apis/tagmanager/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Tag Manager API
@@ -31,164 +38,763 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Tagmanager
  */
-function Tagmanager(options) {
+function Tagmanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
-  self.accounts =
-      {
-        /**
-         * tagmanager.accounts.get
-         * @desc Gets a GTM Account.
-         * @alias tagmanager.accounts.get
-         * @memberOf! tagmanager(v1)
-         *
-         * @param {object} params Parameters for request
-         * @param {string} params.accountId The GTM Account ID.
-         * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-         * @param {callback} callback The callback that handles the response.
-         * @return {object} Request object
-         */
-        get(params, options, callback) {
-          if (typeof options === 'function') {
-            callback = options;
-            options = {};
-          }
-          options = options || {};
-          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-          const parameters = {
-            options: Object.assign(
-                {
-                  url: (rootUrl + '/tagmanager/v1/accounts/{accountId}')
-                           .replace(/([^:]\/)\/+/g, '$1'),
-                  method: 'GET'
-                },
-                options),
-            params,
-            requiredParams: ['accountId'],
-            pathParams: ['accountId'],
-            context: self
-          };
-          return createAPIRequest(parameters, callback);
-        }, /**
-            * tagmanager.accounts.list
-            * @desc Lists all GTM Accounts that a user has access to.
-            * @alias tagmanager.accounts.list
-            * @memberOf! tagmanager(v1)
-            *
-            * @param {object=} params Parameters for request
-            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-            * @param {callback} callback The callback that handles the response.
-            * @return {object} Request object
-            */
-        list(params, options, callback) {
-          if (typeof options === 'function') {
-            callback = options;
-            options = {};
-          }
-          options = options || {};
-          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-          const parameters = {
-            options: Object.assign(
-                {
-                  url: (rootUrl + '/tagmanager/v1/accounts')
-                           .replace(/([^:]\/)\/+/g, '$1'),
-                  method: 'GET'
-                },
-                options),
-            params,
-            requiredParams: [],
-            pathParams: [],
-            context: self
-          };
-          return createAPIRequest(parameters, callback);
-        }, /**
-            * tagmanager.accounts.update
-            * @desc Updates a GTM Account.
-            * @alias tagmanager.accounts.update
-            * @memberOf! tagmanager(v1)
-            *
-            * @param {object} params Parameters for request
-            * @param {string} params.accountId The GTM Account ID.
-            * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the account in storage.
-            * @param {tagmanager(v1).Account} params.resource Request body data
-            * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-            * @param {callback} callback The callback that handles the response.
-            * @return {object} Request object
-            */
-        update(params, options, callback) {
-          if (typeof options === 'function') {
-            callback = options;
-            options = {};
-          }
-          options = options || {};
-          const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-          const parameters = {
-            options: Object.assign(
-                {
-                  url: (rootUrl + '/tagmanager/v1/accounts/{accountId}')
-                           .replace(/([^:]\/)\/+/g, '$1'),
-                  method: 'PUT'
-                },
-                options),
-            params,
-            requiredParams: ['accountId'],
-            pathParams: ['accountId'],
-            context: self
-          };
-          return createAPIRequest(parameters, callback);
-        },
-        containers:
+  self.accounts = {
+    /**
+     * tagmanager.accounts.get
+     * @desc Gets a GTM Account.
+     * @alias tagmanager.accounts.get
+     * @memberOf! tagmanager(v1)
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.accountId The GTM Account ID.
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
             {
+              url: (rootUrl + '/tagmanager/v1/accounts/{accountId}')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['accountId'],
+        pathParams: ['accountId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * tagmanager.accounts.list
+        * @desc Lists all GTM Accounts that a user has access to.
+        * @alias tagmanager.accounts.list
+        * @memberOf! tagmanager(v1)
+        *
+        * @param {object=} params Parameters for request
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/tagmanager/v1/accounts')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: [],
+        pathParams: [],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    }, /**
+        * tagmanager.accounts.update
+        * @desc Updates a GTM Account.
+        * @alias tagmanager.accounts.update
+        * @memberOf! tagmanager(v1)
+        *
+        * @param {object} params Parameters for request
+        * @param {string} params.accountId The GTM Account ID.
+        * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the account in storage.
+        * @param {tagmanager(v1).Account} params.resource Request body data
+        * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+        * @param {callback} callback The callback that handles the response.
+        * @return {object} Request object
+        */
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
+      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/tagmanager/v1/accounts/{accountId}')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'PUT'
+            },
+            options),
+        params,
+        requiredParams: ['accountId'],
+        pathParams: ['accountId'],
+        context: self
+      };
+      return createAPIRequest(parameters, callback!);
+    },
+    containers:
+        {
+          /**
+           * tagmanager.accounts.containers.create
+           * @desc Creates a Container.
+           * @alias tagmanager.accounts.containers.create
+           * @memberOf! tagmanager(v1)
+           *
+           * @param {object} params Parameters for request
+           * @param {string} params.accountId The GTM Account ID.
+           * @param {tagmanager(v1).Container} params.resource Request body data
+           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+           * @param {callback} callback The callback that handles the response.
+           * @return {object} Request object
+           */
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl +
+                          '/tagmanager/v1/accounts/{accountId}/containers')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'POST'
+                  },
+                  options),
+              params,
+              requiredParams: ['accountId'],
+              pathParams: ['accountId'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * tagmanager.accounts.containers.delete
+              * @desc Deletes a Container.
+              * @alias tagmanager.accounts.containers.delete
+              * @memberOf! tagmanager(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.accountId The GTM Account ID.
+              * @param {string} params.containerId The GTM Container ID.
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url:
+                        (rootUrl +
+                         '/tagmanager/v1/accounts/{accountId}/containers/{containerId}')
+                            .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'DELETE'
+                  },
+                  options),
+              params,
+              requiredParams: ['accountId', 'containerId'],
+              pathParams: ['accountId', 'containerId'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * tagmanager.accounts.containers.get
+              * @desc Gets a Container.
+              * @alias tagmanager.accounts.containers.get
+              * @memberOf! tagmanager(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.accountId The GTM Account ID.
+              * @param {string} params.containerId The GTM Container ID.
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url:
+                        (rootUrl +
+                         '/tagmanager/v1/accounts/{accountId}/containers/{containerId}')
+                            .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'GET'
+                  },
+                  options),
+              params,
+              requiredParams: ['accountId', 'containerId'],
+              pathParams: ['accountId', 'containerId'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * tagmanager.accounts.containers.list
+              * @desc Lists all Containers that belongs to a GTM Account.
+              * @alias tagmanager.accounts.containers.list
+              * @memberOf! tagmanager(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.accountId The GTM Account ID.
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url: (rootUrl +
+                          '/tagmanager/v1/accounts/{accountId}/containers')
+                             .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'GET'
+                  },
+                  options),
+              params,
+              requiredParams: ['accountId'],
+              pathParams: ['accountId'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          }, /**
+              * tagmanager.accounts.containers.update
+              * @desc Updates a Container.
+              * @alias tagmanager.accounts.containers.update
+              * @memberOf! tagmanager(v1)
+              *
+              * @param {object} params Parameters for request
+              * @param {string} params.accountId The GTM Account ID.
+              * @param {string} params.containerId The GTM Container ID.
+              * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the container in storage.
+              * @param {tagmanager(v1).Container} params.resource Request body data
+              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+              * @param {callback} callback The callback that handles the response.
+              * @return {object} Request object
+              */
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
+            if (typeof options === 'function') {
+              callback = options;
+              options = {};
+            }
+            options = options || {};
+            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+            const parameters = {
+              options: Object.assign(
+                  {
+                    url:
+                        (rootUrl +
+                         '/tagmanager/v1/accounts/{accountId}/containers/{containerId}')
+                            .replace(/([^:]\/)\/+/g, '$1'),
+                    method: 'PUT'
+                  },
+                  options),
+              params,
+              requiredParams: ['accountId', 'containerId'],
+              pathParams: ['accountId', 'containerId'],
+              context: self
+            };
+            return createAPIRequest(parameters, callback!);
+          },
+          environments: {
+            /**
+             * tagmanager.accounts.containers.environments.create
+             * @desc Creates a GTM Environment.
+             * @alias tagmanager.accounts.containers.environments.create
+             * @memberOf! tagmanager(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.accountId The GTM Account ID.
+             * @param {string} params.containerId The GTM Container ID.
+             * @param {tagmanager(v1).Environment} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.environments.delete
+                * @desc Deletes a GTM Environment.
+                * @alias tagmanager.accounts.containers.environments.delete
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.environmentId The GTM Environment ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'DELETE'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'environmentId'],
+                pathParams: ['accountId', 'containerId', 'environmentId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.environments.get
+                * @desc Gets a GTM Environment.
+                * @alias tagmanager.accounts.containers.environments.get
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.environmentId The GTM Environment ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'environmentId'],
+                pathParams: ['accountId', 'containerId', 'environmentId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.environments.list
+                * @desc Lists all GTM Environments of a GTM Container.
+                * @alias tagmanager.accounts.containers.environments.list
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.environments.patch
+                * @desc Updates a GTM Environment. This method supports patch
+                * semantics.
+                * @alias tagmanager.accounts.containers.environments.patch
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.environmentId The GTM Environment ID.
+                * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the environment in storage.
+                * @param {tagmanager(v1).Environment} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PATCH'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'environmentId'],
+                pathParams: ['accountId', 'containerId', 'environmentId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.environments.update
+                * @desc Updates a GTM Environment.
+                * @alias tagmanager.accounts.containers.environments.update
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.environmentId The GTM Environment ID.
+                * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the environment in storage.
+                * @param {tagmanager(v1).Environment} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PUT'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'environmentId'],
+                pathParams: ['accountId', 'containerId', 'environmentId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }
+
+          },
+          folders: {
+            /**
+             * tagmanager.accounts.containers.folders.create
+             * @desc Creates a GTM Folder.
+             * @alias tagmanager.accounts.containers.folders.create
+             * @memberOf! tagmanager(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.accountId The GTM Account ID.
+             * @param {string} params.containerId The GTM Container ID.
+             * @param {tagmanager(v1).Folder} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.folders.delete
+                * @desc Deletes a GTM Folder.
+                * @alias tagmanager.accounts.containers.folders.delete
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.folderId The GTM Folder ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'DELETE'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'folderId'],
+                pathParams: ['accountId', 'containerId', 'folderId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.folders.get
+                * @desc Gets a GTM Folder.
+                * @alias tagmanager.accounts.containers.folders.get
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.folderId The GTM Folder ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'folderId'],
+                pathParams: ['accountId', 'containerId', 'folderId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.folders.list
+                * @desc Lists all GTM Folders of a Container.
+                * @alias tagmanager.accounts.containers.folders.list
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.folders.update
+                * @desc Updates a GTM Folder.
+                * @alias tagmanager.accounts.containers.folders.update
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the folder in storage.
+                * @param {string} params.folderId The GTM Folder ID.
+                * @param {tagmanager(v1).Folder} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PUT'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'folderId'],
+                pathParams: ['accountId', 'containerId', 'folderId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            },
+            entities: {
               /**
-               * tagmanager.accounts.containers.create
-               * @desc Creates a Container.
-               * @alias tagmanager.accounts.containers.create
+               * tagmanager.accounts.containers.folders.entities.list
+               * @desc List all entities in a GTM Folder.
+               * @alias tagmanager.accounts.containers.folders.entities.list
                * @memberOf! tagmanager(v1)
                *
                * @param {object} params Parameters for request
                * @param {string} params.accountId The GTM Account ID.
-               * @param {tagmanager(v1).Container} params.resource Request body data
+               * @param {string} params.containerId The GTM Container ID.
+               * @param {string} params.folderId The GTM Folder ID.
                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
                * @param {callback} callback The callback that handles the response.
                * @return {object} Request object
                */
-              create(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url: (rootUrl +
-                              '/tagmanager/v1/accounts/{accountId}/containers')
-                                 .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'POST'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId'],
-                  pathParams: ['accountId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * tagmanager.accounts.containers.delete
-                  * @desc Deletes a Container.
-                  * @alias tagmanager.accounts.containers.delete
-                  * @memberOf! tagmanager(v1)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The GTM Account ID.
-                  * @param {string} params.containerId The GTM Container ID.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              delete (params, options, callback) {
+              list(
+                  params: any, options: MethodOptions|BodyResponseCallback<any>,
+                  callback?: BodyResponseCallback<any>) {
                 if (typeof options === 'function') {
                   callback = options;
                   options = {};
@@ -201,1283 +807,712 @@ function Tagmanager(options) {
                       {
                         url:
                             (rootUrl +
-                             '/tagmanager/v1/accounts/{accountId}/containers/{containerId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'DELETE'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'containerId'],
-                  pathParams: ['accountId', 'containerId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * tagmanager.accounts.containers.get
-                  * @desc Gets a Container.
-                  * @alias tagmanager.accounts.containers.get
-                  * @memberOf! tagmanager(v1)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The GTM Account ID.
-                  * @param {string} params.containerId The GTM Container ID.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              get(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/tagmanager/v1/accounts/{accountId}/containers/{containerId}')
+                             '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}/entities')
                                 .replace(/([^:]\/)\/+/g, '$1'),
                         method: 'GET'
                       },
                       options),
                   params,
-                  requiredParams: ['accountId', 'containerId'],
-                  pathParams: ['accountId', 'containerId'],
+                  requiredParams: ['accountId', 'containerId', 'folderId'],
+                  pathParams: ['accountId', 'containerId', 'folderId'],
                   context: self
                 };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * tagmanager.accounts.containers.list
-                  * @desc Lists all Containers that belongs to a GTM Account.
-                  * @alias tagmanager.accounts.containers.list
-                  * @memberOf! tagmanager(v1)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The GTM Account ID.
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              list(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url: (rootUrl +
-                              '/tagmanager/v1/accounts/{accountId}/containers')
-                                 .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'GET'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId'],
-                  pathParams: ['accountId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              }, /**
-                  * tagmanager.accounts.containers.update
-                  * @desc Updates a Container.
-                  * @alias tagmanager.accounts.containers.update
-                  * @memberOf! tagmanager(v1)
-                  *
-                  * @param {object} params Parameters for request
-                  * @param {string} params.accountId The GTM Account ID.
-                  * @param {string} params.containerId The GTM Container ID.
-                  * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the container in storage.
-                  * @param {tagmanager(v1).Container} params.resource Request body data
-                  * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                  * @param {callback} callback The callback that handles the response.
-                  * @return {object} Request object
-                  */
-              update(params, options, callback) {
-                if (typeof options === 'function') {
-                  callback = options;
-                  options = {};
-                }
-                options = options || {};
-                const rootUrl =
-                    options.rootUrl || 'https://www.googleapis.com/';
-                const parameters = {
-                  options: Object.assign(
-                      {
-                        url:
-                            (rootUrl +
-                             '/tagmanager/v1/accounts/{accountId}/containers/{containerId}')
-                                .replace(/([^:]\/)\/+/g, '$1'),
-                        method: 'PUT'
-                      },
-                      options),
-                  params,
-                  requiredParams: ['accountId', 'containerId'],
-                  pathParams: ['accountId', 'containerId'],
-                  context: self
-                };
-                return createAPIRequest(parameters, callback);
-              },
-              environments: {
-                /**
-                 * tagmanager.accounts.containers.environments.create
-                 * @desc Creates a GTM Environment.
-                 * @alias tagmanager.accounts.containers.environments.create
-                 * @memberOf! tagmanager(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string} params.accountId The GTM Account ID.
-                 * @param {string} params.containerId The GTM Container ID.
-                 * @param {tagmanager(v1).Environment} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                create(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.environments.delete
-                    * @desc Deletes a GTM Environment.
-                    * @alias tagmanager.accounts.containers.environments.delete
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.environmentId The GTM Environment ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                delete (params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'DELETE'
-                        },
-                        options),
-                    params,
-                    requiredParams:
-                        ['accountId', 'containerId', 'environmentId'],
-                    pathParams: ['accountId', 'containerId', 'environmentId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.environments.get
-                    * @desc Gets a GTM Environment.
-                    * @alias tagmanager.accounts.containers.environments.get
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.environmentId The GTM Environment ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                get(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams:
-                        ['accountId', 'containerId', 'environmentId'],
-                    pathParams: ['accountId', 'containerId', 'environmentId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.environments.list
-                    * @desc Lists all GTM Environments of a GTM Container.
-                    * @alias tagmanager.accounts.containers.environments.list
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                list(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.environments.patch
-                    * @desc Updates a GTM Environment. This method supports
-                    * patch semantics.
-                    * @alias tagmanager.accounts.containers.environments.patch
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.environmentId The GTM Environment ID.
-                    * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the environment in storage.
-                    * @param {tagmanager(v1).Environment} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                patch(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PATCH'
-                        },
-                        options),
-                    params,
-                    requiredParams:
-                        ['accountId', 'containerId', 'environmentId'],
-                    pathParams: ['accountId', 'containerId', 'environmentId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.environments.update
-                    * @desc Updates a GTM Environment.
-                    * @alias tagmanager.accounts.containers.environments.update
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.environmentId The GTM Environment ID.
-                    * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the environment in storage.
-                    * @param {tagmanager(v1).Environment} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                update(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/environments/{environmentId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PUT'
-                        },
-                        options),
-                    params,
-                    requiredParams:
-                        ['accountId', 'containerId', 'environmentId'],
-                    pathParams: ['accountId', 'containerId', 'environmentId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }
+                return createAPIRequest(parameters, callback!);
+              }
 
-              },
-              folders: {
-                /**
-                 * tagmanager.accounts.containers.folders.create
-                 * @desc Creates a GTM Folder.
-                 * @alias tagmanager.accounts.containers.folders.create
-                 * @memberOf! tagmanager(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string} params.accountId The GTM Account ID.
-                 * @param {string} params.containerId The GTM Container ID.
-                 * @param {tagmanager(v1).Folder} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                create(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.folders.delete
-                    * @desc Deletes a GTM Folder.
-                    * @alias tagmanager.accounts.containers.folders.delete
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.folderId The GTM Folder ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                delete (params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'DELETE'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'folderId'],
-                    pathParams: ['accountId', 'containerId', 'folderId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.folders.get
-                    * @desc Gets a GTM Folder.
-                    * @alias tagmanager.accounts.containers.folders.get
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.folderId The GTM Folder ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                get(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'folderId'],
-                    pathParams: ['accountId', 'containerId', 'folderId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.folders.list
-                    * @desc Lists all GTM Folders of a Container.
-                    * @alias tagmanager.accounts.containers.folders.list
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                list(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.folders.update
-                    * @desc Updates a GTM Folder.
-                    * @alias tagmanager.accounts.containers.folders.update
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the folder in storage.
-                    * @param {string} params.folderId The GTM Folder ID.
-                    * @param {tagmanager(v1).Folder} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                update(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PUT'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'folderId'],
-                    pathParams: ['accountId', 'containerId', 'folderId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                },
-                entities: {
-                  /**
-                   * tagmanager.accounts.containers.folders.entities.list
-                   * @desc List all entities in a GTM Folder.
-                   * @alias tagmanager.accounts.containers.folders.entities.list
-                   * @memberOf! tagmanager(v1)
-                   *
-                   * @param {object} params Parameters for request
-                   * @param {string} params.accountId The GTM Account ID.
-                   * @param {string} params.containerId The GTM Container ID.
-                   * @param {string} params.folderId The GTM Folder ID.
-                   * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                   * @param {callback} callback The callback that handles the response.
-                   * @return {object} Request object
-                   */
-                  list(params, options, callback) {
-                    if (typeof options === 'function') {
-                      callback = options;
-                      options = {};
-                    }
-                    options = options || {};
-                    const rootUrl =
-                        options.rootUrl || 'https://www.googleapis.com/';
-                    const parameters = {
-                      options: Object.assign(
-                          {
-                            url:
-                                (rootUrl +
-                                 '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/folders/{folderId}/entities')
-                                    .replace(/([^:]\/)\/+/g, '$1'),
-                            method: 'GET'
-                          },
-                          options),
-                      params,
-                      requiredParams: ['accountId', 'containerId', 'folderId'],
-                      pathParams: ['accountId', 'containerId', 'folderId'],
-                      context: self
-                    };
-                    return createAPIRequest(parameters, callback);
-                  }
+            }
+          },
+          move_folders: {
+            /**
+             * tagmanager.accounts.containers.move_folders.update
+             * @desc Moves entities to a GTM Folder.
+             * @alias tagmanager.accounts.containers.move_folders.update
+             * @memberOf! tagmanager(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.accountId The GTM Account ID.
+             * @param {string} params.containerId The GTM Container ID.
+             * @param {string} params.folderId The GTM Folder ID.
+             * @param {string=} params.tagId The tags to be moved to the folder.
+             * @param {string=} params.triggerId The triggers to be moved to the folder.
+             * @param {string=} params.variableId The variables to be moved to the folder.
+             * @param {tagmanager(v1).Folder} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/move_folders/{folderId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PUT'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'folderId'],
+                pathParams: ['accountId', 'containerId', 'folderId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }
 
-                }
-              },
-              move_folders: {
-                /**
-                 * tagmanager.accounts.containers.move_folders.update
-                 * @desc Moves entities to a GTM Folder.
-                 * @alias tagmanager.accounts.containers.move_folders.update
-                 * @memberOf! tagmanager(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string} params.accountId The GTM Account ID.
-                 * @param {string} params.containerId The GTM Container ID.
-                 * @param {string} params.folderId The GTM Folder ID.
-                 * @param {string=} params.tagId The tags to be moved to the folder.
-                 * @param {string=} params.triggerId The triggers to be moved to the folder.
-                 * @param {string=} params.variableId The variables to be moved to the folder.
-                 * @param {tagmanager(v1).Folder} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                update(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/move_folders/{folderId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PUT'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'folderId'],
-                    pathParams: ['accountId', 'containerId', 'folderId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }
+          },
+          reauthorize_environments: {
+            /**
+             * tagmanager.accounts.containers.reauthorize_environments.update
+             * @desc Re-generates the authorization code for a GTM Environment.
+             * @alias
+             * tagmanager.accounts.containers.reauthorize_environments.update
+             * @memberOf! tagmanager(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.accountId The GTM Account ID.
+             * @param {string} params.containerId The GTM Container ID.
+             * @param {string} params.environmentId The GTM Environment ID.
+             * @param {tagmanager(v1).Environment} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/reauthorize_environments/{environmentId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PUT'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'environmentId'],
+                pathParams: ['accountId', 'containerId', 'environmentId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }
 
-              },
-              reauthorize_environments: {
-                /**
-                 * tagmanager.accounts.containers.reauthorize_environments.update
-                 * @desc Re-generates the authorization code for a GTM
-                 * Environment.
-                 * @alias
-                 * tagmanager.accounts.containers.reauthorize_environments.update
-                 * @memberOf! tagmanager(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string} params.accountId The GTM Account ID.
-                 * @param {string} params.containerId The GTM Container ID.
-                 * @param {string} params.environmentId The GTM Environment ID.
-                 * @param {tagmanager(v1).Environment} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                update(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/reauthorize_environments/{environmentId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PUT'
-                        },
-                        options),
-                    params,
-                    requiredParams:
-                        ['accountId', 'containerId', 'environmentId'],
-                    pathParams: ['accountId', 'containerId', 'environmentId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }
+          },
+          tags: {
+            /**
+             * tagmanager.accounts.containers.tags.create
+             * @desc Creates a GTM Tag.
+             * @alias tagmanager.accounts.containers.tags.create
+             * @memberOf! tagmanager(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.accountId The GTM Account ID.
+             * @param {string} params.containerId The GTM Container ID.
+             * @param {tagmanager(v1).Tag} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.tags.delete
+                * @desc Deletes a GTM Tag.
+                * @alias tagmanager.accounts.containers.tags.delete
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.tagId The GTM Tag ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags/{tagId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'DELETE'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'tagId'],
+                pathParams: ['accountId', 'containerId', 'tagId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.tags.get
+                * @desc Gets a GTM Tag.
+                * @alias tagmanager.accounts.containers.tags.get
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.tagId The GTM Tag ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags/{tagId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'tagId'],
+                pathParams: ['accountId', 'containerId', 'tagId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.tags.list
+                * @desc Lists all GTM Tags of a Container.
+                * @alias tagmanager.accounts.containers.tags.list
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.tags.update
+                * @desc Updates a GTM Tag.
+                * @alias tagmanager.accounts.containers.tags.update
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the tag in storage.
+                * @param {string} params.tagId The GTM Tag ID.
+                * @param {tagmanager(v1).Tag} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags/{tagId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PUT'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'tagId'],
+                pathParams: ['accountId', 'containerId', 'tagId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }
 
-              },
-              tags: {
-                /**
-                 * tagmanager.accounts.containers.tags.create
-                 * @desc Creates a GTM Tag.
-                 * @alias tagmanager.accounts.containers.tags.create
-                 * @memberOf! tagmanager(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string} params.accountId The GTM Account ID.
-                 * @param {string} params.containerId The GTM Container ID.
-                 * @param {tagmanager(v1).Tag} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                create(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.tags.delete
-                    * @desc Deletes a GTM Tag.
-                    * @alias tagmanager.accounts.containers.tags.delete
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.tagId The GTM Tag ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                delete (params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags/{tagId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'DELETE'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'tagId'],
-                    pathParams: ['accountId', 'containerId', 'tagId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.tags.get
-                    * @desc Gets a GTM Tag.
-                    * @alias tagmanager.accounts.containers.tags.get
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.tagId The GTM Tag ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                get(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags/{tagId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'tagId'],
-                    pathParams: ['accountId', 'containerId', 'tagId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.tags.list
-                    * @desc Lists all GTM Tags of a Container.
-                    * @alias tagmanager.accounts.containers.tags.list
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                list(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.tags.update
-                    * @desc Updates a GTM Tag.
-                    * @alias tagmanager.accounts.containers.tags.update
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the tag in storage.
-                    * @param {string} params.tagId The GTM Tag ID.
-                    * @param {tagmanager(v1).Tag} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                update(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/tags/{tagId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PUT'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'tagId'],
-                    pathParams: ['accountId', 'containerId', 'tagId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }
+          },
+          triggers: {
+            /**
+             * tagmanager.accounts.containers.triggers.create
+             * @desc Creates a GTM Trigger.
+             * @alias tagmanager.accounts.containers.triggers.create
+             * @memberOf! tagmanager(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.accountId The GTM Account ID.
+             * @param {string} params.containerId The GTM Container ID.
+             * @param {tagmanager(v1).Trigger} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.triggers.delete
+                * @desc Deletes a GTM Trigger.
+                * @alias tagmanager.accounts.containers.triggers.delete
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.triggerId The GTM Trigger ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers/{triggerId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'DELETE'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'triggerId'],
+                pathParams: ['accountId', 'containerId', 'triggerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.triggers.get
+                * @desc Gets a GTM Trigger.
+                * @alias tagmanager.accounts.containers.triggers.get
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.triggerId The GTM Trigger ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers/{triggerId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'triggerId'],
+                pathParams: ['accountId', 'containerId', 'triggerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.triggers.list
+                * @desc Lists all GTM Triggers of a Container.
+                * @alias tagmanager.accounts.containers.triggers.list
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.triggers.update
+                * @desc Updates a GTM Trigger.
+                * @alias tagmanager.accounts.containers.triggers.update
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the trigger in storage.
+                * @param {string} params.triggerId The GTM Trigger ID.
+                * @param {tagmanager(v1).Trigger} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers/{triggerId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PUT'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'triggerId'],
+                pathParams: ['accountId', 'containerId', 'triggerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }
 
-              },
-              triggers: {
-                /**
-                 * tagmanager.accounts.containers.triggers.create
-                 * @desc Creates a GTM Trigger.
-                 * @alias tagmanager.accounts.containers.triggers.create
-                 * @memberOf! tagmanager(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string} params.accountId The GTM Account ID.
-                 * @param {string} params.containerId The GTM Container ID.
-                 * @param {tagmanager(v1).Trigger} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                create(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.triggers.delete
-                    * @desc Deletes a GTM Trigger.
-                    * @alias tagmanager.accounts.containers.triggers.delete
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.triggerId The GTM Trigger ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                delete (params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers/{triggerId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'DELETE'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'triggerId'],
-                    pathParams: ['accountId', 'containerId', 'triggerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.triggers.get
-                    * @desc Gets a GTM Trigger.
-                    * @alias tagmanager.accounts.containers.triggers.get
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.triggerId The GTM Trigger ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                get(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers/{triggerId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'triggerId'],
-                    pathParams: ['accountId', 'containerId', 'triggerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.triggers.list
-                    * @desc Lists all GTM Triggers of a Container.
-                    * @alias tagmanager.accounts.containers.triggers.list
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                list(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.triggers.update
-                    * @desc Updates a GTM Trigger.
-                    * @alias tagmanager.accounts.containers.triggers.update
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the trigger in storage.
-                    * @param {string} params.triggerId The GTM Trigger ID.
-                    * @param {tagmanager(v1).Trigger} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                update(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/triggers/{triggerId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PUT'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'triggerId'],
-                    pathParams: ['accountId', 'containerId', 'triggerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }
+          },
+          variables: {
+            /**
+             * tagmanager.accounts.containers.variables.create
+             * @desc Creates a GTM Variable.
+             * @alias tagmanager.accounts.containers.variables.create
+             * @memberOf! tagmanager(v1)
+             *
+             * @param {object} params Parameters for request
+             * @param {string} params.accountId The GTM Account ID.
+             * @param {string} params.containerId The GTM Container ID.
+             * @param {tagmanager(v1).Variable} params.resource Request body data
+             * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+             * @param {callback} callback The callback that handles the response.
+             * @return {object} Request object
+             */
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'POST'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.variables.delete
+                * @desc Deletes a GTM Variable.
+                * @alias tagmanager.accounts.containers.variables.delete
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.variableId The GTM Variable ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables/{variableId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'DELETE'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'variableId'],
+                pathParams: ['accountId', 'containerId', 'variableId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.variables.get
+                * @desc Gets a GTM Variable.
+                * @alias tagmanager.accounts.containers.variables.get
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string} params.variableId The GTM Variable ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables/{variableId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'variableId'],
+                pathParams: ['accountId', 'containerId', 'variableId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.variables.list
+                * @desc Lists all GTM Variables of a Container.
+                * @alias tagmanager.accounts.containers.variables.list
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'GET'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId'],
+                pathParams: ['accountId', 'containerId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }, /**
+                * tagmanager.accounts.containers.variables.update
+                * @desc Updates a GTM Variable.
+                * @alias tagmanager.accounts.containers.variables.update
+                * @memberOf! tagmanager(v1)
+                *
+                * @param {object} params Parameters for request
+                * @param {string} params.accountId The GTM Account ID.
+                * @param {string} params.containerId The GTM Container ID.
+                * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the variable in storage.
+                * @param {string} params.variableId The GTM Variable ID.
+                * @param {tagmanager(v1).Variable} params.resource Request body data
+                * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+                * @param {callback} callback The callback that handles the response.
+                * @return {object} Request object
+                */
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
+              if (typeof options === 'function') {
+                callback = options;
+                options = {};
+              }
+              options = options || {};
+              const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+              const parameters = {
+                options: Object.assign(
+                    {
+                      url:
+                          (rootUrl +
+                           '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables/{variableId}')
+                              .replace(/([^:]\/)\/+/g, '$1'),
+                      method: 'PUT'
+                    },
+                    options),
+                params,
+                requiredParams: ['accountId', 'containerId', 'variableId'],
+                pathParams: ['accountId', 'containerId', 'variableId'],
+                context: self
+              };
+              return createAPIRequest(parameters, callback!);
+            }
 
-              },
-              variables: {
-                /**
-                 * tagmanager.accounts.containers.variables.create
-                 * @desc Creates a GTM Variable.
-                 * @alias tagmanager.accounts.containers.variables.create
-                 * @memberOf! tagmanager(v1)
-                 *
-                 * @param {object} params Parameters for request
-                 * @param {string} params.accountId The GTM Account ID.
-                 * @param {string} params.containerId The GTM Container ID.
-                 * @param {tagmanager(v1).Variable} params.resource Request body data
-                 * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                 * @param {callback} callback The callback that handles the response.
-                 * @return {object} Request object
-                 */
-                create(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'POST'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.variables.delete
-                    * @desc Deletes a GTM Variable.
-                    * @alias tagmanager.accounts.containers.variables.delete
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.variableId The GTM Variable ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                delete (params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables/{variableId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'DELETE'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'variableId'],
-                    pathParams: ['accountId', 'containerId', 'variableId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.variables.get
-                    * @desc Gets a GTM Variable.
-                    * @alias tagmanager.accounts.containers.variables.get
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string} params.variableId The GTM Variable ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                get(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables/{variableId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'variableId'],
-                    pathParams: ['accountId', 'containerId', 'variableId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.variables.list
-                    * @desc Lists all GTM Variables of a Container.
-                    * @alias tagmanager.accounts.containers.variables.list
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                list(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'GET'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId'],
-                    pathParams: ['accountId', 'containerId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }, /**
-                    * tagmanager.accounts.containers.variables.update
-                    * @desc Updates a GTM Variable.
-                    * @alias tagmanager.accounts.containers.variables.update
-                    * @memberOf! tagmanager(v1)
-                    *
-                    * @param {object} params Parameters for request
-                    * @param {string} params.accountId The GTM Account ID.
-                    * @param {string} params.containerId The GTM Container ID.
-                    * @param {string=} params.fingerprint When provided, this fingerprint must match the fingerprint of the variable in storage.
-                    * @param {string} params.variableId The GTM Variable ID.
-                    * @param {tagmanager(v1).Variable} params.resource Request body data
-                    * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-                    * @param {callback} callback The callback that handles the response.
-                    * @return {object} Request object
-                    */
-                update(params, options, callback) {
-                  if (typeof options === 'function') {
-                    callback = options;
-                    options = {};
-                  }
-                  options = options || {};
-                  const rootUrl =
-                      options.rootUrl || 'https://www.googleapis.com/';
-                  const parameters = {
-                    options: Object.assign(
-                        {
-                          url:
-                              (rootUrl +
-                               '/tagmanager/v1/accounts/{accountId}/containers/{containerId}/variables/{variableId}')
-                                  .replace(/([^:]\/)\/+/g, '$1'),
-                          method: 'PUT'
-                        },
-                        options),
-                    params,
-                    requiredParams: ['accountId', 'containerId', 'variableId'],
-                    pathParams: ['accountId', 'containerId', 'variableId'],
-                    context: self
-                  };
-                  return createAPIRequest(parameters, callback);
-                }
-
-              },
-              versions: {
+          },
+          versions:
+              {
                 /**
                  * tagmanager.accounts.containers.versions.create
                  * @desc Creates a Container Version.
@@ -1492,7 +1527,10 @@ function Tagmanager(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1515,7 +1553,7 @@ function Tagmanager(options) {
                     pathParams: ['accountId', 'containerId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.versions.delete
                     * @desc Deletes a Container Version.
@@ -1530,7 +1568,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1555,7 +1596,7 @@ function Tagmanager(options) {
                         ['accountId', 'containerId', 'containerVersionId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.versions.get
                     * @desc Gets a Container Version.
@@ -1570,7 +1611,9 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1595,7 +1638,7 @@ function Tagmanager(options) {
                         ['accountId', 'containerId', 'containerVersionId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.versions.list
                     * @desc Lists all Container Versions of a GTM Container.
@@ -1611,7 +1654,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1634,7 +1680,7 @@ function Tagmanager(options) {
                     pathParams: ['accountId', 'containerId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.versions.publish
                     * @desc Publishes a Container Version.
@@ -1650,7 +1696,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                publish(params, options, callback) {
+                publish(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1675,7 +1724,7 @@ function Tagmanager(options) {
                         ['accountId', 'containerId', 'containerVersionId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.versions.restore
                     * @desc Restores a Container Version. This will overwrite
@@ -1694,7 +1743,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                restore(params, options, callback) {
+                restore(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1719,7 +1771,7 @@ function Tagmanager(options) {
                         ['accountId', 'containerId', 'containerVersionId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.versions.undelete
                     * @desc Undeletes a Container Version.
@@ -1734,7 +1786,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                undelete(params, options, callback) {
+                undelete(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1759,7 +1814,7 @@ function Tagmanager(options) {
                         ['accountId', 'containerId', 'containerVersionId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.versions.update
                     * @desc Updates a Container Version.
@@ -1776,7 +1831,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                update(params, options, callback) {
+                update(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1801,196 +1859,205 @@ function Tagmanager(options) {
                         ['accountId', 'containerId', 'containerVersionId'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }
 
               }
-            },
-        permissions: {
-          /**
-           * tagmanager.accounts.permissions.create
-           * @desc Creates a user's Account & Container Permissions.
-           * @alias tagmanager.accounts.permissions.create
-           * @memberOf! tagmanager(v1)
-           *
-           * @param {object} params Parameters for request
-           * @param {string} params.accountId The GTM Account ID.
-           * @param {tagmanager(v1).UserAccess} params.resource Request body data
-           * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-           * @param {callback} callback The callback that handles the response.
-           * @return {object} Request object
-           */
-          create(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url: (rootUrl +
-                          '/tagmanager/v1/accounts/{accountId}/permissions')
-                             .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'POST'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * tagmanager.accounts.permissions.delete
-              * @desc Removes a user from the account, revoking access to it and
-              * all of its containers.
-              * @alias tagmanager.accounts.permissions.delete
-              * @memberOf! tagmanager(v1)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId The GTM Account ID.
-              * @param {string} params.permissionId The GTM User ID.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          delete (params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/tagmanager/v1/accounts/{accountId}/permissions/{permissionId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'DELETE'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'permissionId'],
-              pathParams: ['accountId', 'permissionId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * tagmanager.accounts.permissions.get
-              * @desc Gets a user's Account & Container Permissions.
-              * @alias tagmanager.accounts.permissions.get
-              * @memberOf! tagmanager(v1)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId The GTM Account ID.
-              * @param {string} params.permissionId The GTM User ID.
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          get(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/tagmanager/v1/accounts/{accountId}/permissions/{permissionId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'permissionId'],
-              pathParams: ['accountId', 'permissionId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * tagmanager.accounts.permissions.list
-              * @desc List all users that have access to the account along with
-              * Account and Container Permissions granted to each of them.
-              * @alias tagmanager.accounts.permissions.list
-              * @memberOf! tagmanager(v1)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId The GTM Account ID. @required tagmanager.accounts.permissions.list
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          list(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url: (rootUrl +
-                          '/tagmanager/v1/accounts/{accountId}/permissions')
-                             .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'GET'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId'],
-              pathParams: ['accountId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }, /**
-              * tagmanager.accounts.permissions.update
-              * @desc Updates a user's Account & Container Permissions.
-              * @alias tagmanager.accounts.permissions.update
-              * @memberOf! tagmanager(v1)
-              *
-              * @param {object} params Parameters for request
-              * @param {string} params.accountId The GTM Account ID.
-              * @param {string} params.permissionId The GTM User ID.
-              * @param {tagmanager(v1).UserAccess} params.resource Request body data
-              * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-              * @param {callback} callback The callback that handles the response.
-              * @return {object} Request object
-              */
-          update(params, options, callback) {
-            if (typeof options === 'function') {
-              callback = options;
-              options = {};
-            }
-            options = options || {};
-            const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-            const parameters = {
-              options: Object.assign(
-                  {
-                    url:
-                        (rootUrl +
-                         '/tagmanager/v1/accounts/{accountId}/permissions/{permissionId}')
-                            .replace(/([^:]\/)\/+/g, '$1'),
-                    method: 'PUT'
-                  },
-                  options),
-              params,
-              requiredParams: ['accountId', 'permissionId'],
-              pathParams: ['accountId', 'permissionId'],
-              context: self
-            };
-            return createAPIRequest(parameters, callback);
-          }
-
+        },
+    permissions: {
+      /**
+       * tagmanager.accounts.permissions.create
+       * @desc Creates a user's Account & Container Permissions.
+       * @alias tagmanager.accounts.permissions.create
+       * @memberOf! tagmanager(v1)
+       *
+       * @param {object} params Parameters for request
+       * @param {string} params.accountId The GTM Account ID.
+       * @param {tagmanager(v1).UserAccess} params.resource Request body data
+       * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+       * @param {callback} callback The callback that handles the response.
+       * @return {object} Request object
+       */
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
         }
-      };
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl +
+                      '/tagmanager/v1/accounts/{accountId}/permissions')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'POST'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * tagmanager.accounts.permissions.delete
+          * @desc Removes a user from the account, revoking access to it and all
+          * of its containers.
+          * @alias tagmanager.accounts.permissions.delete
+          * @memberOf! tagmanager(v1)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The GTM Account ID.
+          * @param {string} params.permissionId The GTM User ID.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/tagmanager/v1/accounts/{accountId}/permissions/{permissionId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'DELETE'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'permissionId'],
+          pathParams: ['accountId', 'permissionId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * tagmanager.accounts.permissions.get
+          * @desc Gets a user's Account & Container Permissions.
+          * @alias tagmanager.accounts.permissions.get
+          * @memberOf! tagmanager(v1)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The GTM Account ID.
+          * @param {string} params.permissionId The GTM User ID.
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/tagmanager/v1/accounts/{accountId}/permissions/{permissionId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'permissionId'],
+          pathParams: ['accountId', 'permissionId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * tagmanager.accounts.permissions.list
+          * @desc List all users that have access to the account along with
+          * Account and Container Permissions granted to each of them.
+          * @alias tagmanager.accounts.permissions.list
+          * @memberOf! tagmanager(v1)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The GTM Account ID. @required tagmanager.accounts.permissions.list
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url: (rootUrl +
+                      '/tagmanager/v1/accounts/{accountId}/permissions')
+                         .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'GET'
+              },
+              options),
+          params,
+          requiredParams: ['accountId'],
+          pathParams: ['accountId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }, /**
+          * tagmanager.accounts.permissions.update
+          * @desc Updates a user's Account & Container Permissions.
+          * @alias tagmanager.accounts.permissions.update
+          * @memberOf! tagmanager(v1)
+          *
+          * @param {object} params Parameters for request
+          * @param {string} params.accountId The GTM Account ID.
+          * @param {string} params.permissionId The GTM User ID.
+          * @param {tagmanager(v1).UserAccess} params.resource Request body data
+          * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+          * @param {callback} callback The callback that handles the response.
+          * @return {object} Request object
+          */
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
+        if (typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
+        const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+        const parameters = {
+          options: Object.assign(
+              {
+                url:
+                    (rootUrl +
+                     '/tagmanager/v1/accounts/{accountId}/permissions/{permissionId}')
+                        .replace(/([^:]\/)\/+/g, '$1'),
+                method: 'PUT'
+              },
+              options),
+          params,
+          requiredParams: ['accountId', 'permissionId'],
+          pathParams: ['accountId', 'permissionId'],
+          context: self
+        };
+        return createAPIRequest(parameters, callback!);
+      }
+
+    }
+  };
 }
 /**
  * @typedef Account

--- a/src/apis/tagmanager/v2.ts
+++ b/src/apis/tagmanager/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Tag Manager API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Tagmanager
  */
-function Tagmanager(options) {
+function Tagmanager(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.accounts =
@@ -48,7 +55,8 @@ function Tagmanager(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -68,7 +76,7 @@ function Tagmanager(options) {
             pathParams: ['path'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tagmanager.accounts.list
             * @desc Lists all GTM Accounts that a user has access to.
@@ -81,7 +89,9 @@ function Tagmanager(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -101,7 +111,7 @@ function Tagmanager(options) {
             pathParams: [],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tagmanager.accounts.update
             * @desc Updates a GTM Account.
@@ -116,7 +126,9 @@ function Tagmanager(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        update(params, options, callback) {
+        update(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -136,7 +148,7 @@ function Tagmanager(options) {
             pathParams: ['path'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         containers: {
           /**
@@ -152,7 +164,9 @@ function Tagmanager(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -172,7 +186,7 @@ function Tagmanager(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.containers.delete
               * @desc Deletes a Container.
@@ -185,7 +199,9 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -205,7 +221,7 @@ function Tagmanager(options) {
               pathParams: ['path'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.containers.get
               * @desc Gets a Container.
@@ -218,7 +234,8 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -238,7 +255,7 @@ function Tagmanager(options) {
               pathParams: ['path'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.containers.list
               * @desc Lists all Containers that belongs to a GTM Account.
@@ -252,7 +269,9 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -272,7 +291,7 @@ function Tagmanager(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.containers.update
               * @desc Updates a Container.
@@ -287,7 +306,9 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -307,7 +328,7 @@ function Tagmanager(options) {
               pathParams: ['path'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           environments: {
             /**
@@ -323,7 +344,9 @@ function Tagmanager(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -343,7 +366,7 @@ function Tagmanager(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.environments.delete
                 * @desc Deletes a GTM Environment.
@@ -356,7 +379,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -376,7 +401,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.environments.get
                 * @desc Gets a GTM Environment.
@@ -389,7 +414,8 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -409,7 +435,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.environments.list
                 * @desc Lists all GTM Environments of a GTM Container.
@@ -423,7 +449,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -443,7 +471,7 @@ function Tagmanager(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.environments.patch
                 * @desc Updates a GTM Environment. This method supports patch
@@ -459,7 +487,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            patch(params, options, callback) {
+            patch(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -479,7 +509,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.environments.reauthorize
                 * @desc Re-generates the authorization code for a GTM
@@ -494,7 +524,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            reauthorize(params, options, callback) {
+            reauthorize(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -514,7 +546,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.environments.update
                 * @desc Updates a GTM Environment.
@@ -529,7 +561,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            update(params, options, callback) {
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -549,7 +583,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -566,7 +600,9 @@ function Tagmanager(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            delete (params, options, callback) {
+            delete (
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -586,7 +622,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.versions.get
                 * @desc Gets a Container Version.
@@ -600,7 +636,8 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -620,7 +657,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.versions.live
                 * @desc Gets the live (i.e. published) container version
@@ -633,7 +670,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            live(params, options, callback) {
+            live(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -653,7 +692,7 @@ function Tagmanager(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.versions.publish
                 * @desc Publishes a Container Version.
@@ -667,7 +706,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            publish(params, options, callback) {
+            publish(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -687,7 +728,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.versions.set_latest
                 * @desc Sets the latest version used for synchronization of
@@ -701,7 +742,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            set_latest(params, options, callback) {
+            set_latest(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -721,7 +764,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.versions.undelete
                 * @desc Undeletes a Container Version.
@@ -734,7 +777,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            undelete(params, options, callback) {
+            undelete(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -754,7 +799,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.versions.update
                 * @desc Updates a Container Version.
@@ -769,7 +814,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            update(params, options, callback) {
+            update(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -789,7 +836,7 @@ function Tagmanager(options) {
                 pathParams: ['path'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -806,7 +853,9 @@ function Tagmanager(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            latest(params, options, callback) {
+            latest(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -827,7 +876,7 @@ function Tagmanager(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * tagmanager.accounts.containers.version_headers.list
                 * @desc Lists all Container Versions of a GTM Container.
@@ -842,7 +891,9 @@ function Tagmanager(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -862,7 +913,7 @@ function Tagmanager(options) {
                 pathParams: ['parent'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -881,7 +932,10 @@ function Tagmanager(options) {
                  * @param {callback} callback The callback that handles the response.
                  * @return {object} Request object
                  */
-                create(params, options, callback) {
+                create(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -902,7 +956,7 @@ function Tagmanager(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.create_version
                     * @desc Creates a Container Version from the entities
@@ -919,7 +973,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                create_version(params, options, callback) {
+                create_version(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -941,7 +998,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.delete
                     * @desc Deletes a Workspace.
@@ -954,7 +1011,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                delete (params, options, callback) {
+                delete (
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -975,7 +1035,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.get
                     * @desc Gets a Workspace.
@@ -988,7 +1048,9 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                get(params, options, callback) {
+                get(params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1009,7 +1071,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.getProposal
                     * @desc Gets a GTM Workspace Proposal.
@@ -1023,7 +1085,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                getProposal(params, options, callback) {
+                getProposal(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1044,7 +1109,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.getStatus
                     * @desc Finds conflicting and modified entities in the
@@ -1058,7 +1123,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                getStatus(params, options, callback) {
+                getStatus(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1079,7 +1147,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.list
                     * @desc Lists all Workspaces that belong to a GTM Container.
@@ -1093,7 +1161,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                list(params, options, callback) {
+                list(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1114,7 +1185,7 @@ function Tagmanager(options) {
                     pathParams: ['parent'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.quick_preview
                     * @desc Quick previews a workspace by creating a fake
@@ -1130,7 +1201,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                quick_preview(params, options, callback) {
+                quick_preview(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1151,7 +1225,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.resolve_conflict
                     * @desc Resolves a merge conflict for a workspace entity by
@@ -1168,7 +1242,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                resolve_conflict(params, options, callback) {
+                resolve_conflict(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1190,7 +1267,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.sync
                     * @desc Syncs a workspace to the latest container version by
@@ -1205,7 +1282,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                sync(params, options, callback) {
+                sync(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1226,7 +1306,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.update
                     * @desc Updates a Workspace.
@@ -1241,7 +1321,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                update(params, options, callback) {
+                update(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1262,7 +1345,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 }, /**
                     * tagmanager.accounts.containers.workspaces.updateProposal
                     * @desc Updates a GTM Workspace Proposal.
@@ -1277,7 +1360,10 @@ function Tagmanager(options) {
                     * @param {callback} callback The callback that handles the response.
                     * @return {object} Request object
                     */
-                updateProposal(params, options, callback) {
+                updateProposal(
+                    params: any,
+                    options: MethodOptions|BodyResponseCallback<any>,
+                    callback?: BodyResponseCallback<any>) {
                   if (typeof options === 'function') {
                     callback = options;
                     options = {};
@@ -1298,7 +1384,7 @@ function Tagmanager(options) {
                     pathParams: ['path'],
                     context: self
                   };
-                  return createAPIRequest(parameters, callback);
+                  return createAPIRequest(parameters, callback!);
                 },
                 built_in_variables: {
                   /**
@@ -1315,7 +1401,10 @@ function Tagmanager(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  create(params, options, callback) {
+                  create(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1337,7 +1426,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.built_in_variables.delete
                       * @desc Deletes one or more GTM Built-In Variables.
@@ -1352,7 +1441,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  delete (params, options, callback) {
+                  delete (
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1373,7 +1465,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.built_in_variables.list
                       * @desc Lists all the enabled Built-In Variables of a GTM
@@ -1389,7 +1481,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1411,7 +1506,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.built_in_variables.revert
                       * @desc Reverts changes to a GTM Built-In Variables in a
@@ -1427,7 +1522,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  revert(params, options, callback) {
+                  revert(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1450,7 +1548,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1469,7 +1567,10 @@ function Tagmanager(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  create(params, options, callback) {
+                  create(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1490,7 +1591,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.folders.delete
                       * @desc Deletes a GTM Folder.
@@ -1504,7 +1605,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  delete (params, options, callback) {
+                  delete (
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1525,7 +1629,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.folders.entities
                       * @desc List all entities in a GTM Folder.
@@ -1540,7 +1644,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  entities(params, options, callback) {
+                  entities(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1561,7 +1668,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.folders.get
                       * @desc Gets a GTM Folder.
@@ -1575,7 +1682,9 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  get(params, options, callback) {
+                  get(params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1596,7 +1705,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.folders.list
                       * @desc Lists all GTM Folders of a Container.
@@ -1611,7 +1720,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1632,7 +1744,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.folders.move_entities_to_folder
                       * @desc Moves entities to a GTM Folder.
@@ -1650,7 +1762,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  move_entities_to_folder(params, options, callback) {
+                  move_entities_to_folder(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1673,7 +1788,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.folders.revert
                       * @desc Reverts changes to a GTM Folder in a GTM
@@ -1689,7 +1804,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  revert(params, options, callback) {
+                  revert(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1710,7 +1828,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.folders.update
                       * @desc Updates a GTM Folder.
@@ -1726,7 +1844,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  update(params, options, callback) {
+                  update(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1747,7 +1868,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1766,7 +1887,10 @@ function Tagmanager(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  create(params, options, callback) {
+                  create(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1787,7 +1911,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.proposal.delete
                       * @desc Deletes a GTM Workspace Proposal.
@@ -1801,7 +1925,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  delete (params, options, callback) {
+                  delete (
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1822,7 +1949,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -1842,7 +1969,10 @@ function Tagmanager(options) {
                        * @param {callback} callback The callback that handles the response.
                        * @return {object} Request object
                        */
-                      create(params, options, callback) {
+                      create(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1863,7 +1993,7 @@ function Tagmanager(options) {
                           pathParams: ['parent'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * tagmanager.accounts.containers.workspaces.tags.delete
                           * @desc Deletes a GTM Tag.
@@ -1877,7 +2007,10 @@ function Tagmanager(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      delete (params, options, callback) {
+                      delete (
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1898,7 +2031,7 @@ function Tagmanager(options) {
                           pathParams: ['path'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * tagmanager.accounts.containers.workspaces.tags.get
                           * @desc Gets a GTM Tag.
@@ -1912,7 +2045,9 @@ function Tagmanager(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      get(params, options, callback) {
+                      get(params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1933,7 +2068,7 @@ function Tagmanager(options) {
                           pathParams: ['path'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * tagmanager.accounts.containers.workspaces.tags.list
                           * @desc Lists all GTM Tags of a Container.
@@ -1948,7 +2083,10 @@ function Tagmanager(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      list(params, options, callback) {
+                      list(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -1969,7 +2107,7 @@ function Tagmanager(options) {
                           pathParams: ['parent'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * tagmanager.accounts.containers.workspaces.tags.revert
                           * @desc Reverts changes to a GTM Tag in a GTM
@@ -1985,7 +2123,10 @@ function Tagmanager(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      revert(params, options, callback) {
+                      revert(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2006,7 +2147,7 @@ function Tagmanager(options) {
                           pathParams: ['path'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }, /**
                           * tagmanager.accounts.containers.workspaces.tags.update
                           * @desc Updates a GTM Tag.
@@ -2022,7 +2163,10 @@ function Tagmanager(options) {
                           * @param {callback} callback The callback that handles the response.
                           * @return {object} Request object
                           */
-                      update(params, options, callback) {
+                      update(
+                          params: any,
+                          options: MethodOptions|BodyResponseCallback<any>,
+                          callback?: BodyResponseCallback<any>) {
                         if (typeof options === 'function') {
                           callback = options;
                           options = {};
@@ -2043,7 +2187,7 @@ function Tagmanager(options) {
                           pathParams: ['path'],
                           context: self
                         };
-                        return createAPIRequest(parameters, callback);
+                        return createAPIRequest(parameters, callback!);
                       }
 
                     },
@@ -2062,7 +2206,10 @@ function Tagmanager(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  create(params, options, callback) {
+                  create(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2083,7 +2230,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.triggers.delete
                       * @desc Deletes a GTM Trigger.
@@ -2097,7 +2244,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  delete (params, options, callback) {
+                  delete (
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2118,7 +2268,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.triggers.get
                       * @desc Gets a GTM Trigger.
@@ -2132,7 +2282,9 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  get(params, options, callback) {
+                  get(params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2153,7 +2305,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.triggers.list
                       * @desc Lists all GTM Triggers of a Container.
@@ -2168,7 +2320,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2189,7 +2344,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.triggers.revert
                       * @desc Reverts changes to a GTM Trigger in a GTM
@@ -2205,7 +2360,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  revert(params, options, callback) {
+                  revert(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2226,7 +2384,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.triggers.update
                       * @desc Updates a GTM Trigger.
@@ -2242,7 +2400,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  update(params, options, callback) {
+                  update(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2263,7 +2424,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 },
@@ -2282,7 +2443,10 @@ function Tagmanager(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  create(params, options, callback) {
+                  create(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2303,7 +2467,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.variables.delete
                       * @desc Deletes a GTM Variable.
@@ -2317,7 +2481,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  delete (params, options, callback) {
+                  delete (
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2338,7 +2505,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.variables.get
                       * @desc Gets a GTM Variable.
@@ -2352,7 +2519,9 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  get(params, options, callback) {
+                  get(params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2373,7 +2542,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.variables.list
                       * @desc Lists all GTM Variables of a Container.
@@ -2388,7 +2557,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2409,7 +2581,7 @@ function Tagmanager(options) {
                       pathParams: ['parent'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.variables.revert
                       * @desc Reverts changes to a GTM Variable in a GTM
@@ -2425,7 +2597,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  revert(params, options, callback) {
+                  revert(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2446,7 +2621,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * tagmanager.accounts.containers.workspaces.variables.update
                       * @desc Updates a GTM Variable.
@@ -2462,7 +2637,10 @@ function Tagmanager(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  update(params, options, callback) {
+                  update(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -2483,7 +2661,7 @@ function Tagmanager(options) {
                       pathParams: ['path'],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 }
@@ -2503,7 +2681,9 @@ function Tagmanager(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2523,7 +2703,7 @@ function Tagmanager(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.user_permissions.delete
               * @desc Removes a user from the account, revoking access to it and
@@ -2537,7 +2717,9 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          delete (params, options, callback) {
+          delete (
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2557,7 +2739,7 @@ function Tagmanager(options) {
               pathParams: ['path'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.user_permissions.get
               * @desc Gets a user's Account & Container access.
@@ -2570,7 +2752,8 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2590,7 +2773,7 @@ function Tagmanager(options) {
               pathParams: ['path'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.user_permissions.list
               * @desc List all users that have access to the account along with
@@ -2605,7 +2788,9 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2625,7 +2810,7 @@ function Tagmanager(options) {
               pathParams: ['parent'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * tagmanager.accounts.user_permissions.update
               * @desc Updates a user's Account & Container access.
@@ -2639,7 +2824,9 @@ function Tagmanager(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          update(params, options, callback) {
+          update(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -2659,7 +2846,7 @@ function Tagmanager(options) {
               pathParams: ['path'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         }

--- a/src/apis/taskqueue/v1beta1.ts
+++ b/src/apis/taskqueue/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * TaskQueue API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Taskqueue
  */
-function Taskqueue(options) {
+function Taskqueue(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.taskqueues = {
@@ -49,7 +56,8 @@ function Taskqueue(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +79,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -90,7 +98,9 @@ function Taskqueue(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -112,7 +122,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'task', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.get
         * @desc Get a particular task from a TaskQueue.
@@ -127,7 +137,8 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -149,7 +160,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'task', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.lease
         * @desc Lease 1 or more tasks from a TaskQueue.
@@ -165,7 +176,9 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    lease(params, options, callback) {
+    lease(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -187,7 +200,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.list
         * @desc List Tasks in a TaskQueue
@@ -201,7 +214,9 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -223,7 +238,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/taskqueue/v1beta2.ts
+++ b/src/apis/taskqueue/v1beta2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * TaskQueue API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta2
  * @param {object=} options Options for Taskqueue
  */
-function Taskqueue(options) {
+function Taskqueue(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.taskqueues = {
@@ -49,7 +56,8 @@ function Taskqueue(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +79,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -90,7 +98,9 @@ function Taskqueue(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -112,7 +122,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'task', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.get
         * @desc Get a particular task from a TaskQueue.
@@ -127,7 +137,8 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -149,7 +160,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'task', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.insert
         * @desc Insert a new task in a TaskQueue
@@ -164,7 +175,9 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -186,7 +199,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.lease
         * @desc Lease 1 or more tasks from a TaskQueue.
@@ -204,7 +217,9 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    lease(params, options, callback) {
+    lease(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -226,7 +241,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.list
         * @desc List Tasks in a TaskQueue
@@ -240,7 +255,9 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -262,7 +279,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.patch
         * @desc Update tasks that are leased out of a TaskQueue. This method
@@ -280,7 +297,9 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -302,7 +321,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'task', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * taskqueue.tasks.update
         * @desc Update tasks that are leased out of a TaskQueue.
@@ -319,7 +338,9 @@ function Taskqueue(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -341,7 +362,7 @@ function Taskqueue(options) {
         pathParams: ['project', 'task', 'taskqueue'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/tasks/v1.ts
+++ b/src/apis/tasks/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Tasks API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Tasks
  */
-function Tasks(options) {
+function Tasks(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.tasklists = {
@@ -47,7 +54,9 @@ function Tasks(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -67,7 +76,7 @@ function Tasks(options) {
         pathParams: ['tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasklists.get
         * @desc Returns the authenticated user's specified task list.
@@ -80,7 +89,8 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -100,7 +110,7 @@ function Tasks(options) {
         pathParams: ['tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasklists.insert
         * @desc Creates a new task list and adds it to the authenticated user's
@@ -114,7 +124,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -134,7 +146,7 @@ function Tasks(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasklists.list
         * @desc Returns all the authenticated user's task lists.
@@ -148,7 +160,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -168,7 +182,7 @@ function Tasks(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasklists.patch
         * @desc Updates the authenticated user's specified task list. This
@@ -183,7 +197,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -203,7 +219,7 @@ function Tasks(options) {
         pathParams: ['tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasklists.update
         * @desc Updates the authenticated user's specified task list.
@@ -217,7 +233,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -237,7 +255,7 @@ function Tasks(options) {
         pathParams: ['tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -256,7 +274,9 @@ function Tasks(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    clear(params, options, callback) {
+    clear(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -276,7 +296,7 @@ function Tasks(options) {
         pathParams: ['tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasks.delete
         * @desc Deletes the specified task from the task list.
@@ -290,7 +310,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -310,7 +332,7 @@ function Tasks(options) {
         pathParams: ['task', 'tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasks.get
         * @desc Returns the specified task.
@@ -324,7 +346,8 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -344,7 +367,7 @@ function Tasks(options) {
         pathParams: ['task', 'tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasks.insert
         * @desc Creates a new task on the specified task list.
@@ -360,7 +383,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -380,7 +405,7 @@ function Tasks(options) {
         pathParams: ['tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasks.list
         * @desc Returns all tasks in the specified task list.
@@ -403,7 +428,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -423,7 +450,7 @@ function Tasks(options) {
         pathParams: ['tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasks.move
         * @desc Moves the specified task to another position in the task list.
@@ -441,7 +468,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    move(params, options, callback) {
+    move(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -461,7 +490,7 @@ function Tasks(options) {
         pathParams: ['task', 'tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasks.patch
         * @desc Updates the specified task. This method supports patch
@@ -477,7 +506,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    patch(params, options, callback) {
+    patch(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -497,7 +528,7 @@ function Tasks(options) {
         pathParams: ['task', 'tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * tasks.tasks.update
         * @desc Updates the specified task.
@@ -512,7 +543,9 @@ function Tasks(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -532,7 +565,7 @@ function Tasks(options) {
         pathParams: ['task', 'tasklist'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/testing/v1.ts
+++ b/src/apis/testing/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Testing API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Testing
  */
-function Testing(options) {
+function Testing(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.applicationDetailService = {
@@ -48,7 +55,9 @@ function Testing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getApkDetails(params, options, callback) {
+    getApkDetails(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Testing(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -93,7 +102,9 @@ function Testing(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      cancel(params, options, callback) {
+      cancel(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -115,7 +126,7 @@ function Testing(options) {
           pathParams: ['projectId', 'testMatrixId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * testing.projects.testMatrices.create
           * @desc Request to run a matrix of tests according to the given
@@ -137,7 +148,9 @@ function Testing(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -157,7 +170,7 @@ function Testing(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * testing.projects.testMatrices.get
           * @desc Check the status of a test matrix.  May return any of the
@@ -174,7 +187,8 @@ function Testing(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -195,7 +209,7 @@ function Testing(options) {
           pathParams: ['projectId', 'testMatrixId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -217,7 +231,8 @@ function Testing(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -237,7 +252,7 @@ function Testing(options) {
         pathParams: ['environmentType'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/toolresults/v1beta3.ts
+++ b/src/apis/toolresults/v1beta3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Tool Results API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta3
  * @param {object=} options Options for Toolresults
  */
-function Toolresults(options) {
+function Toolresults(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -49,7 +56,9 @@ function Toolresults(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    getSettings(params, options, callback) {
+    getSettings(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Toolresults(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * toolresults.projects.initializeSettings
         * @desc Creates resources for settings which have not yet been set.
@@ -102,7 +111,9 @@ function Toolresults(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    initializeSettings(params, options, callback) {
+    initializeSettings(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -124,7 +135,7 @@ function Toolresults(options) {
         pathParams: ['projectId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     histories: {
       /**
@@ -145,7 +156,9 @@ function Toolresults(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -166,7 +179,7 @@ function Toolresults(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * toolresults.projects.histories.get
           * @desc Gets a History.  May return any of the following canonical
@@ -183,7 +196,8 @@ function Toolresults(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -205,7 +219,7 @@ function Toolresults(options) {
           pathParams: ['historyId', 'projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * toolresults.projects.histories.list
           * @desc Lists Histories for a given Project.  The histories are sorted
@@ -227,7 +241,9 @@ function Toolresults(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -248,7 +264,7 @@ function Toolresults(options) {
           pathParams: ['projectId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       executions: {
         /**
@@ -270,7 +286,9 @@ function Toolresults(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -292,7 +310,7 @@ function Toolresults(options) {
             pathParams: ['historyId', 'projectId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * toolresults.projects.histories.executions.get
             * @desc Gets an Execution.  May return any of the following
@@ -310,7 +328,8 @@ function Toolresults(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -332,7 +351,7 @@ function Toolresults(options) {
             pathParams: ['executionId', 'historyId', 'projectId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * toolresults.projects.histories.executions.list
             * @desc Lists Histories for a given Project.  The executions are
@@ -354,7 +373,9 @@ function Toolresults(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -376,7 +397,7 @@ function Toolresults(options) {
             pathParams: ['historyId', 'projectId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * toolresults.projects.histories.executions.patch
             * @desc Updates an existing Execution with the supplied partial
@@ -398,7 +419,9 @@ function Toolresults(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        patch(params, options, callback) {
+        patch(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -420,7 +443,7 @@ function Toolresults(options) {
             pathParams: ['executionId', 'historyId', 'projectId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         },
         clusters: {
           /**
@@ -438,7 +461,8 @@ function Toolresults(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -462,7 +486,7 @@ function Toolresults(options) {
                   ['clusterId', 'executionId', 'historyId', 'projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * toolresults.projects.histories.executions.clusters.list
               * @desc Lists Screenshot Clusters  Returns the list of screenshot
@@ -483,7 +507,9 @@ function Toolresults(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -505,7 +531,7 @@ function Toolresults(options) {
               pathParams: ['executionId', 'historyId', 'projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }
 
         },
@@ -531,7 +557,9 @@ function Toolresults(options) {
            * @param {callback} callback The callback that handles the response.
            * @return {object} Request object
            */
-          create(params, options, callback) {
+          create(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -553,7 +581,7 @@ function Toolresults(options) {
               pathParams: ['executionId', 'historyId', 'projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * toolresults.projects.histories.executions.steps.get
               * @desc Gets a Step.  May return any of the following canonical
@@ -572,7 +600,8 @@ function Toolresults(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          get(params, options, callback) {
+          get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -595,7 +624,7 @@ function Toolresults(options) {
               pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * toolresults.projects.histories.executions.steps.getPerfMetricsSummary
               * @desc Retrieves a PerfMetricsSummary.  May return any of the
@@ -614,7 +643,9 @@ function Toolresults(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          getPerfMetricsSummary(params, options, callback) {
+          getPerfMetricsSummary(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -637,7 +668,7 @@ function Toolresults(options) {
               pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * toolresults.projects.histories.executions.steps.list
               * @desc Lists Steps for a given Execution.  The steps are sorted
@@ -663,7 +694,9 @@ function Toolresults(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          list(params, options, callback) {
+          list(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -685,7 +718,7 @@ function Toolresults(options) {
               pathParams: ['executionId', 'historyId', 'projectId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * toolresults.projects.histories.executions.steps.patch
               * @desc Updates an existing Step with the supplied partial entity.
@@ -710,7 +743,9 @@ function Toolresults(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          patch(params, options, callback) {
+          patch(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -733,7 +768,7 @@ function Toolresults(options) {
               pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           }, /**
               * toolresults.projects.histories.executions.steps.publishXunitXmlFiles
               * @desc Publish xml files to an existing Step.  May return any of
@@ -757,7 +792,9 @@ function Toolresults(options) {
               * @param {callback} callback The callback that handles the response.
               * @return {object} Request object
               */
-          publishXunitXmlFiles(params, options, callback) {
+          publishXunitXmlFiles(
+              params: any, options: MethodOptions|BodyResponseCallback<any>,
+              callback?: BodyResponseCallback<any>) {
             if (typeof options === 'function') {
               callback = options;
               options = {};
@@ -780,7 +817,7 @@ function Toolresults(options) {
               pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
               context: self
             };
-            return createAPIRequest(parameters, callback);
+            return createAPIRequest(parameters, callback!);
           },
           perfMetricsSummary: {
             /**
@@ -803,7 +840,9 @@ function Toolresults(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -826,7 +865,7 @@ function Toolresults(options) {
                 pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           },
@@ -851,7 +890,9 @@ function Toolresults(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            create(params, options, callback) {
+            create(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -874,7 +915,7 @@ function Toolresults(options) {
                 pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * toolresults.projects.histories.executions.steps.perfSampleSeries.get
                 * @desc Gets a PerfSampleSeries.  May return any of the
@@ -894,7 +935,8 @@ function Toolresults(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            get(params, options, callback) {
+            get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -922,7 +964,7 @@ function Toolresults(options) {
                 ],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }, /**
                 * toolresults.projects.histories.executions.steps.perfSampleSeries.list
                 * @desc Lists PerfSampleSeries for a given Step.  The request
@@ -945,7 +987,9 @@ function Toolresults(options) {
                 * @param {callback} callback The callback that handles the response.
                 * @return {object} Request object
                 */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -968,7 +1012,7 @@ function Toolresults(options) {
                 pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             },
             samples:
                 {
@@ -998,7 +1042,10 @@ function Toolresults(options) {
                    * @param {callback} callback The callback that handles the response.
                    * @return {object} Request object
                    */
-                  batchCreate(params, options, callback) {
+                  batchCreate(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1027,7 +1074,7 @@ function Toolresults(options) {
                       ],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }, /**
                       * toolresults.projects.histories.executions.steps.perfSampleSeries.samples.list
                       * @desc Lists the Performance Samples of a given Sample
@@ -1058,7 +1105,10 @@ function Toolresults(options) {
                       * @param {callback} callback The callback that handles the response.
                       * @return {object} Request object
                       */
-                  list(params, options, callback) {
+                  list(
+                      params: any,
+                      options: MethodOptions|BodyResponseCallback<any>,
+                      callback?: BodyResponseCallback<any>) {
                     if (typeof options === 'function') {
                       callback = options;
                       options = {};
@@ -1087,7 +1137,7 @@ function Toolresults(options) {
                       ],
                       context: self
                     };
-                    return createAPIRequest(parameters, callback);
+                    return createAPIRequest(parameters, callback!);
                   }
 
                 }
@@ -1116,7 +1166,9 @@ function Toolresults(options) {
              * @param {callback} callback The callback that handles the response.
              * @return {object} Request object
              */
-            list(params, options, callback) {
+            list(
+                params: any, options: MethodOptions|BodyResponseCallback<any>,
+                callback?: BodyResponseCallback<any>) {
               if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -1139,7 +1191,7 @@ function Toolresults(options) {
                 pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
                 context: self
               };
-              return createAPIRequest(parameters, callback);
+              return createAPIRequest(parameters, callback!);
             }
 
           }

--- a/src/apis/tpu/v1alpha1.ts
+++ b/src/apis/tpu/v1alpha1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud TPU API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1alpha1
  * @param {object=} options Options for Tpu
  */
-function Tpu(options) {
+function Tpu(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.projects = {
@@ -48,7 +55,8 @@ function Tpu(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -68,7 +76,7 @@ function Tpu(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * tpu.projects.locations.list
           * @desc Lists information about the supported locations for this
@@ -85,7 +93,9 @@ function Tpu(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -105,7 +115,7 @@ function Tpu(options) {
           pathParams: ['name'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       nodes: {
         /**
@@ -122,7 +132,9 @@ function Tpu(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -142,7 +154,7 @@ function Tpu(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.nodes.delete
             * @desc Deletes a node.
@@ -155,7 +167,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -175,7 +189,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.nodes.get
             * @desc Gets the details of a node.
@@ -188,7 +202,8 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -208,7 +223,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.nodes.list
             * @desc Lists nodes.
@@ -223,7 +238,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -243,7 +260,7 @@ function Tpu(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.nodes.reimage
             * @desc Reimages a node's OS.
@@ -257,7 +274,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        reimage(params, options, callback) {
+        reimage(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -277,7 +296,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.nodes.reset
             * @desc Resets a node, which stops and starts the VM.
@@ -291,7 +310,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        reset(params, options, callback) {
+        reset(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -311,7 +332,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.nodes.start
             * @desc Starts a node.
@@ -325,7 +346,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        start(params, options, callback) {
+        start(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -345,7 +368,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.nodes.stop
             * @desc Stops a node.
@@ -359,7 +382,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        stop(params, options, callback) {
+        stop(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -379,7 +404,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -405,7 +430,9 @@ function Tpu(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        cancel(params, options, callback) {
+        cancel(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -425,7 +452,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.operations.delete
             * @desc Deletes a long-running operation. This method indicates that
@@ -441,7 +468,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -461,7 +490,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.operations.get
             * @desc Gets the latest state of a long-running operation.  Clients
@@ -476,7 +505,8 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -496,7 +526,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.operations.list
             * @desc Lists operations that match the specified filter in the
@@ -521,7 +551,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -541,7 +573,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       },
@@ -558,7 +590,8 @@ function Tpu(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        get(params, options, callback) {
+        get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -578,7 +611,7 @@ function Tpu(options) {
             pathParams: ['name'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * tpu.projects.locations.tensorflowVersions.list
             * @desc Lists TensorFlow versions supported by this API.
@@ -595,7 +628,9 @@ function Tpu(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -615,7 +650,7 @@ function Tpu(options) {
             pathParams: ['parent'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }

--- a/src/apis/translate/v2.ts
+++ b/src/apis/translate/v2.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Translation API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v2
  * @param {object=} options Options for Translate
  */
-function Translate(options) {
+function Translate(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.detections = {
@@ -48,7 +55,9 @@ function Translate(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    detect(params, options, callback) {
+    detect(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Translate(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.detections.list
         * @desc Detects the language of text within a request.
@@ -81,7 +90,9 @@ function Translate(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -101,7 +112,7 @@ function Translate(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -119,7 +130,9 @@ function Translate(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -139,7 +152,7 @@ function Translate(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -161,7 +174,9 @@ function Translate(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -181,7 +196,7 @@ function Translate(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * language.translations.translate
         * @desc Translates input text, returning translated text.
@@ -194,7 +209,9 @@ function Translate(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    translate(params, options, callback) {
+    translate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -214,7 +231,7 @@ function Translate(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/urlshortener/v1.ts
+++ b/src/apis/urlshortener/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * URL Shortener API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Urlshortener
  */
-function Urlshortener(options) {
+function Urlshortener(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.url = {
@@ -48,7 +55,8 @@ function Urlshortener(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +76,7 @@ function Urlshortener(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * urlshortener.url.insert
         * @desc Creates a new short URL.
@@ -81,7 +89,9 @@ function Urlshortener(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -101,7 +111,7 @@ function Urlshortener(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * urlshortener.url.list
         * @desc Retrieves a list of URLs shortened by a user.
@@ -115,7 +125,9 @@ function Urlshortener(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -135,7 +147,7 @@ function Urlshortener(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/vault/v1.ts
+++ b/src/apis/vault/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Vault API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Vault
  */
-function Vault(options) {
+function Vault(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.matters = {
@@ -48,7 +55,9 @@ function Vault(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    addPermissions(params, options, callback) {
+    addPermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.close
         * @desc Closes the specified matter. Returns matter with updated state.
@@ -82,7 +91,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    close(params, options, callback) {
+    close(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +113,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.create
         * @desc Creates a new matter with the given name and description. The
@@ -117,7 +128,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -136,7 +149,7 @@ function Vault(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.delete
         * @desc Deletes the specified matter. Returns matter with updated state.
@@ -149,7 +162,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -169,7 +184,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.get
         * @desc Gets the specified matter.
@@ -183,7 +198,8 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -203,7 +219,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.list
         * @desc Lists matters the user has access to.
@@ -219,7 +235,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -238,7 +256,7 @@ function Vault(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.removePermissions
         * @desc Removes an account as a matter collaborator.
@@ -252,7 +270,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    removePermissions(params, options, callback) {
+    removePermissions(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -272,7 +292,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.reopen
         * @desc Reopens the specified matter. Returns matter with updated state.
@@ -286,7 +306,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reopen(params, options, callback) {
+    reopen(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -306,7 +328,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.undelete
         * @desc Undeletes the specified matter. Returns matter with updated
@@ -321,7 +343,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    undelete(params, options, callback) {
+    undelete(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -341,7 +365,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vault.matters.update
         * @desc Updates the specified matter. This updates only the name and
@@ -357,7 +381,9 @@ function Vault(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -377,7 +403,7 @@ function Vault(options) {
         pathParams: ['matterId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     holds: {
       /**
@@ -393,7 +419,9 @@ function Vault(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      create(params, options, callback) {
+      create(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -413,7 +441,7 @@ function Vault(options) {
           pathParams: ['matterId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * vault.matters.holds.delete
           * @desc Removes a hold by ID. This will release any HeldAccounts on
@@ -428,7 +456,9 @@ function Vault(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      delete (params, options, callback) {
+      delete (
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -448,7 +478,7 @@ function Vault(options) {
           pathParams: ['holdId', 'matterId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * vault.matters.holds.get
           * @desc Gets a hold by ID.
@@ -463,7 +493,8 @@ function Vault(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -483,7 +514,7 @@ function Vault(options) {
           pathParams: ['holdId', 'matterId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * vault.matters.holds.list
           * @desc Lists holds within a matter. An empty page token in
@@ -500,7 +531,9 @@ function Vault(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -520,7 +553,7 @@ function Vault(options) {
           pathParams: ['matterId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * vault.matters.holds.update
           * @desc Updates the OU and/or query parameters of a hold. You cannot
@@ -538,7 +571,9 @@ function Vault(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      update(params, options, callback) {
+      update(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -558,7 +593,7 @@ function Vault(options) {
           pathParams: ['holdId', 'matterId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       },
       accounts: {
         /**
@@ -577,7 +612,9 @@ function Vault(options) {
          * @param {callback} callback The callback that handles the response.
          * @return {object} Request object
          */
-        create(params, options, callback) {
+        create(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -598,7 +635,7 @@ function Vault(options) {
             pathParams: ['holdId', 'matterId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * vault.matters.holds.accounts.delete
             * @desc Removes a HeldAccount from a hold. If this request leaves
@@ -615,7 +652,9 @@ function Vault(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        delete (params, options, callback) {
+        delete (
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -637,7 +676,7 @@ function Vault(options) {
             pathParams: ['accountId', 'holdId', 'matterId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }, /**
             * vault.matters.holds.accounts.list
             * @desc Lists HeldAccounts for a hold. This will only list
@@ -654,7 +693,9 @@ function Vault(options) {
             * @param {callback} callback The callback that handles the response.
             * @return {object} Request object
             */
-        list(params, options, callback) {
+        list(
+            params: any, options: MethodOptions|BodyResponseCallback<any>,
+            callback?: BodyResponseCallback<any>) {
           if (typeof options === 'function') {
             callback = options;
             options = {};
@@ -675,7 +716,7 @@ function Vault(options) {
             pathParams: ['holdId', 'matterId'],
             context: self
           };
-          return createAPIRequest(parameters, callback);
+          return createAPIRequest(parameters, callback!);
         }
 
       }
@@ -707,6 +748,7 @@ function Vault(options) {
  * @type object
  * @property {vault(v1).HeldDriveQuery} driveQuery Details pertaining to Drive holds. If set, corpus must be Drive.
  * @property {vault(v1).HeldGroupsQuery} groupsQuery Details pertaining to Groups holds. If set, corpus must be Groups.
+ * @property {vault(v1).HeldHangoutsChatQuery} hangoutsChatQuery Details pertaining to Hangouts Chat holds. If set, corpus must be Hangouts Chat.
  * @property {vault(v1).HeldMailQuery} mailQuery Details pertaining to mail holds. If set, corpus must be mail.
  */
 /**
@@ -734,6 +776,12 @@ function Vault(options) {
  * @property {string} endTime The end time range for the search query. These timestamps are in GMT and rounded down to the start of the given date.
  * @property {string} startTime The start time range for the search query. These timestamps are in GMT and rounded down to the start of the given date.
  * @property {string} terms The search terms for the hold.
+ */
+/**
+ * @typedef HeldHangoutsChatQuery
+ * @memberOf! vault(v1)
+ * @type object
+ * @property {boolean} includeRooms If true, include rooms the user has participated in.
  */
 /**
  * @typedef HeldMailQuery

--- a/src/apis/videointelligence/v1beta1.ts
+++ b/src/apis/videointelligence/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Cloud Video Intelligence API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Videointelligence
  */
-function Videointelligence(options) {
+function Videointelligence(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.videos = {
@@ -50,7 +57,9 @@ function Videointelligence(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    annotate(params, options, callback) {
+    annotate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -71,7 +80,7 @@ function Videointelligence(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/vision/v1.ts
+++ b/src/apis/vision/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Vision API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Vision
  */
-function Vision(options) {
+function Vision(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.images = {
@@ -103,7 +110,9 @@ function Vision(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    annotate(params, options, callback) {
+    annotate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -123,7 +132,7 @@ function Vision(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -149,7 +158,9 @@ function Vision(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    cancel(params, options, callback) {
+    cancel(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -169,7 +180,7 @@ function Vision(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vision.operations.delete
         * @desc Deletes a long-running operation. This method indicates that the
@@ -185,7 +196,9 @@ function Vision(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -204,7 +217,7 @@ function Vision(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vision.operations.get
         * @desc Gets the latest state of a long-running operation.  Clients can
@@ -219,7 +232,8 @@ function Vision(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -238,7 +252,7 @@ function Vision(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * vision.operations.list
         * @desc Lists operations that match the specified filter in the request.
@@ -262,7 +276,9 @@ function Vision(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -281,7 +297,7 @@ function Vision(options) {
         pathParams: ['name'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/vision/v1p1beta1.ts
+++ b/src/apis/vision/v1p1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Vision API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1p1beta1
  * @param {object=} options Options for Vision
  */
-function Vision(options) {
+function Vision(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.images = {
@@ -49,7 +56,9 @@ function Vision(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    annotate(params, options, callback) {
+    annotate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Vision(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/vision/v1p2beta1.ts
+++ b/src/apis/vision/v1p2beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Cloud Vision API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1p2beta1
  * @param {object=} options Options for Vision
  */
-function Vision(options) {
+function Vision(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.files = {
@@ -54,7 +61,9 @@ function Vision(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    asyncBatchAnnotate(params, options, callback) {
+    asyncBatchAnnotate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -74,7 +83,7 @@ function Vision(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -91,7 +100,9 @@ function Vision(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    annotate(params, options, callback) {
+    annotate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -111,7 +122,7 @@ function Vision(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/webfonts/v1.ts
+++ b/src/apis/webfonts/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Google Fonts Developer API
@@ -33,7 +40,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Webfonts
  */
-function Webfonts(options) {
+function Webfonts(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.webfonts = {
@@ -50,7 +57,9 @@ function Webfonts(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -70,7 +79,7 @@ function Webfonts(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/webmasters/v3.ts
+++ b/src/apis/webmasters/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * Search Console API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Webmasters
  */
-function Webmasters(options) {
+function Webmasters(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.searchanalytics = {
@@ -53,7 +60,9 @@ function Webmasters(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -74,7 +83,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -92,7 +101,9 @@ function Webmasters(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -113,7 +124,7 @@ function Webmasters(options) {
         pathParams: ['feedpath', 'siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.sitemaps.get
         * @desc Retrieves information about a specific sitemap.
@@ -127,7 +138,8 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -148,7 +160,7 @@ function Webmasters(options) {
         pathParams: ['feedpath', 'siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.sitemaps.list
         * @desc Lists the sitemaps-entries submitted for this site, or included
@@ -164,7 +176,9 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -184,7 +198,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.sitemaps.submit
         * @desc Submits a sitemap for a site.
@@ -198,7 +212,9 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    submit(params, options, callback) {
+    submit(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -219,7 +235,7 @@ function Webmasters(options) {
         pathParams: ['feedpath', 'siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -236,7 +252,8 @@ function Webmasters(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    add(params, options, callback) {
+    add(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -256,7 +273,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.sites.delete
         * @desc Removes a site from the set of the user's Search Console sites.
@@ -269,7 +286,9 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -289,7 +308,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.sites.get
         * @desc Retrieves information about specific site.
@@ -302,7 +321,8 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -322,7 +342,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.sites.list
         * @desc Lists the user's Search Console sites.
@@ -334,7 +354,9 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -354,7 +376,7 @@ function Webmasters(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -375,7 +397,9 @@ function Webmasters(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -396,7 +420,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -416,7 +440,8 @@ function Webmasters(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -438,7 +463,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl', 'url'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.urlcrawlerrorssamples.list
         * @desc Lists a site's sample URLs for the specified crawl error
@@ -454,7 +479,9 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -475,7 +502,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * webmasters.urlcrawlerrorssamples.markAsFixed
         * @desc Marks the provided site's sample URL as fixed, and removes it
@@ -492,7 +519,9 @@ function Webmasters(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    markAsFixed(params, options, callback) {
+    markAsFixed(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -514,7 +543,7 @@ function Webmasters(options) {
         pathParams: ['siteUrl', 'url'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/youtube/v3.ts
+++ b/src/apis/youtube/v3.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * YouTube Data API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v3
  * @param {object=} options Options for Youtube
  */
-function Youtube(options) {
+function Youtube(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.activities = {
@@ -55,7 +62,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -75,7 +84,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.activities.list
         * @desc Returns a list of channel activity events that match the request
@@ -100,7 +109,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -120,7 +131,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -139,7 +150,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -159,7 +172,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.captions.download
         * @desc Downloads a caption track. The caption track is returned in its
@@ -179,7 +192,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    download(params, options, callback) {
+    download(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -199,7 +214,7 @@ function Youtube(options) {
         pathParams: ['id'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.captions.insert
         * @desc Uploads a caption track.
@@ -219,7 +234,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -241,7 +258,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.captions.list
         * @desc Returns a list of caption tracks that are associated with a
@@ -261,7 +278,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -281,7 +300,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.captions.update
         * @desc Updates a caption track. When updating a caption track, you can
@@ -303,7 +322,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -325,7 +346,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -355,7 +376,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -377,7 +400,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -405,7 +428,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -425,7 +450,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.channels.update
         * @desc Updates a channel's metadata. Note that this method currently
@@ -442,7 +467,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -462,7 +489,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -480,7 +507,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -500,7 +529,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.channelSections.insert
         * @desc Adds a channelSection for the authenticated user's channel.
@@ -516,7 +545,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -536,7 +567,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.channelSections.list
         * @desc Returns channelSection resources that match the API request
@@ -555,7 +586,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -575,7 +608,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.channelSections.update
         * @desc Update a channelSection.
@@ -590,7 +623,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -610,7 +645,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -627,7 +662,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -647,7 +684,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.comments.insert
         * @desc Creates a reply to an existing comment. Note: To create a
@@ -662,7 +699,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -682,7 +721,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.comments.list
         * @desc Returns a list of comments that match the API request
@@ -701,7 +740,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -721,7 +762,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.comments.markAsSpam
         * @desc Expresses the caller's opinion that one or more comments should
@@ -735,7 +776,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    markAsSpam(params, options, callback) {
+    markAsSpam(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -755,7 +798,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.comments.setModerationStatus
         * @desc Sets the moderation status of one or more comments. The API
@@ -772,7 +815,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    setModerationStatus(params, options, callback) {
+    setModerationStatus(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -792,7 +837,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.comments.update
         * @desc Modifies a comment.
@@ -806,7 +851,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -826,7 +873,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -845,7 +892,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -865,7 +914,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.commentThreads.list
         * @desc Returns a list of comment threads that match the API request
@@ -889,7 +938,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -909,7 +960,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.commentThreads.update
         * @desc Modifies the top-level comment in a comment thread.
@@ -923,7 +974,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -943,7 +996,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -963,7 +1016,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -983,7 +1038,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1004,7 +1059,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1024,7 +1081,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1043,7 +1100,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1063,7 +1122,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1082,7 +1141,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1102,7 +1163,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1126,7 +1187,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    bind(params, options, callback) {
+    bind(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1146,7 +1209,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveBroadcasts.control
         * @desc Controls the settings for a slate that can be displayed in the
@@ -1166,7 +1229,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    control(params, options, callback) {
+    control(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1186,7 +1251,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveBroadcasts.delete
         * @desc Deletes a broadcast.
@@ -1201,7 +1266,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1221,7 +1288,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveBroadcasts.insert
         * @desc Creates a broadcast.
@@ -1237,7 +1304,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1257,7 +1326,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveBroadcasts.list
         * @desc Returns a list of YouTube broadcasts that match the API request
@@ -1279,7 +1348,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1299,7 +1370,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveBroadcasts.transition
         * @desc Changes the status of a YouTube live broadcast and initiates any
@@ -1321,7 +1392,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    transition(params, options, callback) {
+    transition(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1341,7 +1414,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveBroadcasts.update
         * @desc Updates a broadcast. For example, you could modify the broadcast
@@ -1359,7 +1432,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1379,7 +1454,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1396,7 +1471,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1416,7 +1493,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveChatBans.insert
         * @desc Adds a new ban to the chat.
@@ -1430,7 +1507,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1450,7 +1529,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1467,7 +1546,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1487,7 +1568,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveChatMessages.insert
         * @desc Adds a message to a live chat.
@@ -1501,7 +1582,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1521,7 +1604,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveChatMessages.list
         * @desc Lists live chat messages for a specific chat.
@@ -1539,7 +1622,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1559,7 +1644,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1576,7 +1661,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1596,7 +1683,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveChatModerators.insert
         * @desc Adds a new moderator for the chat.
@@ -1610,7 +1697,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1630,7 +1719,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveChatModerators.list
         * @desc Lists moderators for a live chat.
@@ -1646,7 +1735,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1666,7 +1757,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1685,7 +1776,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1705,7 +1798,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveStreams.insert
         * @desc Creates a video stream. The stream enables you to send your
@@ -1722,7 +1815,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1742,7 +1837,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveStreams.list
         * @desc Returns a list of video streams that match the API request
@@ -1762,7 +1857,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1782,7 +1879,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.liveStreams.update
         * @desc Updates a video stream. If the properties that you want to
@@ -1800,7 +1897,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1820,7 +1919,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1838,7 +1937,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1858,7 +1959,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.playlistItems.insert
         * @desc Adds a resource to a playlist.
@@ -1873,7 +1974,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1893,7 +1996,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.playlistItems.list
         * @desc Returns a collection of playlist items that match the API
@@ -1915,7 +2018,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1935,7 +2040,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.playlistItems.update
         * @desc Modifies a playlist item. For example, you could update the
@@ -1951,7 +2056,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -1971,7 +2078,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -1989,7 +2096,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2009,7 +2118,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.playlists.insert
         * @desc Creates a playlist.
@@ -2025,7 +2134,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2045,7 +2156,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.playlists.list
         * @desc Returns a collection of playlists that match the API request
@@ -2069,7 +2180,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2089,7 +2202,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.playlists.update
         * @desc Modifies a playlist. For example, you could change a playlist's
@@ -2105,7 +2218,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2125,7 +2240,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2175,7 +2290,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2195,7 +2312,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2215,7 +2332,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2235,7 +2354,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2252,7 +2371,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2272,7 +2393,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.subscriptions.insert
         * @desc Adds a subscription for the authenticated user's channel.
@@ -2286,7 +2407,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2306,7 +2429,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.subscriptions.list
         * @desc Returns subscription resources that match the API request
@@ -2331,7 +2454,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2351,7 +2476,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2371,7 +2496,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2391,7 +2518,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2413,7 +2540,8 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    set(params, options, callback) {
+    set(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2435,7 +2563,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2454,7 +2582,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2474,7 +2604,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2495,7 +2625,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2515,7 +2647,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2533,7 +2665,9 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2553,7 +2687,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.videos.getRating
         * @desc Retrieves the ratings that the authorized user gave to a list of
@@ -2568,7 +2702,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    getRating(params, options, callback) {
+    getRating(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2588,7 +2724,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.videos.insert
         * @desc Uploads a video to YouTube and optionally sets the video's
@@ -2611,7 +2747,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2633,7 +2771,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.videos.list
         * @desc Returns a list of videos that match the API request parameters.
@@ -2658,7 +2796,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2678,7 +2818,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.videos.rate
         * @desc Add a like or dislike rating to a video or remove a rating from
@@ -2693,7 +2833,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    rate(params, options, callback) {
+    rate(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2713,7 +2855,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.videos.reportAbuse
         * @desc Report abuse for a video.
@@ -2727,7 +2869,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    reportAbuse(params, options, callback) {
+    reportAbuse(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2747,7 +2891,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.videos.update
         * @desc Updates a video's metadata.
@@ -2762,7 +2906,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2782,7 +2928,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -2804,7 +2950,8 @@ function Youtube(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    set(params, options, callback) {
+    set(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2826,7 +2973,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtube.watermarks.unset
         * @desc Deletes a channel's watermark image.
@@ -2840,7 +2987,9 @@ function Youtube(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    unset(params, options, callback) {
+    unset(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -2860,7 +3009,7 @@ function Youtube(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/youtubeAnalytics/v1.ts
+++ b/src/apis/youtubeAnalytics/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * YouTube Analytics API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Youtubeanalytics
  */
-function Youtubeanalytics(options) {
+function Youtubeanalytics(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.groupItems = {
@@ -48,7 +55,9 @@ function Youtubeanalytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groupItems.insert
         * @desc Creates a group item.
@@ -82,7 +91,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +113,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groupItems.list
         * @desc Returns a collection of group items that match the API request
@@ -117,7 +128,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -137,7 +150,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -155,7 +168,9 @@ function Youtubeanalytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -175,7 +190,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groups.insert
         * @desc Creates a group.
@@ -189,7 +204,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -209,7 +226,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groups.list
         * @desc Returns a collection of groups that match the API request
@@ -228,7 +245,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -248,7 +267,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groups.update
         * @desc Modifies a group. For example, you could change a group's title.
@@ -262,7 +281,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -282,7 +303,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -309,7 +330,9 @@ function Youtubeanalytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -329,7 +352,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/youtubeAnalytics/v1beta1.ts
+++ b/src/apis/youtubeAnalytics/v1beta1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * YouTube Analytics API
@@ -31,7 +38,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1beta1
  * @param {object=} options Options for Youtubeanalytics
  */
-function Youtubeanalytics(options) {
+function Youtubeanalytics(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.groupItems = {
@@ -48,7 +55,9 @@ function Youtubeanalytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -68,7 +77,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groupItems.insert
         * @desc Creates a group item.
@@ -82,7 +91,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -102,7 +113,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groupItems.list
         * @desc Returns a collection of group items that match the API request
@@ -117,7 +128,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -137,7 +150,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -155,7 +168,9 @@ function Youtubeanalytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -175,7 +190,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groups.insert
         * @desc Creates a group.
@@ -189,7 +204,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    insert(params, options, callback) {
+    insert(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -209,7 +226,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groups.list
         * @desc Returns a collection of groups that match the API request
@@ -228,7 +245,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -248,7 +267,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubeAnalytics.groups.update
         * @desc Modifies a group. For example, you could change a group's title.
@@ -262,7 +281,9 @@ function Youtubeanalytics(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    update(params, options, callback) {
+    update(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -282,7 +303,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -309,7 +330,9 @@ function Youtubeanalytics(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    query(params, options, callback) {
+    query(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -329,7 +352,7 @@ function Youtubeanalytics(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/apis/youtubereporting/v1.ts
+++ b/src/apis/youtubereporting/v1.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
 import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+
 
 /**
  * YouTube Reporting API
@@ -32,7 +39,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation v1
  * @param {object=} options Options for Youtubereporting
  */
-function Youtubereporting(options) {
+function Youtubereporting(options: GlobalOptions) {
   const self = this;
   self._options = options || {};
   self.jobs = {
@@ -49,7 +56,9 @@ function Youtubereporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    create(params, options, callback) {
+    create(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -69,7 +78,7 @@ function Youtubereporting(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubereporting.jobs.delete
         * @desc Deletes a job.
@@ -83,7 +92,9 @@ function Youtubereporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    delete (params, options, callback) {
+    delete (
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -103,7 +114,7 @@ function Youtubereporting(options) {
         pathParams: ['jobId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubereporting.jobs.get
         * @desc Gets a job.
@@ -117,7 +128,8 @@ function Youtubereporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    get(params, options, callback) {
+    get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -137,7 +149,7 @@ function Youtubereporting(options) {
         pathParams: ['jobId'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }, /**
         * youtubereporting.jobs.list
         * @desc Lists jobs.
@@ -153,7 +165,9 @@ function Youtubereporting(options) {
         * @param {callback} callback The callback that handles the response.
         * @return {object} Request object
         */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -173,7 +187,7 @@ function Youtubereporting(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     },
     reports: {
       /**
@@ -190,7 +204,8 @@ function Youtubereporting(options) {
        * @param {callback} callback The callback that handles the response.
        * @return {object} Request object
        */
-      get(params, options, callback) {
+      get(params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -211,7 +226,7 @@ function Youtubereporting(options) {
           pathParams: ['jobId', 'reportId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }, /**
           * youtubereporting.jobs.reports.list
           * @desc Lists reports created by a specific job. Returns NOT_FOUND if
@@ -231,7 +246,9 @@ function Youtubereporting(options) {
           * @param {callback} callback The callback that handles the response.
           * @return {object} Request object
           */
-      list(params, options, callback) {
+      list(
+          params: any, options: MethodOptions|BodyResponseCallback<any>,
+          callback?: BodyResponseCallback<any>) {
         if (typeof options === 'function') {
           callback = options;
           options = {};
@@ -252,7 +269,7 @@ function Youtubereporting(options) {
           pathParams: ['jobId'],
           context: self
         };
-        return createAPIRequest(parameters, callback);
+        return createAPIRequest(parameters, callback!);
       }
 
     }
@@ -271,7 +288,9 @@ function Youtubereporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    download(params, options, callback) {
+    download(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -292,7 +311,7 @@ function Youtubereporting(options) {
         pathParams: ['resourceName'],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };
@@ -312,7 +331,9 @@ function Youtubereporting(options) {
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
      */
-    list(params, options, callback) {
+    list(
+        params: any, options: MethodOptions|BodyResponseCallback<any>,
+        callback?: BodyResponseCallback<any>) {
       if (typeof options === 'function') {
         callback = options;
         options = {};
@@ -332,7 +353,7 @@ function Youtubereporting(options) {
         pathParams: [],
         context: self
       };
-      return createAPIRequest(parameters, callback);
+      return createAPIRequest(parameters, callback!);
     }
 
   };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AxiosAdapter, AxiosProxyConfig, AxiosRequestConfig, AxiosTransformer, CancelToken} from 'axios';
+import {AxiosAdapter, AxiosProxyConfig, AxiosRequestConfig, AxiosResponse, AxiosTransformer, CancelToken} from 'axios';
 import {OAuth2Client} from 'google-auth-library/build/src/auth/oauth2client';
 import {OutgoingHttpHeaders} from 'http';
 import * as stream from 'stream';
@@ -74,6 +74,11 @@ export interface GlobalOptions {
   proxy?: AxiosProxyConfig|false;
   cancelToken?: CancelToken;
 }
+
+export interface MethodOptions extends AxiosRequestConfig { rootUrl?: string; }
+
+export type BodyResponseCallback<T> =
+    (err: Error|null, res?: AxiosResponse<T>|null) => void;
 
 export interface APIRequestMethodParams {
   // tslint:disable-next-line: no-any

--- a/src/lib/apirequest.ts
+++ b/src/lib/apirequest.ts
@@ -18,7 +18,7 @@ import * as stream from 'stream';
 import * as parseString from 'string-template';
 import * as uuid from 'uuid';
 
-import {APIRequestParams} from './api';
+import {APIRequestParams, GlobalOptions} from './api';
 import {SchemaParameters} from './schema';
 
 const maxContentLength = Math.pow(2, 31);
@@ -222,5 +222,12 @@ export function createAPIRequest<T>(
     authClient.request(mergedOptions, callback);
   } else {
     (new DefaultTransporter()).request(mergedOptions, callback);
+  }
+}
+
+export class BaseAPI {
+  protected _options: GlobalOptions;
+  constructor(options: GlobalOptions) {
+    this._options = options || {};
   }
 }

--- a/src/lib/googleapis.ts
+++ b/src/lib/googleapis.ts
@@ -43,7 +43,7 @@ export class GoogleApis extends apis.GeneratedAPIs {
    * @class GoogleApis
    * @param {Object} [options] Configuration options.
    */
-  constructor(options?: {}) {
+  constructor(options?: GlobalOptions) {
     super();
     this.options(options);
     // tslint:disable-next-line: no-any

--- a/src/templates/api-endpoint.njk
+++ b/src/templates/api-endpoint.njk
@@ -19,6 +19,13 @@
  */
 
 import {createAPIRequest} from '../../lib/apirequest';
+import { MethodOptions, GlobalOptions, BodyResponseCallback } from '../../lib/api';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the interim we 
+// want to turn on no-implicit-any.  
+
+// tslint:disable: no-any
+
 {% set Name = api.name|capitalize %}
 {% if api.version %}
 {% set Version = api.version|replace('\.', '_')|capitalize %}
@@ -40,7 +47,7 @@ import {createAPIRequest} from '../../lib/apirequest';
  * @variation {{ api.version }}
  * @param {object=} options Options for {{ Name }}
  */
-function {{ Name }} (options) {
+function {{ Name }} (options: GlobalOptions) {
   const self = this;
   self._options = options || {};
 {% if api.methods %}

--- a/src/templates/method-partial.njk
+++ b/src/templates/method-partial.njk
@@ -38,8 +38,8 @@
  * @param {callback} callback The callback that handles the response.
  * @return {object} Request object
  */
-{% if globalmethods %}this.{{ mname }} = (params, options, callback) => { {% endif %}
-{% if not globalmethods %}{{ mname }} (params, options, callback) { {% endif %}
+{% if globalmethods %}this.{{ mname }} = (params: any, options: MethodOptions|BodyResponseCallback<any>, callback?: BodyResponseCallback<any>) => { {% endif %}
+{% if not globalmethods %}{{ mname }} (params: any, options: MethodOptions|BodyResponseCallback<any>, callback?: BodyResponseCallback<any>) { {% endif %}
 
   if (typeof options === 'function') {
     callback = options;
@@ -58,5 +58,5 @@
     pathParams: [{% if pathParams.length %}'{{ pathParams|join("', '")|safe }}'{% endif %}],
     context: self
   };
-  return createAPIRequest(parameters, callback);
+  return createAPIRequest(parameters, callback!);
 }{% if globalmethods %};{% endif %}{% endmacro %}


### PR DESCRIPTION
This portly PR comes in 2 commits.  One with the changes to the generator and the templates, and another with just the generated files.  No behavioral changes, just one more step towards type safety. 