### PR TITLE
chore: setup nightly builds workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,22 @@
 ---
 # "Include" for unit tests definition.
+
+remove_package_lock: &remove_package_lock
+  name: Remove package-lock.json if needed.
+  command: |
+    WORKFLOW_NAME=`python .circleci/get_workflow_name.py`
+    echo "Workflow name: $WORKFLOW_NAME"
+    if [ "$WORKFLOW_NAME" = "nightly" ]; then
+      echo "Nightly build detected, removing package-lock.json"
+      rm -f package-lock.json samples/package-lock.json
+    else
+      echo "Not a nightly build, skipping this step."
+    fi
+
 unit_tests: &unit_tests
   steps:
     - checkout
+    - run: *remove_package_lock
     - run:
         name: Install modules and dependencies.
         command: npm install
@@ -22,6 +36,7 @@ unit_tests: &unit_tests
 test_samples: &test_samples
   steps:
     - checkout
+    - run: *remove_package_lock
     - run: npm install
     - run: mkdir ~/.npm-packages
     - run: echo "prefix = $HOME/.npm-packages" >> ~/.npmrc
@@ -32,7 +47,7 @@ version: 2.0
 workflows:
   version: 2
   tests:
-    jobs:
+    jobs: &workflow_jobs
       - node4:
           filters:
             tags:
@@ -60,6 +75,14 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[\d.]+$/
+  nightly:
+    triggers:
+      - schedule:
+          cron: 0 7 * * *
+          filters:
+            branches:
+              only: master
+    jobs: *workflow_jobs
 
 jobs:
   node4:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ remove_package_lock: &remove_package_lock
     echo "Workflow name: $WORKFLOW_NAME"
     if [ "$WORKFLOW_NAME" = "nightly" ]; then
       echo "Nightly build detected, removing package-lock.json"
-      rm -f package-lock.json samples/package-lock.json
+      rm -f package-lock.json
     else
       echo "Not a nightly build, skipping this step."
     fi

--- a/.circleci/get_workflow_name.py
+++ b/.circleci/get_workflow_name.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Get workflow name for the current build using CircleCI API.
+Would be great if this information is available in one of
+CircleCI environment variables, but it's not there.
+https://circleci.ideas.aha.io/ideas/CCI-I-295
+"""
+
+import json
+import os
+import sys
+import urllib2
+
+
+def main():
+    try:
+        username = os.environ['CIRCLE_PROJECT_USERNAME']
+        reponame = os.environ['CIRCLE_PROJECT_REPONAME']
+        build_num = os.environ['CIRCLE_BUILD_NUM']
+    except:
+        sys.stderr.write(
+            'Looks like we are not inside CircleCI container. Exiting...\n')
+        return 1
+
+    try:
+        request = urllib2.Request(
+            "https://circleci.com/api/v1.1/project/github/%s/%s/%s" %
+            (username, reponame, build_num),
+            headers={"Accept": "application/json"})
+        contents = urllib2.urlopen(request).read()
+    except:
+        sys.stderr.write('Cannot query CircleCI API. Exiting...\n')
+        return 1
+
+    try:
+        build_info = json.loads(contents)
+    except:
+        sys.stderr.write(
+            'Cannot parse JSON received from CircleCI API. Exiting...\n')
+        return 1
+
+    try:
+        workflow_name = build_info['workflows']['workflow_name']
+    except:
+        sys.stderr.write(
+            'Cannot get workflow name from CircleCI build info. Exiting...\n')
+        return 1
+
+    print workflow_name
+    return 0
+
+
+retval = main()
+exit(retval)

--- a/.circleci/get_workflow_name.py
+++ b/.circleci/get_workflow_name.py
@@ -26,14 +26,23 @@ import urllib2
 
 def main():
     try:
-        token = os.environ['CIRCLECI_TOKEN']
         username = os.environ['CIRCLE_PROJECT_USERNAME']
         reponame = os.environ['CIRCLE_PROJECT_REPONAME']
         build_num = os.environ['CIRCLE_BUILD_NUM']
     except:
         sys.stderr.write(
             'Looks like we are not inside CircleCI container. Exiting...\n')
-        return 1
+        print 'undefined'
+        return 0
+
+    try:
+        token = os.environ['CIRCLECI_TOKEN']
+    except:
+        sys.stderr.write(
+            'Looks like we we don\'t have CircleCI environment set up. Exiting...\n'
+        )
+        print 'undefined'
+        return 0
 
     try:
         request = urllib2.Request(
@@ -43,21 +52,24 @@ def main():
         contents = urllib2.urlopen(request).read()
     except:
         sys.stderr.write('Cannot query CircleCI API. Exiting...\n')
-        return 1
+        print 'undefined'
+        return 0
 
     try:
         build_info = json.loads(contents)
     except:
         sys.stderr.write(
             'Cannot parse JSON received from CircleCI API. Exiting...\n')
-        return 1
+        print 'undefined'
+        return 0
 
     try:
         workflow_name = build_info['workflows']['workflow_name']
     except:
         sys.stderr.write(
             'Cannot get workflow name from CircleCI build info. Exiting...\n')
-        return 1
+        print 'undefined'
+        return 0
 
     print workflow_name
     return 0

--- a/.circleci/get_workflow_name.py
+++ b/.circleci/get_workflow_name.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Get workflow name for the current build using CircleCI API.
 Would be great if this information is available in one of
@@ -27,6 +26,7 @@ import urllib2
 
 def main():
     try:
+        token = os.environ['CIRCLECI_TOKEN']
         username = os.environ['CIRCLE_PROJECT_USERNAME']
         reponame = os.environ['CIRCLE_PROJECT_REPONAME']
         build_num = os.environ['CIRCLE_BUILD_NUM']
@@ -37,8 +37,8 @@ def main():
 
     try:
         request = urllib2.Request(
-            "https://circleci.com/api/v1.1/project/github/%s/%s/%s" %
-            (username, reponame, build_num),
+            "https://circleci.com/api/v1.1/project/github/%s/%s/%s?circle-token=%s"
+            % (username, reponame, build_num, token),
             headers={"Accept": "application/json"})
         contents = urllib2.urlopen(request).read()
     except:


### PR DESCRIPTION
Pretty much the same change I applied to all Veneer libraries, but with some specifics (requiring token to access API; the token is set in CircleCI environment).

- [x] `npm test` succeeds
- [x] Pull request has been squashed into 1 commit
- [x] I did NOT manually make changes to anything in `apis/`
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate JSDoc comments were updated in source code (if applicable)
- [x] Appropriate changes to readme/docs are included in PR
