### PR TITLE
Update authenticate method docs with the right URL

### DIFF
--- a/samples/sampleclient.js
+++ b/samples/sampleclient.js
@@ -46,7 +46,7 @@ class SampleClient {
 
   // Open an http server to accept the oauth callback. In this
   // simple example, the only request to our webserver is to
-  // /callback?code=<code>
+  // /oauth2callback?code=<code>
   async authenticate (scopes) {
     return new Promise((resolve, reject) => {
       // grab the url that will be used for authorization


### PR DESCRIPTION
The webserver callback should be done to oauth2callback since it's what in line 59 are been compared.

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm test` succeeds
- [ ] Pull request has been squashed into 1 commit
- [ ] I did NOT manually make changes to anything in `apis/`
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate JSDoc comments were updated in source code (if applicable)
- [ ] Appropriate changes to readme/docs are included in PR
