### PR TITLE
fix: use `requestBody` instead of `resource`

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,12 +266,12 @@ See the [Options section][options] for more information.
 
 ### Specifying request body
 
-The body of the request is specified in the `resource` parameter object of the request. The resource/body is specified as a JavaScript object with key/value pairs. For example, this sample creates a watcher that posts notifications to a Google Cloud Pub/Sub topic when emails are sent to a gmail account:
+The body of the request is specified in the `requestBody` parameter object of the request. The body is specified as a JavaScript object with key/value pairs. For example, this sample creates a watcher that posts notifications to a Google Cloud Pub/Sub topic when emails are sent to a gmail account:
 
 ```js
 const res = await gmail.users.watch({
   userId: 'me',
-  resource: {
+  requestBody: {
     // Replace with `projects/${PROJECT_ID}/topics/${TOPIC_NAME}`
     topicName: `projects/el-gato/topics/gmail`
   }
@@ -280,7 +280,7 @@ console.log(res.data);
 ```
 
 ### Media uploads
-This client supports multipart media uploads. The resource parameters are specified in the `resource` parameter object, and the media itself is specified in the `media.body` parameter with mime-type specified in `media.mimeType`.
+This client supports multipart media uploads. The resource parameters are specified in the `requestBody` parameter object, and the media itself is specified in the `media.body` parameter with mime-type specified in `media.mimeType`.
 
 This example uploads a plain text file to Google Drive with the title "Test" and contents "Hello World".
 
@@ -291,7 +291,7 @@ const drive = google.drive({
 });
 
 const res = await drive.files.create({
-  resource: {
+  requestBody: {
     name: 'Test',
     mimeType: 'text/plain'
   },
@@ -314,7 +314,7 @@ const drive = google.drive({
 
 async function main() {
   const res = await drive.files.create({
-    resource: {
+    requestBody: {
       name: 'testimage.png',
       mimeType: 'image/png'
     },

--- a/samples/analytics/analytics.js
+++ b/samples/analytics/analytics.js
@@ -36,21 +36,18 @@ const variations = [
   {'name': 'variation 2', 'url': 'http://www.2.com', 'status': 'ACTIVE'}
 ];
 
-// Specify Experiment configuration
-const resourceBody = {
-  'name': 'Example Experiment',
-  'status': 'READY_TO_RUN',
-  'objectiveMetric': objectiveMetric,
-  'servingFramework': servingFramework,
-  'variations': variations
-};
-
 async function runSample () {
   const res = await analytics.management.experiments.insert({
     accountId: 'your-accountId',
     webPropertyId: 'your-webPropertyId',
     profileId: 'your-profileId',
-    resource: resourceBody
+    requestBody: {
+      'name': 'Example Experiment',
+      'status': 'READY_TO_RUN',
+      'objectiveMetric': objectiveMetric,
+      'servingFramework': servingFramework,
+      'variations': variations
+    }
   });
   console.log(res.data);
   return res.data;

--- a/samples/analyticsReporting/batchGet.js
+++ b/samples/analyticsReporting/batchGet.js
@@ -23,7 +23,7 @@ const analyticsreporting = google.analyticsreporting({
 
 async function runSample () {
   const res = await analyticsreporting.reports.batchGet({
-    resource: {
+    requestBody: {
       reportRequests: [{
         viewId: '65704806',
         dateRanges: [

--- a/samples/blogger/insert.js
+++ b/samples/blogger/insert.js
@@ -24,7 +24,7 @@ const blogger = google.blogger({
 async function runSample () {
   const res = await blogger.posts.insert({
     blogId: '4340475495955554224',
-    resource: {
+    requestBody: {
       title: 'Hello from the googleapis npm module!',
       content: 'Visit https://github.com/google/google-api-nodejs-client to learn more!'
     }

--- a/samples/directory_v1/group-email-insert.js
+++ b/samples/directory_v1/group-email-insert.js
@@ -43,7 +43,7 @@ jwt.authorize((err, data) => {
   // Insert member in Google group
   admin.members.insert({
     groupKey: 'my_group@example.com',
-    resource: { email: 'me@example.com' },
+    requestBody: { email: 'me@example.com' },
     auth: jwt
   }, (err, data) => {
     console.log(err || data);

--- a/samples/directory_v1/group-insert.js
+++ b/samples/directory_v1/group-insert.js
@@ -42,7 +42,7 @@ jwt.authorize((err, data) => {
 
   // Insert group
   admin.groups.insert({
-    resource: { email: 'some_group@example.com' },
+    requestBody: { email: 'some_group@example.com' },
     auth: jwt
   }, (err, data) => {
     console.log(err || data);

--- a/samples/drive/upload.js
+++ b/samples/drive/upload.js
@@ -25,8 +25,8 @@ const drive = google.drive({
 async function runSample (fileName) {
   const fileSize = fs.statSync(fileName).size;
   const res = await drive.files.create({
-    resource: {
-      // a resource element is required if you want to use multipart
+    requestBody: {
+      // a requestBody element is required if you want to use multipart
     },
     media: {
       body: fs.createReadStream(fileName)

--- a/samples/gmail/labels.js
+++ b/samples/gmail/labels.js
@@ -26,7 +26,7 @@ async function runSample (action, messageId, labelId) {
     const res = await gmail.users.messages.modify({
       userId: 'me',
       id: messageId,
-      resource: {
+      requestBody: {
         'addLabelIds': [labelId]
       }
     });
@@ -36,7 +36,7 @@ async function runSample (action, messageId, labelId) {
     const res = await gmail.users.messages.modify({
       userId: 'me',
       id: messageId,
-      resource: {
+      requestBody: {
         'removeLabelIds': [labelId]
       }
     });

--- a/samples/gmail/send.js
+++ b/samples/gmail/send.js
@@ -47,7 +47,7 @@ async function runSample () {
 
   const res = await gmail.users.messages.send({
     userId: 'me',
-    resource: {
+    requestBody: {
       raw: encodedMessage
     }
   });

--- a/samples/gmail/watch.js
+++ b/samples/gmail/watch.js
@@ -33,7 +33,7 @@ const gmail = google.gmail({
 async function runSample () {
   const res = await gmail.users.watch({
     userId: 'me',
-    resource: {
+    requestBody: {
       // Replace with `projects/${PROJECT_ID}/topics/${TOPIC_NAME}`
       topicName: `projects/el-gato/topics/gmail`
     }

--- a/samples/mediaupload.js
+++ b/samples/mediaupload.js
@@ -20,7 +20,7 @@ const sampleClient = require('./sampleclient');
 async function runSamples () {
   // insertion example
   let res = await drive.files.insert({
-    resource: {
+    requestBody: {
       title: 'Test',
       mimeType: 'text/plain'
     },
@@ -46,7 +46,7 @@ async function runSamples () {
   // update example with metadata update
   res = await drive.files.update({
     fileId: '0B-skmV2...',
-    resource: {
+    requestBody: {
       title: 'Updated title'
     },
     media: {

--- a/samples/plus/post.js
+++ b/samples/plus/post.js
@@ -24,7 +24,7 @@ const plus = google.plusDomains({
 async function runSample () {
   const res = await plus.activities.insert({
     userId: 'me',
-    resource: {
+    requestBody: {
       object: {
         originalContent: 'Hello from the Node.js Google API Client!'
       },

--- a/samples/sheets/append.js
+++ b/samples/sheets/append.js
@@ -26,7 +26,7 @@ async function runSample (spreadsheetId, range) {
     spreadsheetId,
     range,
     valueInputOption: 'USER_ENTERED',
-    resource: {
+    requestBody: {
       values: [
         ['Justin', '1/1/2001', 'Website'],
         ['Node.js', '2018-03-14', 'Fun']

--- a/samples/urlshortener/urlshortener.js
+++ b/samples/urlshortener/urlshortener.js
@@ -30,7 +30,7 @@ urlshortener.url.get({
 });
 
 urlshortener.url.insert({
-  resource: {
+  requestBody: {
     longUrl: 'http://somelongurl.com'
   }
 }, (err, res) => {

--- a/samples/webmasters/query.js
+++ b/samples/webmasters/query.js
@@ -24,7 +24,7 @@ const webmasters = google.webmasters({
 async function runSample () {
   const res = await webmasters.searchanalytics.query({
     siteUrl: 'http://jbeckwith.com',
-    resource: {
+    requestBody: {
       startDate: '2018-01-01',
       endDate: '2018-04-01'
     }

--- a/samples/youtube/upload.js
+++ b/samples/youtube/upload.js
@@ -33,7 +33,7 @@ async function runSample (fileName, callback) {
   const res = await youtube.videos.insert({
     part: 'id,snippet,status',
     notifySubscribers: false,
-    resource: {
+    requestBody: {
       snippet: {
         title: 'Node.js YouTube Upload Test',
         description: 'Testing YouTube upload via Google APIs Node.js Client'

--- a/src/apis/acceleratedmobilepageurl/v1.ts
+++ b/src/apis/acceleratedmobilepageurl/v1.ts
@@ -225,9 +225,10 @@ export namespace acceleratedmobilepageurl_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchGetAmpUrlsRequest;
+    requestBody?: Schema$BatchGetAmpUrlsRequest;
   }
 }

--- a/src/apis/adexchangebuyer/v1.2.ts
+++ b/src/apis/adexchangebuyer/v1.2.ts
@@ -557,10 +557,11 @@ export namespace adexchangebuyer_v1_2 {
      * The account id
      */
     id?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
   export interface Params$Resource$Accounts$Update {
     /**
@@ -572,10 +573,11 @@ export namespace adexchangebuyer_v1_2 {
      * The account id
      */
     id?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
 
@@ -808,6 +810,12 @@ export namespace adexchangebuyer_v1_2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Creatives$List {
     /**

--- a/src/apis/adexchangebuyer/v1.3.ts
+++ b/src/apis/adexchangebuyer/v1.3.ts
@@ -966,10 +966,11 @@ export namespace adexchangebuyer_v1_3 {
      * The account id
      */
     id?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
   export interface Params$Resource$Accounts$Update {
     /**
@@ -981,10 +982,11 @@ export namespace adexchangebuyer_v1_3 {
      * The account id
      */
     id?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
 
@@ -1389,10 +1391,11 @@ export namespace adexchangebuyer_v1_3 {
      * The billing id associated with the budget being updated.
      */
     billingId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Budget;
+    requestBody?: Schema$Budget;
   }
   export interface Params$Resource$Budget$Update {
     /**
@@ -1408,10 +1411,11 @@ export namespace adexchangebuyer_v1_3 {
      * The billing id associated with the budget being updated.
      */
     billingId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Budget;
+    requestBody?: Schema$Budget;
   }
 
 
@@ -1646,6 +1650,12 @@ export namespace adexchangebuyer_v1_3 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Creatives$List {
     /**
@@ -2421,10 +2431,11 @@ export namespace adexchangebuyer_v1_3 {
      * The account id to insert the pretargeting config for.
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PretargetingConfig;
+    requestBody?: Schema$PretargetingConfig;
   }
   export interface Params$Resource$Pretargetingconfig$List {
     /**
@@ -2451,10 +2462,11 @@ export namespace adexchangebuyer_v1_3 {
      * The specific id of the configuration to update.
      */
     configId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PretargetingConfig;
+    requestBody?: Schema$PretargetingConfig;
   }
   export interface Params$Resource$Pretargetingconfig$Update {
     /**
@@ -2470,9 +2482,10 @@ export namespace adexchangebuyer_v1_3 {
      * The specific id of the configuration to update.
      */
     configId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PretargetingConfig;
+    requestBody?: Schema$PretargetingConfig;
   }
 }

--- a/src/apis/adexchangebuyer/v1.4.ts
+++ b/src/apis/adexchangebuyer/v1.4.ts
@@ -2053,10 +2053,11 @@ export namespace adexchangebuyer_v1_4 {
      * The account id
      */
     id?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
   export interface Params$Resource$Accounts$Update {
     /**
@@ -2072,10 +2073,11 @@ export namespace adexchangebuyer_v1_4 {
      * The account id
      */
     id?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
 
@@ -2480,10 +2482,11 @@ export namespace adexchangebuyer_v1_4 {
      * The billing id associated with the budget being updated.
      */
     billingId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Budget;
+    requestBody?: Schema$Budget;
   }
   export interface Params$Resource$Budget$Update {
     /**
@@ -2499,10 +2502,11 @@ export namespace adexchangebuyer_v1_4 {
      * The billing id associated with the budget being updated.
      */
     billingId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Budget;
+    requestBody?: Schema$Budget;
   }
 
 
@@ -2965,6 +2969,12 @@ export namespace adexchangebuyer_v1_4 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Creatives$List {
     /**
@@ -3345,10 +3355,11 @@ export namespace adexchangebuyer_v1_4 {
      * The proposalId to delete deals from.
      */
     proposalId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeleteOrderDealsRequest;
+    requestBody?: Schema$DeleteOrderDealsRequest;
   }
   export interface Params$Resource$Marketplacedeals$Insert {
     /**
@@ -3360,10 +3371,11 @@ export namespace adexchangebuyer_v1_4 {
      * proposalId for which deals need to be added.
      */
     proposalId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AddOrderDealsRequest;
+    requestBody?: Schema$AddOrderDealsRequest;
   }
   export interface Params$Resource$Marketplacedeals$List {
     /**
@@ -3391,10 +3403,11 @@ export namespace adexchangebuyer_v1_4 {
      * The proposalId to edit deals on.
      */
     proposalId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EditAllOrderDealsRequest;
+    requestBody?: Schema$EditAllOrderDealsRequest;
   }
 
 
@@ -3560,10 +3573,11 @@ export namespace adexchangebuyer_v1_4 {
      * The proposalId to add notes for.
      */
     proposalId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AddOrderNotesRequest;
+    requestBody?: Schema$AddOrderNotesRequest;
   }
   export interface Params$Resource$Marketplacenotes$List {
     /**
@@ -3676,10 +3690,11 @@ export namespace adexchangebuyer_v1_4 {
      * The private auction id to be updated.
      */
     privateAuctionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdatePrivateAuctionProposalRequest;
+    requestBody?: Schema$UpdatePrivateAuctionProposalRequest;
   }
 
 
@@ -4267,10 +4282,11 @@ export namespace adexchangebuyer_v1_4 {
      * The account id to insert the pretargeting config for.
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PretargetingConfig;
+    requestBody?: Schema$PretargetingConfig;
   }
   export interface Params$Resource$Pretargetingconfig$List {
     /**
@@ -4297,10 +4313,11 @@ export namespace adexchangebuyer_v1_4 {
      * The specific id of the configuration to update.
      */
     configId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PretargetingConfig;
+    requestBody?: Schema$PretargetingConfig;
   }
   export interface Params$Resource$Pretargetingconfig$Update {
     /**
@@ -4316,10 +4333,11 @@ export namespace adexchangebuyer_v1_4 {
      * The specific id of the configuration to update.
      */
     configId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PretargetingConfig;
+    requestBody?: Schema$PretargetingConfig;
   }
 
 
@@ -4911,6 +4929,12 @@ export namespace adexchangebuyer_v1_4 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$CreateOrdersRequest;
   }
   export interface Params$Resource$Proposals$Patch {
     /**
@@ -4934,10 +4958,11 @@ export namespace adexchangebuyer_v1_4 {
      * it must be set when updating a proposal.
      */
     updateAction?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Proposal;
+    requestBody?: Schema$Proposal;
   }
   export interface Params$Resource$Proposals$Search {
     /**
@@ -4983,10 +5008,11 @@ export namespace adexchangebuyer_v1_4 {
      * it must be set when updating a proposal.
      */
     updateAction?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Proposal;
+    requestBody?: Schema$Proposal;
   }
 
 

--- a/src/apis/adexchangebuyer2/v2beta1.ts
+++ b/src/apis/adexchangebuyer2/v2beta1.ts
@@ -1015,16 +1015,6 @@ export namespace adexchangebuyer2_v2beta1 {
     nonBillableWinningBidStatusRows?: Schema$NonBillableWinningBidStatusRow[];
   }
   /**
-   * Response message for listing publishers that had recent inventory matches
-   * with the requesting buyer.
-   */
-  export interface Schema$ListPublishersResponse {
-    /**
-     * List of publishers.
-     */
-    publisher?: Schema$Publisher[];
-  }
-  /**
    * @OutputOnly The Geo criteria the restriction applies to.
    */
   export interface Schema$LocationContext {
@@ -1138,26 +1128,6 @@ export namespace adexchangebuyer2_v2beta1 {
      * The platforms this restriction applies to.
      */
     platforms?: string[];
-  }
-  /**
-   * The publisher ID and name contain values relevant to the requesting buyer
-   * depending on whether it is an Ad Exchange buyer or Exchange Bidding buyer.
-   */
-  export interface Schema$Publisher {
-    /**
-     * Publisher name contains: - Seller network name when the requesting buyer
-     * is an Ad Exchange buyer. - DFP network name or AdMob publisher code when
-     * the requesting buyer is an   Exchange Bidding buyer.
-     */
-    publisherDisplayName?: string;
-    /**
-     * Publisher ID contains: - Seller network ID when the requesting buyer is
-     * an Ad Exchange buyer.   See
-     * [seller-network-ids](https://developers.google.com/ad-exchange/rtb/downloads/seller-network-ids)
-     * - DFP network code or AdMob publisher code when the requesting buyer is
-     * an   Exchange Bidding buyer.
-     */
-    publisherId?: string;
   }
   /**
    * An open-ended realtime time range specified by the start timestamp. For
@@ -1336,13 +1306,11 @@ export namespace adexchangebuyer2_v2beta1 {
     root: Adexchangebuyer2;
     clients: Resource$Accounts$Clients;
     creatives: Resource$Accounts$Creatives;
-    publishers: Resource$Accounts$Publishers;
     constructor(root: Adexchangebuyer2) {
       this.root = root;
       this.getRoot.bind(this);
       this.clients = new Resource$Accounts$Clients(root);
       this.creatives = new Resource$Accounts$Creatives(root);
-      this.publishers = new Resource$Accounts$Publishers(root);
     }
 
     getRoot() {
@@ -1652,10 +1620,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * customer; the sponsor buyer to create a client for. (required)
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Client;
+    requestBody?: Schema$Client;
   }
   export interface Params$Resource$Accounts$Clients$Get {
     /**
@@ -1715,10 +1684,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * Unique numerical account ID of the client to update. (required)
      */
     clientAccountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Client;
+    requestBody?: Schema$Client;
   }
 
   export class Resource$Accounts$Clients$Invitations {
@@ -1976,10 +1946,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * associated with. (required)
      */
     clientAccountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ClientUserInvitation;
+    requestBody?: Schema$ClientUserInvitation;
   }
   export interface Params$Resource$Accounts$Clients$Invitations$Get {
     /**
@@ -2332,10 +2303,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * Numerical identifier of the user to retrieve. (required)
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ClientUser;
+    requestBody?: Schema$ClientUser;
   }
 
 
@@ -2791,10 +2763,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * NO_DUPLICATES (one ID per creative).
      */
     duplicateIdMode?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Accounts$Creatives$Get {
     /**
@@ -2864,10 +2837,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * specify stopping account level notifications.
      */
     creativeId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StopWatchingCreativeRequest;
+    requestBody?: Schema$StopWatchingCreativeRequest;
   }
   export interface Params$Resource$Accounts$Creatives$Update {
     /**
@@ -2885,10 +2859,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * response of the creatives.list method.
      */
     creativeId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Accounts$Creatives$Watch {
     /**
@@ -2907,10 +2882,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * sent to the creative-level notification topic.
      */
     creativeId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WatchCreativeRequest;
+    requestBody?: Schema$WatchCreativeRequest;
   }
 
   export class Resource$Accounts$Creatives$Dealassociations {
@@ -3162,10 +3138,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * The ID of the creative associated with the deal.
      */
     creativeId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AddDealAssociationRequest;
+    requestBody?: Schema$AddDealAssociationRequest;
   }
   export interface Params$Resource$Accounts$Creatives$Dealassociations$List {
     /**
@@ -3221,113 +3198,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * The ID of the creative associated with the deal.
      */
     creativeId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemoveDealAssociationRequest;
-  }
-
-
-
-  export class Resource$Accounts$Publishers {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
-
-
-    /**
-     * adexchangebuyer2.accounts.publishers.list
-     * @desc Lists publishers that had recent inventory matches with the
-     * requesting buyer.
-     * @alias adexchangebuyer2.accounts.publishers.list
-     * @memberOf! ()
-     *
-     * @param {object} params Parameters for request
-     * @param {string} params.accountId Account ID of the requesting buyer.
-     * @param {string=} params.environment Optional environment (WEB, APP) for which to return publishers. If specified, response will only include publishers that had recent inventory matches with the requesting buyer on the specified platform.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    list(
-        params?: Params$Resource$Accounts$Publishers$List,
-        options?: MethodOptions): AxiosPromise<Schema$ListPublishersResponse>;
-    list(
-        params: Params$Resource$Accounts$Publishers$List,
-        options: MethodOptions|
-        BodyResponseCallback<Schema$ListPublishersResponse>,
-        callback: BodyResponseCallback<Schema$ListPublishersResponse>): void;
-    list(
-        params: Params$Resource$Accounts$Publishers$List,
-        callback: BodyResponseCallback<Schema$ListPublishersResponse>): void;
-    list(callback: BodyResponseCallback<Schema$ListPublishersResponse>): void;
-    list(
-        paramsOrCallback?: Params$Resource$Accounts$Publishers$List|
-        BodyResponseCallback<Schema$ListPublishersResponse>,
-        optionsOrCallback?: MethodOptions|
-        BodyResponseCallback<Schema$ListPublishersResponse>,
-        callback?: BodyResponseCallback<Schema$ListPublishersResponse>):
-        void|AxiosPromise<Schema$ListPublishersResponse> {
-      let params =
-          (paramsOrCallback || {}) as Params$Resource$Accounts$Publishers$List;
-      let options = (optionsOrCallback || {}) as MethodOptions;
-
-      if (typeof paramsOrCallback === 'function') {
-        callback = paramsOrCallback;
-        params = {} as Params$Resource$Accounts$Publishers$List;
-        options = {};
-      }
-
-      if (typeof optionsOrCallback === 'function') {
-        callback = optionsOrCallback;
-        options = {};
-      }
-
-      const rootUrl =
-          options.rootUrl || 'https://adexchangebuyer.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-            {
-              url: (rootUrl + '/v2beta1/accounts/{accountId}/publishers')
-                       .replace(/([^:]\/)\/+/g, '$1'),
-              method: 'GET'
-            },
-            options),
-        params,
-        requiredParams: ['accountId'],
-        pathParams: ['accountId'],
-        context: this.getRoot()
-      };
-      if (callback) {
-        createAPIRequest<Schema$ListPublishersResponse>(parameters, callback);
-      } else {
-        return createAPIRequest<Schema$ListPublishersResponse>(parameters);
-      }
-    }
-  }
-
-  export interface Params$Resource$Accounts$Publishers$List {
-    /**
-     * Auth client or API Key for the request
-     */
-    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
-
-    /**
-     * Account ID of the requesting buyer.
-     */
-    accountId?: string;
-    /**
-     * Optional environment (WEB, APP) for which to return publishers. If
-     * specified, response will only include publishers that had recent
-     * inventory matches with the requesting buyer on the specified platform.
-     */
-    environment?: string;
+    requestBody?: Schema$RemoveDealAssociationRequest;
   }
 
 
@@ -3698,10 +3573,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * bidder is 123: `bidders/123/accounts/456`
      */
     ownerName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FilterSet;
+    requestBody?: Schema$FilterSet;
   }
   export interface Params$Resource$Bidders$Accounts$Filtersets$Delete {
     /**
@@ -5371,10 +5247,11 @@ export namespace adexchangebuyer2_v2beta1 {
      * bidder is 123: `bidders/123/accounts/456`
      */
     ownerName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FilterSet;
+    requestBody?: Schema$FilterSet;
   }
   export interface Params$Resource$Bidders$Filtersets$Delete {
     /**

--- a/src/apis/admin/datatransfer_v1.ts
+++ b/src/apis/admin/datatransfer_v1.ts
@@ -623,6 +623,12 @@ export namespace admin_datatransfer_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$DataTransfer;
   }
   export interface Params$Resource$Transfers$List {
     /**

--- a/src/apis/admin/directory_v1.ts
+++ b/src/apis/admin/directory_v1.ts
@@ -36,9 +36,8 @@ export namespace admin_directory_v1 {
   /**
    * Admin Directory API
    *
-   * The Admin SDK Directory API lets you view and manage enterprise resources
-   * such as users and groups, administrative notifications, security features,
-   * and more.
+   * Manages enterprise resources such as users and groups, administrative
+   * notifications, security features, and more.
    *
    * @example
    * const google = require('googleapis');
@@ -1476,6 +1475,10 @@ export namespace admin_directory_v1 {
    */
   export interface Schema$Schema {
     /**
+     * Display name for the schema.
+     */
+    displayName?: string;
+    /**
      * ETag of the resource.
      */
     etag?: string;
@@ -1500,6 +1503,10 @@ export namespace admin_directory_v1 {
    * JSON template for FieldSpec resource for Schemas in Directory API.
    */
   export interface Schema$SchemaFieldSpec {
+    /**
+     * Display Name of the field.
+     */
+    displayName?: string;
     /**
      * ETag of the resource.
      */
@@ -2207,6 +2214,10 @@ export namespace admin_directory_v1 {
      */
     homeDirectory?: string;
     /**
+     * The operating system type for this account.
+     */
+    operatingSystemType?: string;
+    /**
      * If this is user&#39;s primary account within the SystemId.
      */
     primary?: boolean;
@@ -2696,6 +2707,12 @@ export namespace admin_directory_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Channel;
   }
 
 
@@ -3150,10 +3167,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of Chrome OS Device
      */
     resourceId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChromeOsDeviceAction;
+    requestBody?: Schema$ChromeOsDeviceAction;
   }
   export interface Params$Resource$Chromeosdevices$Get {
     /**
@@ -3229,10 +3247,11 @@ export namespace admin_directory_v1 {
      * Full path of the target organizational unit or its ID
      */
     orgUnitPath?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChromeOsMoveDevicesToOu;
+    requestBody?: Schema$ChromeOsMoveDevicesToOu;
   }
   export interface Params$Resource$Chromeosdevices$Patch {
     /**
@@ -3252,10 +3271,11 @@ export namespace admin_directory_v1 {
      * Restrict information returned to a set of selected fields.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChromeOsDevice;
+    requestBody?: Schema$ChromeOsDevice;
   }
   export interface Params$Resource$Chromeosdevices$Update {
     /**
@@ -3275,10 +3295,11 @@ export namespace admin_directory_v1 {
      * Restrict information returned to a set of selected fields.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChromeOsDevice;
+    requestBody?: Schema$ChromeOsDevice;
   }
 
 
@@ -3506,10 +3527,11 @@ export namespace admin_directory_v1 {
      * Id of the customer to be updated
      */
     customerKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Customer;
+    requestBody?: Schema$Customer;
   }
   export interface Params$Resource$Customers$Update {
     /**
@@ -3521,10 +3543,11 @@ export namespace admin_directory_v1 {
      * Id of the customer to be updated
      */
     customerKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Customer;
+    requestBody?: Schema$Customer;
   }
 
 
@@ -3851,10 +3874,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the G Suite account.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DomainAlias;
+    requestBody?: Schema$DomainAlias;
   }
   export interface Params$Resource$Domainaliases$List {
     /**
@@ -4184,10 +4208,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the G Suite account.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Domains;
+    requestBody?: Schema$Domains;
   }
   export interface Params$Resource$Domains$List {
     /**
@@ -4406,7 +4431,8 @@ export namespace admin_directory_v1 {
 
     /**
      * directory.groups.list
-     * @desc Retrieve all groups in a domain (paginated)
+     * @desc Retrieve all groups of a domain or of a user given a userKey
+     * (paginated)
      * @alias directory.groups.list
      * @memberOf! ()
      *
@@ -4414,8 +4440,11 @@ export namespace admin_directory_v1 {
      * @param {string=} params.customer Immutable ID of the G Suite account. In case of multi-domain, to fetch all groups for a customer, fill this field instead of domain.
      * @param {string=} params.domain Name of the domain. Fill this field to get groups from only this domain. To return all groups in a multi-domain fill customer field instead.
      * @param {integer=} params.maxResults Maximum number of results to return. Default is 200
+     * @param {string=} params.orderBy Column to use for sorting results
      * @param {string=} params.pageToken Token to specify next page in the list
-     * @param {string=} params.userKey Email or immutable ID of the user if only those groups are to be listed, the given user is a member of. If ID, it should match with id of user object
+     * @param {string=} params.query Query string search. Should be of the form "". Complete documentation is at https://developers.google.com/admin-sdk/directory/v1/guides/search-users
+     * @param {string=} params.sortOrder Whether to return results in ascending or descending order. Only of use when orderBy is also used
+     * @param {string=} params.userKey Email or immutable Id of the user if only those groups are to be listed, the given user is a member of. If Id, it should match with id of user object
      * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
      * @param {callback} callback The callback that handles the response.
      * @return {object} Request object
@@ -4629,6 +4658,12 @@ export namespace admin_directory_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Group;
   }
   export interface Params$Resource$Groups$List {
     /**
@@ -4651,12 +4686,27 @@ export namespace admin_directory_v1 {
      */
     maxResults?: number;
     /**
+     * Column to use for sorting results
+     */
+    orderBy?: string;
+    /**
      * Token to specify next page in the list
      */
     pageToken?: string;
     /**
-     * Email or immutable ID of the user if only those groups are to be listed,
-     * the given user is a member of. If ID, it should match with id of user
+     * Query string search. Should be of the form "". Complete documentation is
+     * at
+     * https://developers.google.com/admin-sdk/directory/v1/guides/search-users
+     */
+    query?: string;
+    /**
+     * Whether to return results in ascending or descending order. Only of use
+     * when orderBy is also used
+     */
+    sortOrder?: string;
+    /**
+     * Email or immutable Id of the user if only those groups are to be listed,
+     * the given user is a member of. If Id, it should match with id of user
      * object
      */
     userKey?: string;
@@ -4672,10 +4722,11 @@ export namespace admin_directory_v1 {
      * group object
      */
     groupKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
   export interface Params$Resource$Groups$Update {
     /**
@@ -4688,10 +4739,11 @@ export namespace admin_directory_v1 {
      * group object
      */
     groupKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
 
   export class Resource$Groups$Aliases {
@@ -4930,10 +4982,11 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the group
      */
     groupKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Alias;
+    requestBody?: Schema$Alias;
   }
   export interface Params$Resource$Groups$Aliases$List {
     /**
@@ -5233,6 +5286,7 @@ export namespace admin_directory_v1 {
      *
      * @param {object} params Parameters for request
      * @param {string} params.groupKey Email or immutable ID of the group
+     * @param {boolean=} params.includeDerivedMembership Whether to list indirect memberships. Default: false.
      * @param {integer=} params.maxResults Maximum number of results to return. Default is 200
      * @param {string=} params.pageToken Token to specify next page in the list
      * @param {string=} params.roles Comma separated role values to filter list results on.
@@ -5484,10 +5538,11 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the group
      */
     groupKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Member;
+    requestBody?: Schema$Member;
   }
   export interface Params$Resource$Members$List {
     /**
@@ -5499,6 +5554,10 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the group
      */
     groupKey?: string;
+    /**
+     * Whether to list indirect memberships. Default: false.
+     */
+    includeDerivedMembership?: boolean;
     /**
      * Maximum number of results to return. Default is 200
      */
@@ -5528,10 +5587,11 @@ export namespace admin_directory_v1 {
      * member object
      */
     memberKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Member;
+    requestBody?: Schema$Member;
   }
   export interface Params$Resource$Members$Update {
     /**
@@ -5549,10 +5609,11 @@ export namespace admin_directory_v1 {
      * member object
      */
     memberKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Member;
+    requestBody?: Schema$Member;
   }
 
 
@@ -5859,10 +5920,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of Mobile Device
      */
     resourceId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$MobileDeviceAction;
+    requestBody?: Schema$MobileDeviceAction;
   }
   export interface Params$Resource$Mobiledevices$Delete {
     /**
@@ -6365,10 +6427,11 @@ export namespace admin_directory_v1 {
      * The unique ID of the notification.
      */
     notificationId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Notification;
+    requestBody?: Schema$Notification;
   }
   export interface Params$Resource$Notifications$Update {
     /**
@@ -6384,10 +6447,11 @@ export namespace admin_directory_v1 {
      * The unique ID of the notification.
      */
     notificationId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Notification;
+    requestBody?: Schema$Notification;
   }
 
 
@@ -6842,10 +6906,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the G Suite account
      */
     customerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrgUnit;
+    requestBody?: Schema$OrgUnit;
   }
   export interface Params$Resource$Orgunits$List {
     /**
@@ -6880,10 +6945,11 @@ export namespace admin_directory_v1 {
      * Full path of the organizational unit or its ID
      */
     orgUnitPath?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrgUnit;
+    requestBody?: Schema$OrgUnit;
   }
   export interface Params$Resource$Orgunits$Update {
     /**
@@ -6899,10 +6965,11 @@ export namespace admin_directory_v1 {
      * Full path of the organizational unit or its ID
      */
     orgUnitPath?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrgUnit;
+    requestBody?: Schema$OrgUnit;
   }
 
 
@@ -7652,10 +7719,11 @@ export namespace admin_directory_v1 {
      * account's customer ID.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Building;
+    requestBody?: Schema$Building;
   }
   export interface Params$Resource$Resources$Buildings$List {
     /**
@@ -7694,10 +7762,11 @@ export namespace admin_directory_v1 {
      * account's customer ID.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Building;
+    requestBody?: Schema$Building;
   }
   export interface Params$Resource$Resources$Buildings$Update {
     /**
@@ -7715,10 +7784,11 @@ export namespace admin_directory_v1 {
      * account's customer ID.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Building;
+    requestBody?: Schema$Building;
   }
 
 
@@ -8204,10 +8274,11 @@ export namespace admin_directory_v1 {
      * account's customer ID.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CalendarResource;
+    requestBody?: Schema$CalendarResource;
   }
   export interface Params$Resource$Resources$Calendars$List {
     /**
@@ -8266,10 +8337,11 @@ export namespace admin_directory_v1 {
      * account's customer ID.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CalendarResource;
+    requestBody?: Schema$CalendarResource;
   }
   export interface Params$Resource$Resources$Calendars$Update {
     /**
@@ -8287,10 +8359,11 @@ export namespace admin_directory_v1 {
      * account's customer ID.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CalendarResource;
+    requestBody?: Schema$CalendarResource;
   }
 
 
@@ -8833,10 +8906,11 @@ export namespace admin_directory_v1 {
      * account's customer ID.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Feature;
+    requestBody?: Schema$Feature;
   }
   export interface Params$Resource$Resources$Features$List {
     /**
@@ -8875,10 +8949,11 @@ export namespace admin_directory_v1 {
      * The unique ID of the feature to update.
      */
     featureKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Feature;
+    requestBody?: Schema$Feature;
   }
   export interface Params$Resource$Resources$Features$Rename {
     /**
@@ -8896,10 +8971,11 @@ export namespace admin_directory_v1 {
      * The unique ID of the feature to rename.
      */
     oldName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FeatureRename;
+    requestBody?: Schema$FeatureRename;
   }
   export interface Params$Resource$Resources$Features$Update {
     /**
@@ -8917,10 +8993,11 @@ export namespace admin_directory_v1 {
      * The unique ID of the feature to update.
      */
     featureKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Feature;
+    requestBody?: Schema$Feature;
   }
 
 
@@ -9252,10 +9329,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the G Suite account.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RoleAssignment;
+    requestBody?: Schema$RoleAssignment;
   }
   export interface Params$Resource$Roleassignments$List {
     /**
@@ -9733,10 +9811,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the G Suite account.
      */
     customer?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Role;
+    requestBody?: Schema$Role;
   }
   export interface Params$Resource$Roles$List {
     /**
@@ -9771,10 +9850,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the role.
      */
     roleId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Role;
+    requestBody?: Schema$Role;
   }
   export interface Params$Resource$Roles$Update {
     /**
@@ -9790,10 +9870,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the role.
      */
     roleId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Role;
+    requestBody?: Schema$Role;
   }
 
 
@@ -10246,10 +10327,11 @@ export namespace admin_directory_v1 {
      * Immutable ID of the G Suite account
      */
     customerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Schema;
+    requestBody?: Schema$Schema;
   }
   export interface Params$Resource$Schemas$List {
     /**
@@ -10276,10 +10358,11 @@ export namespace admin_directory_v1 {
      * Name or immutable ID of the schema.
      */
     schemaKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Schema;
+    requestBody?: Schema$Schema;
   }
   export interface Params$Resource$Schemas$Update {
     /**
@@ -10295,10 +10378,11 @@ export namespace admin_directory_v1 {
      * Name or immutable ID of the schema.
      */
     schemaKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Schema;
+    requestBody?: Schema$Schema;
   }
 
 
@@ -11210,6 +11294,12 @@ export namespace admin_directory_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$User;
   }
   export interface Params$Resource$Users$List {
     /**
@@ -11281,10 +11371,11 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the user as admin
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserMakeAdmin;
+    requestBody?: Schema$UserMakeAdmin;
   }
   export interface Params$Resource$Users$Patch {
     /**
@@ -11297,10 +11388,11 @@ export namespace admin_directory_v1 {
      * object
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$User;
+    requestBody?: Schema$User;
   }
   export interface Params$Resource$Users$Undelete {
     /**
@@ -11312,10 +11404,11 @@ export namespace admin_directory_v1 {
      * The immutable id of the user
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserUndelete;
+    requestBody?: Schema$UserUndelete;
   }
   export interface Params$Resource$Users$Update {
     /**
@@ -11328,10 +11421,11 @@ export namespace admin_directory_v1 {
      * object
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$User;
+    requestBody?: Schema$User;
   }
   export interface Params$Resource$Users$Watch {
     /**
@@ -11392,10 +11486,11 @@ export namespace admin_directory_v1 {
      * Whether to fetch the ADMIN_VIEW or DOMAIN_PUBLIC view of the user.
      */
     viewType?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
   export class Resource$Users$Aliases {
@@ -11704,10 +11799,11 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the user
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Alias;
+    requestBody?: Schema$Alias;
   }
   export interface Params$Resource$Users$Aliases$List {
     /**
@@ -11738,10 +11834,11 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the user
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -12055,10 +12152,11 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the user
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserPhoto;
+    requestBody?: Schema$UserPhoto;
   }
   export interface Params$Resource$Users$Photos$Update {
     /**
@@ -12070,10 +12168,11 @@ export namespace admin_directory_v1 {
      * Email or immutable ID of the user
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserPhoto;
+    requestBody?: Schema$UserPhoto;
   }
 
 

--- a/src/apis/admin/reports_v1.ts
+++ b/src/apis/admin/reports_v1.ts
@@ -498,10 +498,11 @@ export namespace admin_reports_v1 {
      * for all users.
      */
     userKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -586,6 +587,12 @@ export namespace admin_reports_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Channel;
   }
 
 

--- a/src/apis/adsensehost/v4.1.ts
+++ b/src/apis/adsensehost/v4.1.ts
@@ -1342,10 +1342,11 @@ export namespace adsensehost_v4_1 {
      * Ad client into which to insert the ad unit.
      */
     adClientId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdUnit;
+    requestBody?: Schema$AdUnit;
   }
   export interface Params$Resource$Accounts$Adunits$List {
     /**
@@ -1395,10 +1396,11 @@ export namespace adsensehost_v4_1 {
      * Ad unit to get.
      */
     adUnitId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdUnit;
+    requestBody?: Schema$AdUnit;
   }
   export interface Params$Resource$Accounts$Adunits$Update {
     /**
@@ -1414,10 +1416,11 @@ export namespace adsensehost_v4_1 {
      * Ad client which contains the ad unit.
      */
     adClientId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdUnit;
+    requestBody?: Schema$AdUnit;
   }
 
 
@@ -2387,10 +2390,11 @@ export namespace adsensehost_v4_1 {
      * Ad client to which the new custom channel will be added.
      */
     adClientId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomChannel;
+    requestBody?: Schema$CustomChannel;
   }
   export interface Params$Resource$Customchannels$List {
     /**
@@ -2428,10 +2432,11 @@ export namespace adsensehost_v4_1 {
      * Custom channel to get.
      */
     customChannelId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomChannel;
+    requestBody?: Schema$CustomChannel;
   }
   export interface Params$Resource$Customchannels$Update {
     /**
@@ -2443,10 +2448,11 @@ export namespace adsensehost_v4_1 {
      * Ad client in which the custom channel will be updated.
      */
     adClientId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomChannel;
+    requestBody?: Schema$CustomChannel;
   }
 
 
@@ -2829,10 +2835,11 @@ export namespace adsensehost_v4_1 {
      * Ad client to which the new URL channel will be added.
      */
     adClientId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlChannel;
+    requestBody?: Schema$UrlChannel;
   }
   export interface Params$Resource$Urlchannels$List {
     /**

--- a/src/apis/analytics/v3.ts
+++ b/src/apis/analytics/v3.ts
@@ -3597,10 +3597,11 @@ export namespace analytics_v3 {
      * Account ID to create the user link for.
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityUserLink;
+    requestBody?: Schema$EntityUserLink;
   }
   export interface Params$Resource$Management$Accountuserlinks$List {
     /**
@@ -3636,10 +3637,11 @@ export namespace analytics_v3 {
      * Link ID to update the account-user link for.
      */
     linkId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityUserLink;
+    requestBody?: Schema$EntityUserLink;
   }
 
 
@@ -4155,10 +4157,11 @@ export namespace analytics_v3 {
      * Web property ID for the custom dimension to create.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomDimension;
+    requestBody?: Schema$CustomDimension;
   }
   export interface Params$Resource$Management$Customdimensions$List {
     /**
@@ -4207,10 +4210,11 @@ export namespace analytics_v3 {
      * Web property ID for the custom dimension to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomDimension;
+    requestBody?: Schema$CustomDimension;
   }
   export interface Params$Resource$Management$Customdimensions$Update {
     /**
@@ -4235,10 +4239,11 @@ export namespace analytics_v3 {
      * Web property ID for the custom dimension to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomDimension;
+    requestBody?: Schema$CustomDimension;
   }
 
 
@@ -4644,10 +4649,11 @@ export namespace analytics_v3 {
      * Web property ID for the custom dimension to create.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomMetric;
+    requestBody?: Schema$CustomMetric;
   }
   export interface Params$Resource$Management$Custommetrics$List {
     /**
@@ -4696,10 +4702,11 @@ export namespace analytics_v3 {
      * Web property ID for the custom metric to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomMetric;
+    requestBody?: Schema$CustomMetric;
   }
   export interface Params$Resource$Management$Custommetrics$Update {
     /**
@@ -4724,10 +4731,11 @@ export namespace analytics_v3 {
      * Web property ID for the custom metric to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomMetric;
+    requestBody?: Schema$CustomMetric;
   }
 
 
@@ -5241,10 +5249,11 @@ export namespace analytics_v3 {
      * Web property ID to create the experiment for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Experiment;
+    requestBody?: Schema$Experiment;
   }
   export interface Params$Resource$Management$Experiments$List {
     /**
@@ -5296,10 +5305,11 @@ export namespace analytics_v3 {
      * Web property ID of the experiment to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Experiment;
+    requestBody?: Schema$Experiment;
   }
   export interface Params$Resource$Management$Experiments$Update {
     /**
@@ -5323,10 +5333,11 @@ export namespace analytics_v3 {
      * Web property ID of the experiment to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Experiment;
+    requestBody?: Schema$Experiment;
   }
 
 
@@ -5793,10 +5804,11 @@ export namespace analytics_v3 {
      * Account ID to create filter for.
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Filter;
+    requestBody?: Schema$Filter;
   }
   export interface Params$Resource$Management$Filters$List {
     /**
@@ -5832,10 +5844,11 @@ export namespace analytics_v3 {
      * ID of the filter to be updated.
      */
     filterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Filter;
+    requestBody?: Schema$Filter;
   }
   export interface Params$Resource$Management$Filters$Update {
     /**
@@ -5851,10 +5864,11 @@ export namespace analytics_v3 {
      * ID of the filter to be updated.
      */
     filterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Filter;
+    requestBody?: Schema$Filter;
   }
 
 
@@ -6265,10 +6279,11 @@ export namespace analytics_v3 {
      * Web property ID to create the goal for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Goal;
+    requestBody?: Schema$Goal;
   }
   export interface Params$Resource$Management$Goals$List {
     /**
@@ -6325,10 +6340,11 @@ export namespace analytics_v3 {
      * Web property ID to update the goal.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Goal;
+    requestBody?: Schema$Goal;
   }
   export interface Params$Resource$Management$Goals$Update {
     /**
@@ -6352,10 +6368,11 @@ export namespace analytics_v3 {
      * Web property ID to update the goal.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Goal;
+    requestBody?: Schema$Goal;
   }
 
 
@@ -6865,10 +6882,11 @@ export namespace analytics_v3 {
      * Web property Id to create profile filter link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProfileFilterLink;
+    requestBody?: Schema$ProfileFilterLink;
   }
   export interface Params$Resource$Management$Profilefilterlinks$List {
     /**
@@ -6923,10 +6941,11 @@ export namespace analytics_v3 {
      * Web property Id to which profile filter link belongs
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProfileFilterLink;
+    requestBody?: Schema$ProfileFilterLink;
   }
   export interface Params$Resource$Management$Profilefilterlinks$Update {
     /**
@@ -6950,10 +6969,11 @@ export namespace analytics_v3 {
      * Web property Id to which profile filter link belongs
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProfileFilterLink;
+    requestBody?: Schema$ProfileFilterLink;
   }
 
 
@@ -7440,10 +7460,11 @@ export namespace analytics_v3 {
      * Web property ID to create the view (profile) for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Profile;
+    requestBody?: Schema$Profile;
   }
   export interface Params$Resource$Management$Profiles$List {
     /**
@@ -7491,10 +7512,11 @@ export namespace analytics_v3 {
      * Web property ID to which the view (profile) belongs
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Profile;
+    requestBody?: Schema$Profile;
   }
   export interface Params$Resource$Management$Profiles$Update {
     /**
@@ -7514,10 +7536,11 @@ export namespace analytics_v3 {
      * Web property ID to which the view (profile) belongs
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Profile;
+    requestBody?: Schema$Profile;
   }
 
 
@@ -7863,10 +7886,11 @@ export namespace analytics_v3 {
      * Web Property ID to create the user link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityUserLink;
+    requestBody?: Schema$EntityUserLink;
   }
   export interface Params$Resource$Management$Profileuserlinks$List {
     /**
@@ -7922,10 +7946,11 @@ export namespace analytics_v3 {
      * Web Property ID to update the user link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityUserLink;
+    requestBody?: Schema$EntityUserLink;
   }
 
 
@@ -8422,10 +8447,11 @@ export namespace analytics_v3 {
      * Web property ID for which to create the remarketing audience.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingAudience;
+    requestBody?: Schema$RemarketingAudience;
   }
   export interface Params$Resource$Management$Remarketingaudience$List {
     /**
@@ -8473,10 +8499,11 @@ export namespace analytics_v3 {
      * The web property ID of the remarketing audience to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingAudience;
+    requestBody?: Schema$RemarketingAudience;
   }
   export interface Params$Resource$Management$Remarketingaudience$Update {
     /**
@@ -8496,10 +8523,11 @@ export namespace analytics_v3 {
      * The web property ID of the remarketing audience to update.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingAudience;
+    requestBody?: Schema$RemarketingAudience;
   }
 
 
@@ -8963,10 +8991,11 @@ export namespace analytics_v3 {
      * Web property ID to create the unsampled report for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UnsampledReport;
+    requestBody?: Schema$UnsampledReport;
   }
   export interface Params$Resource$Management$Unsampledreports$List {
     /**
@@ -9319,10 +9348,11 @@ export namespace analytics_v3 {
      * Web property Id for the uploads to be deleted.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyticsDataimportDeleteUploadDataRequest;
+    requestBody?: Schema$AnalyticsDataimportDeleteUploadDataRequest;
   }
   export interface Params$Resource$Management$Uploads$Get {
     /**
@@ -9393,10 +9423,12 @@ export namespace analytics_v3 {
      * Web property UA-string associated with the upload.
      */
     webPropertyId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -9405,7 +9437,7 @@ export namespace analytics_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -9799,10 +9831,11 @@ export namespace analytics_v3 {
      * Account ID to create the web property for.
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Webproperty;
+    requestBody?: Schema$Webproperty;
   }
   export interface Params$Resource$Management$Webproperties$List {
     /**
@@ -9840,10 +9873,11 @@ export namespace analytics_v3 {
      * Web property ID
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Webproperty;
+    requestBody?: Schema$Webproperty;
   }
   export interface Params$Resource$Management$Webproperties$Update {
     /**
@@ -9859,10 +9893,11 @@ export namespace analytics_v3 {
      * Web property ID
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Webproperty;
+    requestBody?: Schema$Webproperty;
   }
 
 
@@ -10367,10 +10402,11 @@ export namespace analytics_v3 {
      * Web property ID to create the link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityAdWordsLink;
+    requestBody?: Schema$EntityAdWordsLink;
   }
   export interface Params$Resource$Management$Webpropertyadwordslinks$List {
     /**
@@ -10415,10 +10451,11 @@ export namespace analytics_v3 {
      * Web property ID to retrieve the AdWords link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityAdWordsLink;
+    requestBody?: Schema$EntityAdWordsLink;
   }
   export interface Params$Resource$Management$Webpropertyadwordslinks$Update {
     /**
@@ -10438,10 +10475,11 @@ export namespace analytics_v3 {
      * Web property ID to retrieve the AdWords link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityAdWordsLink;
+    requestBody?: Schema$EntityAdWordsLink;
   }
 
 
@@ -10777,10 +10815,11 @@ export namespace analytics_v3 {
      * Web Property ID to create the user link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityUserLink;
+    requestBody?: Schema$EntityUserLink;
   }
   export interface Params$Resource$Management$Webpropertyuserlinks$List {
     /**
@@ -10826,10 +10865,11 @@ export namespace analytics_v3 {
      * Web property ID to update the account-user link for.
      */
     webPropertyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EntityUserLink;
+    requestBody?: Schema$EntityUserLink;
   }
 
 
@@ -11095,11 +11135,23 @@ export namespace analytics_v3 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$AccountTicket;
   }
   export interface Params$Resource$Provisioning$Createaccounttree {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$AccountTreeRequest;
   }
 }

--- a/src/apis/analyticsreporting/v4.ts
+++ b/src/apis/analyticsreporting/v4.ts
@@ -1039,9 +1039,10 @@ export namespace analyticsreporting_v4 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetReportsRequest;
+    requestBody?: Schema$GetReportsRequest;
   }
 }

--- a/src/apis/androiddeviceprovisioning/v1.ts
+++ b/src/apis/androiddeviceprovisioning/v1.ts
@@ -1282,10 +1282,11 @@ export namespace androiddeviceprovisioning_v1 {
      * name in the format `customers/[CUSTOMER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Configuration;
+    requestBody?: Schema$Configuration;
   }
   export interface Params$Resource$Customers$Configurations$Delete {
     /**
@@ -1343,10 +1344,11 @@ export namespace androiddeviceprovisioning_v1 {
      * in the Protocol Buffers documentation.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Configuration;
+    requestBody?: Schema$Configuration;
   }
 
 
@@ -1721,10 +1723,11 @@ export namespace androiddeviceprovisioning_v1 {
      * format `customers/[CUSTOMER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomerApplyConfigurationRequest;
+    requestBody?: Schema$CustomerApplyConfigurationRequest;
   }
   export interface Params$Resource$Customers$Devices$Get {
     /**
@@ -1770,10 +1773,11 @@ export namespace androiddeviceprovisioning_v1 {
      * `customers/[CUSTOMER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomerRemoveConfigurationRequest;
+    requestBody?: Schema$CustomerRemoveConfigurationRequest;
   }
   export interface Params$Resource$Customers$Devices$Unclaim {
     /**
@@ -1786,10 +1790,11 @@ export namespace androiddeviceprovisioning_v1 {
      * format `customers/[CUSTOMER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomerUnclaimDeviceRequest;
+    requestBody?: Schema$CustomerUnclaimDeviceRequest;
   }
 
 
@@ -2160,10 +2165,11 @@ export namespace androiddeviceprovisioning_v1 {
      * that identifies the reseller.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateCustomerRequest;
+    requestBody?: Schema$CreateCustomerRequest;
   }
   export interface Params$Resource$Partners$Customers$List {
     /**
@@ -2850,10 +2856,11 @@ export namespace androiddeviceprovisioning_v1 {
      * Required. The ID of the reseller partner.
      */
     partnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ClaimDeviceRequest;
+    requestBody?: Schema$ClaimDeviceRequest;
   }
   export interface Params$Resource$Partners$Devices$Claimasync {
     /**
@@ -2865,10 +2872,11 @@ export namespace androiddeviceprovisioning_v1 {
      * Required. The ID of the reseller partner.
      */
     partnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ClaimDevicesRequest;
+    requestBody?: Schema$ClaimDevicesRequest;
   }
   export interface Params$Resource$Partners$Devices$Findbyidentifier {
     /**
@@ -2880,10 +2888,11 @@ export namespace androiddeviceprovisioning_v1 {
      * Required. The ID of the reseller partner.
      */
     partnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FindDevicesByDeviceIdentifierRequest;
+    requestBody?: Schema$FindDevicesByDeviceIdentifierRequest;
   }
   export interface Params$Resource$Partners$Devices$Findbyowner {
     /**
@@ -2895,10 +2904,11 @@ export namespace androiddeviceprovisioning_v1 {
      * Required. The ID of the reseller partner.
      */
     partnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FindDevicesByOwnerRequest;
+    requestBody?: Schema$FindDevicesByOwnerRequest;
   }
   export interface Params$Resource$Partners$Devices$Get {
     /**
@@ -2927,10 +2937,11 @@ export namespace androiddeviceprovisioning_v1 {
      * ID.
      */
     metadataOwnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateDeviceMetadataRequest;
+    requestBody?: Schema$UpdateDeviceMetadataRequest;
   }
   export interface Params$Resource$Partners$Devices$Unclaim {
     /**
@@ -2942,10 +2953,11 @@ export namespace androiddeviceprovisioning_v1 {
      * Required. The ID of the reseller partner.
      */
     partnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UnclaimDeviceRequest;
+    requestBody?: Schema$UnclaimDeviceRequest;
   }
   export interface Params$Resource$Partners$Devices$Unclaimasync {
     /**
@@ -2957,10 +2969,11 @@ export namespace androiddeviceprovisioning_v1 {
      * Required. The reseller partner ID.
      */
     partnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UnclaimDevicesRequest;
+    requestBody?: Schema$UnclaimDevicesRequest;
   }
   export interface Params$Resource$Partners$Devices$Updatemetadataasync {
     /**
@@ -2972,9 +2985,10 @@ export namespace androiddeviceprovisioning_v1 {
      * Required. The reseller partner ID.
      */
     partnerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateDeviceMetadataInBatchRequest;
+    requestBody?: Schema$UpdateDeviceMetadataInBatchRequest;
   }
 }

--- a/src/apis/androidenterprise/v1.ts
+++ b/src/apis/androidenterprise/v1.ts
@@ -2276,10 +2276,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Device;
+    requestBody?: Schema$Device;
   }
   export interface Params$Resource$Devices$Setstate {
     /**
@@ -2299,10 +2300,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeviceState;
+    requestBody?: Schema$DeviceState;
   }
   export interface Params$Resource$Devices$Update {
     /**
@@ -2328,10 +2330,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Device;
+    requestBody?: Schema$Device;
   }
 
 
@@ -3682,10 +3685,11 @@ export namespace androidenterprise_v1 {
      * The ID of the enterprise.
      */
     enterpriseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdministratorWebTokenSpec;
+    requestBody?: Schema$AdministratorWebTokenSpec;
   }
   export interface Params$Resource$Enterprises$Delete {
     /**
@@ -3708,10 +3712,11 @@ export namespace androidenterprise_v1 {
      * The token provided by the enterprise to register the EMM.
      */
     token?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Enterprise;
+    requestBody?: Schema$Enterprise;
   }
   export interface Params$Resource$Enterprises$Generatesignupurl {
     /**
@@ -3788,10 +3793,11 @@ export namespace androidenterprise_v1 {
      * The token provided by the enterprise to register the EMM.
      */
     token?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Enterprise;
+    requestBody?: Schema$Enterprise;
   }
   export interface Params$Resource$Enterprises$List {
     /**
@@ -3842,10 +3848,11 @@ export namespace androidenterprise_v1 {
      * The ID of the enterprise.
      */
     enterpriseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EnterpriseAccount;
+    requestBody?: Schema$EnterpriseAccount;
   }
   export interface Params$Resource$Enterprises$Setandroiddevicepolicyconfig {
     /**
@@ -3857,10 +3864,11 @@ export namespace androidenterprise_v1 {
      * The ID of the enterprise.
      */
     enterpriseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AndroidDevicePolicyConfig;
+    requestBody?: Schema$AndroidDevicePolicyConfig;
   }
   export interface Params$Resource$Enterprises$Setstorelayout {
     /**
@@ -3872,10 +3880,11 @@ export namespace androidenterprise_v1 {
      * The ID of the enterprise.
      */
     enterpriseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StoreLayout;
+    requestBody?: Schema$StoreLayout;
   }
   export interface Params$Resource$Enterprises$Unenroll {
     /**
@@ -4334,10 +4343,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Entitlement;
+    requestBody?: Schema$Entitlement;
   }
   export interface Params$Resource$Entitlements$Update {
     /**
@@ -4365,10 +4375,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Entitlement;
+    requestBody?: Schema$Entitlement;
   }
 
 
@@ -5112,10 +5123,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Install;
+    requestBody?: Schema$Install;
   }
   export interface Params$Resource$Installs$Update {
     /**
@@ -5140,10 +5152,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Install;
+    requestBody?: Schema$Install;
   }
 
 
@@ -5645,10 +5658,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedConfiguration;
+    requestBody?: Schema$ManagedConfiguration;
   }
   export interface Params$Resource$Managedconfigurationsfordevice$Update {
     /**
@@ -5673,10 +5687,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedConfiguration;
+    requestBody?: Schema$ManagedConfiguration;
   }
 
 
@@ -6144,10 +6159,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedConfiguration;
+    requestBody?: Schema$ManagedConfiguration;
   }
   export interface Params$Resource$Managedconfigurationsforuser$Update {
     /**
@@ -6168,10 +6184,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedConfiguration;
+    requestBody?: Schema$ManagedConfiguration;
   }
 
 
@@ -6921,10 +6938,11 @@ export namespace androidenterprise_v1 {
      * The ID of the product.
      */
     productId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProductsApproveRequest;
+    requestBody?: Schema$ProductsApproveRequest;
   }
   export interface Params$Resource$Products$Generateapprovalurl {
     /**
@@ -7322,10 +7340,11 @@ export namespace androidenterprise_v1 {
      * The ID of the enterprise.
      */
     enterpriseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ServiceAccountKey;
+    requestBody?: Schema$ServiceAccountKey;
   }
   export interface Params$Resource$Serviceaccountkeys$List {
     /**
@@ -7834,10 +7853,11 @@ export namespace androidenterprise_v1 {
      * The ID of the page.
      */
     pageId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StoreCluster;
+    requestBody?: Schema$StoreCluster;
   }
   export interface Params$Resource$Storelayoutclusters$List {
     /**
@@ -7872,10 +7892,11 @@ export namespace androidenterprise_v1 {
      * The ID of the page.
      */
     pageId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StoreCluster;
+    requestBody?: Schema$StoreCluster;
   }
   export interface Params$Resource$Storelayoutclusters$Update {
     /**
@@ -7895,10 +7916,11 @@ export namespace androidenterprise_v1 {
      * The ID of the page.
      */
     pageId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StoreCluster;
+    requestBody?: Schema$StoreCluster;
   }
 
 
@@ -8377,10 +8399,11 @@ export namespace androidenterprise_v1 {
      * The ID of the enterprise.
      */
     enterpriseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StorePage;
+    requestBody?: Schema$StorePage;
   }
   export interface Params$Resource$Storelayoutpages$List {
     /**
@@ -8407,10 +8430,11 @@ export namespace androidenterprise_v1 {
      * The ID of the page.
      */
     pageId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StorePage;
+    requestBody?: Schema$StorePage;
   }
   export interface Params$Resource$Storelayoutpages$Update {
     /**
@@ -8426,10 +8450,11 @@ export namespace androidenterprise_v1 {
      * The ID of the page.
      */
     pageId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StorePage;
+    requestBody?: Schema$StorePage;
   }
 
 
@@ -9375,10 +9400,11 @@ export namespace androidenterprise_v1 {
      * The ID of the enterprise.
      */
     enterpriseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$User;
+    requestBody?: Schema$User;
   }
   export interface Params$Resource$Users$List {
     /**
@@ -9409,10 +9435,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$User;
+    requestBody?: Schema$User;
   }
   export interface Params$Resource$Users$Revokedeviceaccess {
     /**
@@ -9458,10 +9485,11 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProductSet;
+    requestBody?: Schema$ProductSet;
   }
   export interface Params$Resource$Users$Update {
     /**
@@ -9477,9 +9505,10 @@ export namespace androidenterprise_v1 {
      * The ID of the user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$User;
+    requestBody?: Schema$User;
   }
 }

--- a/src/apis/androidmanagement/v1.ts
+++ b/src/apis/androidmanagement/v1.ts
@@ -1918,10 +1918,11 @@ export namespace androidmanagement_v1 {
      * The name of the SignupUrl used to sign up for the enterprise.
      */
     signupUrlName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Enterprise;
+    requestBody?: Schema$Enterprise;
   }
   export interface Params$Resource$Enterprises$Get {
     /**
@@ -1949,10 +1950,11 @@ export namespace androidmanagement_v1 {
      * modifiable fields will be modified.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Enterprise;
+    requestBody?: Schema$Enterprise;
   }
 
   export class Resource$Enterprises$Applications {
@@ -2437,10 +2439,11 @@ export namespace androidmanagement_v1 {
      * enterprises/{enterpriseId}/devices/{deviceId}.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Command;
+    requestBody?: Schema$Command;
   }
   export interface Params$Resource$Enterprises$Devices$List {
     /**
@@ -2478,10 +2481,11 @@ export namespace androidmanagement_v1 {
      * modifiable fields will be modified.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Device;
+    requestBody?: Schema$Device;
   }
 
   export class Resource$Enterprises$Devices$Operations {
@@ -3003,10 +3007,11 @@ export namespace androidmanagement_v1 {
      * The name of the enterprise in the form enterprises/{enterpriseId}.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EnrollmentToken;
+    requestBody?: Schema$EnrollmentToken;
   }
   export interface Params$Resource$Enterprises$Enrollmenttokens$Delete {
     /**
@@ -3362,10 +3367,11 @@ export namespace androidmanagement_v1 {
      * modifiable fields will be modified.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
 
 
@@ -3460,10 +3466,11 @@ export namespace androidmanagement_v1 {
      * The name of the enterprise in the form enterprises/{enterpriseId}.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WebToken;
+    requestBody?: Schema$WebToken;
   }
 
 

--- a/src/apis/androidpublisher/v2.ts
+++ b/src/apis/androidpublisher/v2.ts
@@ -1316,10 +1316,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AppEdit;
+    requestBody?: Schema$AppEdit;
   }
   export interface Params$Resource$Edits$Validate {
     /**
@@ -1902,10 +1903,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ApkListing;
+    requestBody?: Schema$ApkListing;
   }
   export interface Params$Resource$Edits$Apklistings$Update {
     /**
@@ -1933,10 +1935,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ApkListing;
+    requestBody?: Schema$ApkListing;
   }
 
 
@@ -2191,10 +2194,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ApksAddExternallyHostedRequest;
+    requestBody?: Schema$ApksAddExternallyHostedRequest;
   }
   export interface Params$Resource$Edits$Apks$List {
     /**
@@ -2227,10 +2231,12 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2239,7 +2245,7 @@ export namespace androidpublisher_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -2374,10 +2380,12 @@ export namespace androidpublisher_v2 {
      * are being uploaded; for example, "com.spiffygame".
      */
     packageName?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2386,7 +2394,7 @@ export namespace androidpublisher_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -2644,10 +2652,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AppDetails;
+    requestBody?: Schema$AppDetails;
   }
   export interface Params$Resource$Edits$Details$Update {
     /**
@@ -2664,10 +2673,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AppDetails;
+    requestBody?: Schema$AppDetails;
   }
 
 
@@ -3043,10 +3053,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ExpansionFile;
+    requestBody?: Schema$ExpansionFile;
   }
   export interface Params$Resource$Edits$Expansionfiles$Update {
     /**
@@ -3072,10 +3083,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ExpansionFile;
+    requestBody?: Schema$ExpansionFile;
   }
   export interface Params$Resource$Edits$Expansionfiles$Upload {
     /**
@@ -3101,10 +3113,12 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -3113,7 +3127,7 @@ export namespace androidpublisher_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -3537,10 +3551,12 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -3549,7 +3565,7 @@ export namespace androidpublisher_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -4076,10 +4092,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Listing;
+    requestBody?: Schema$Listing;
   }
   export interface Params$Resource$Edits$Listings$Update {
     /**
@@ -4101,10 +4118,11 @@ export namespace androidpublisher_v2 {
      * "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Listing;
+    requestBody?: Schema$Listing;
   }
 
 
@@ -4366,10 +4384,11 @@ export namespace androidpublisher_v2 {
      * "production", "rollout" or "internal".
      */
     track?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Testers;
+    requestBody?: Schema$Testers;
   }
   export interface Params$Resource$Edits$Testers$Update {
     /**
@@ -4391,10 +4410,11 @@ export namespace androidpublisher_v2 {
      * "production", "rollout" or "internal".
      */
     track?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Testers;
+    requestBody?: Schema$Testers;
   }
 
 
@@ -4746,10 +4766,11 @@ export namespace androidpublisher_v2 {
      * The track to read or modify.
      */
     track?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Track;
+    requestBody?: Schema$Track;
   }
   export interface Params$Resource$Edits$Tracks$Update {
     /**
@@ -4770,10 +4791,11 @@ export namespace androidpublisher_v2 {
      * The track to read or modify.
      */
     track?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Track;
+    requestBody?: Schema$Track;
   }
 
 
@@ -5262,10 +5284,11 @@ export namespace androidpublisher_v2 {
      * Unique identifier for the Android app; for example, "com.spiffygame".
      */
     packageName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InAppProduct;
+    requestBody?: Schema$InAppProduct;
   }
   export interface Params$Resource$Inappproducts$List {
     /**
@@ -5312,10 +5335,11 @@ export namespace androidpublisher_v2 {
      * Unique identifier for the in-app product.
      */
     sku?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InAppProduct;
+    requestBody?: Schema$InAppProduct;
   }
   export interface Params$Resource$Inappproducts$Update {
     /**
@@ -5338,10 +5362,11 @@ export namespace androidpublisher_v2 {
      * Unique identifier for the in-app product.
      */
     sku?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InAppProduct;
+    requestBody?: Schema$InAppProduct;
   }
 
 
@@ -5883,10 +5908,11 @@ export namespace androidpublisher_v2 {
      * purchased.
      */
     token?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubscriptionPurchasesDeferRequest;
+    requestBody?: Schema$SubscriptionPurchasesDeferRequest;
   }
   export interface Params$Resource$Purchases$Subscriptions$Get {
     /**
@@ -6371,9 +6397,10 @@ export namespace androidpublisher_v2 {
      *
      */
     reviewId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReviewsReplyRequest;
+    requestBody?: Schema$ReviewsReplyRequest;
   }
 }

--- a/src/apis/appengine/v1.ts
+++ b/src/apis/appengine/v1.ts
@@ -2177,10 +2177,11 @@ export namespace appengine_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
   export interface Params$Resource$Apps$Get {
     /**
@@ -2209,10 +2210,11 @@ export namespace appengine_v1 {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
   export interface Params$Resource$Apps$Repair {
     /**
@@ -2224,10 +2226,11 @@ export namespace appengine_v1 {
      * Part of `name`. Name of the application to repair. Example: apps/myapp
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RepairApplicationRequest;
+    requestBody?: Schema$RepairApplicationRequest;
   }
 
   export class Resource$Apps$Authorizedcertificates {
@@ -2617,10 +2620,11 @@ export namespace appengine_v1 {
      * apps/myapp.
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AuthorizedCertificate;
+    requestBody?: Schema$AuthorizedCertificate;
   }
   export interface Params$Resource$Apps$Authorizedcertificates$Delete {
     /**
@@ -2702,10 +2706,11 @@ export namespace appengine_v1 {
      * supported on the certificate_raw_data and display_name fields.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AuthorizedCertificate;
+    requestBody?: Schema$AuthorizedCertificate;
   }
 
 
@@ -3204,10 +3209,11 @@ export namespace appengine_v1 {
      * this domain. By default, overrides are rejected.
      */
     overrideStrategy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DomainMapping;
+    requestBody?: Schema$DomainMapping;
   }
   export interface Params$Resource$Apps$Domainmappings$Delete {
     /**
@@ -3280,10 +3286,11 @@ export namespace appengine_v1 {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DomainMapping;
+    requestBody?: Schema$DomainMapping;
   }
 
 
@@ -3751,10 +3758,11 @@ export namespace appengine_v1 {
      * apps/myapp/firewall/ingressRules.
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchUpdateIngressRulesRequest;
+    requestBody?: Schema$BatchUpdateIngressRulesRequest;
   }
   export interface Params$Resource$Apps$Firewall$Ingressrules$Create {
     /**
@@ -3767,10 +3775,11 @@ export namespace appengine_v1 {
      * create a new rule. Example: apps/myapp/firewall/ingressRules.
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FirewallRule;
+    requestBody?: Schema$FirewallRule;
   }
   export interface Params$Resource$Apps$Firewall$Ingressrules$Delete {
     /**
@@ -3849,10 +3858,11 @@ export namespace appengine_v1 {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FirewallRule;
+    requestBody?: Schema$FirewallRule;
   }
 
 
@@ -4612,10 +4622,11 @@ export namespace appengine_v1 {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Service;
+    requestBody?: Schema$Service;
   }
 
   export class Resource$Apps$Services$Versions {
@@ -5030,10 +5041,11 @@ export namespace appengine_v1 {
      * Part of `parent`. See documentation of `appsId`.
      */
     servicesId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
   export interface Params$Resource$Apps$Services$Versions$Delete {
     /**
@@ -5130,10 +5142,11 @@ export namespace appengine_v1 {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
 
   export class Resource$Apps$Services$Versions$Instances {
@@ -5467,10 +5480,11 @@ export namespace appengine_v1 {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DebugInstanceRequest;
+    requestBody?: Schema$DebugInstanceRequest;
   }
   export interface Params$Resource$Apps$Services$Versions$Instances$Delete {
     /**

--- a/src/apis/appengine/v1alpha.ts
+++ b/src/apis/appengine/v1alpha.ts
@@ -1077,10 +1077,11 @@ export namespace appengine_v1alpha {
      * apps/myapp.
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AuthorizedCertificate;
+    requestBody?: Schema$AuthorizedCertificate;
   }
   export interface Params$Resource$Apps$Authorizedcertificates$Delete {
     /**
@@ -1162,10 +1163,11 @@ export namespace appengine_v1alpha {
      * supported on the certificate_raw_data and display_name fields.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AuthorizedCertificate;
+    requestBody?: Schema$AuthorizedCertificate;
   }
 
 
@@ -1673,10 +1675,11 @@ export namespace appengine_v1alpha {
      * this domain. By default, overrides are rejected.
      */
     overrideStrategy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DomainMapping;
+    requestBody?: Schema$DomainMapping;
   }
   export interface Params$Resource$Apps$Domainmappings$Delete {
     /**
@@ -1758,10 +1761,11 @@ export namespace appengine_v1alpha {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DomainMapping;
+    requestBody?: Schema$DomainMapping;
   }
 
 

--- a/src/apis/appengine/v1beta.ts
+++ b/src/apis/appengine/v1beta.ts
@@ -2290,10 +2290,11 @@ export namespace appengine_v1beta {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
   export interface Params$Resource$Apps$Get {
     /**
@@ -2322,10 +2323,11 @@ export namespace appengine_v1beta {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
   export interface Params$Resource$Apps$Repair {
     /**
@@ -2337,10 +2339,11 @@ export namespace appengine_v1beta {
      * Part of `name`. Name of the application to repair. Example: apps/myapp
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RepairApplicationRequest;
+    requestBody?: Schema$RepairApplicationRequest;
   }
 
   export class Resource$Apps$Authorizedcertificates {
@@ -2730,10 +2733,11 @@ export namespace appengine_v1beta {
      * apps/myapp.
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AuthorizedCertificate;
+    requestBody?: Schema$AuthorizedCertificate;
   }
   export interface Params$Resource$Apps$Authorizedcertificates$Delete {
     /**
@@ -2815,10 +2819,11 @@ export namespace appengine_v1beta {
      * supported on the certificate_raw_data and display_name fields.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AuthorizedCertificate;
+    requestBody?: Schema$AuthorizedCertificate;
   }
 
 
@@ -3317,10 +3322,11 @@ export namespace appengine_v1beta {
      * this domain. By default, overrides are rejected.
      */
     overrideStrategy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DomainMapping;
+    requestBody?: Schema$DomainMapping;
   }
   export interface Params$Resource$Apps$Domainmappings$Delete {
     /**
@@ -3393,10 +3399,11 @@ export namespace appengine_v1beta {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DomainMapping;
+    requestBody?: Schema$DomainMapping;
   }
 
 
@@ -3867,10 +3874,11 @@ export namespace appengine_v1beta {
      * apps/myapp/firewall/ingressRules.
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchUpdateIngressRulesRequest;
+    requestBody?: Schema$BatchUpdateIngressRulesRequest;
   }
   export interface Params$Resource$Apps$Firewall$Ingressrules$Create {
     /**
@@ -3883,10 +3891,11 @@ export namespace appengine_v1beta {
      * create a new rule. Example: apps/myapp/firewall/ingressRules.
      */
     appsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FirewallRule;
+    requestBody?: Schema$FirewallRule;
   }
   export interface Params$Resource$Apps$Firewall$Ingressrules$Delete {
     /**
@@ -3965,10 +3974,11 @@ export namespace appengine_v1beta {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FirewallRule;
+    requestBody?: Schema$FirewallRule;
   }
 
 
@@ -4728,10 +4738,11 @@ export namespace appengine_v1beta {
      * Standard field mask for the set of fields to be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Service;
+    requestBody?: Schema$Service;
   }
 
   export class Resource$Apps$Services$Versions {
@@ -5146,10 +5157,11 @@ export namespace appengine_v1beta {
      * Part of `parent`. See documentation of `appsId`.
      */
     servicesId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
   export interface Params$Resource$Apps$Services$Versions$Delete {
     /**
@@ -5246,10 +5258,11 @@ export namespace appengine_v1beta {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
 
   export class Resource$Apps$Services$Versions$Instances {
@@ -5583,10 +5596,11 @@ export namespace appengine_v1beta {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DebugInstanceRequest;
+    requestBody?: Schema$DebugInstanceRequest;
   }
   export interface Params$Resource$Apps$Services$Versions$Instances$Delete {
     /**

--- a/src/apis/appengine/v1beta4.ts
+++ b/src/apis/appengine/v1beta4.ts
@@ -1673,10 +1673,11 @@ export namespace appengine_v1beta4 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
   export interface Params$Resource$Apps$Get {
     /**
@@ -1712,10 +1713,11 @@ export namespace appengine_v1beta4 {
      * Standard field mask for the set of fields to be updated.
      */
     mask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
 
   export class Resource$Apps$Locations {
@@ -2272,10 +2274,11 @@ export namespace appengine_v1beta4 {
      * Part of `name`. See documentation of `appsId`.
      */
     modulesId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Module;
+    requestBody?: Schema$Module;
   }
 
   export class Resource$Apps$Modules$Versions {
@@ -2677,10 +2680,11 @@ export namespace appengine_v1beta4 {
      * Part of `name`. See documentation of `appsId`.
      */
     modulesId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
   export interface Params$Resource$Apps$Modules$Versions$Delete {
     /**
@@ -2777,10 +2781,11 @@ export namespace appengine_v1beta4 {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
 
   export class Resource$Apps$Modules$Versions$Instances {
@@ -3113,10 +3118,11 @@ export namespace appengine_v1beta4 {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DebugInstanceRequest;
+    requestBody?: Schema$DebugInstanceRequest;
   }
   export interface Params$Resource$Apps$Modules$Versions$Instances$Delete {
     /**

--- a/src/apis/appengine/v1beta5.ts
+++ b/src/apis/appengine/v1beta5.ts
@@ -1649,10 +1649,11 @@ export namespace appengine_v1beta5 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
   export interface Params$Resource$Apps$Get {
     /**
@@ -1689,10 +1690,11 @@ export namespace appengine_v1beta5 {
      * Standard field mask for the set of fields to be updated.
      */
     mask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Application;
+    requestBody?: Schema$Application;
   }
 
   export class Resource$Apps$Locations {
@@ -2450,10 +2452,11 @@ export namespace appengine_v1beta5 {
      * Part of `name`. See documentation of `appsId`.
      */
     servicesId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Service;
+    requestBody?: Schema$Service;
   }
 
   export class Resource$Apps$Services$Versions {
@@ -2855,10 +2858,11 @@ export namespace appengine_v1beta5 {
      * Part of `name`. See documentation of `appsId`.
      */
     servicesId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
   export interface Params$Resource$Apps$Services$Versions$Delete {
     /**
@@ -2955,10 +2959,11 @@ export namespace appengine_v1beta5 {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
 
   export class Resource$Apps$Services$Versions$Instances {
@@ -3292,10 +3297,11 @@ export namespace appengine_v1beta5 {
      * Part of `name`. See documentation of `appsId`.
      */
     versionsId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DebugInstanceRequest;
+    requestBody?: Schema$DebugInstanceRequest;
   }
   export interface Params$Resource$Apps$Services$Versions$Instances$Delete {
     /**

--- a/src/apis/appstate/v1.ts
+++ b/src/apis/appstate/v1.ts
@@ -552,9 +552,10 @@ export namespace appstate_v1 {
      * The key for the data to be retrieved.
      */
     stateKey?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateRequest;
+    requestBody?: Schema$UpdateRequest;
   }
 }

--- a/src/apis/bigquery/v2.ts
+++ b/src/apis/bigquery/v2.ts
@@ -2813,10 +2813,11 @@ export namespace bigquery_v2 {
      * Project ID of the new dataset
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Dataset;
+    requestBody?: Schema$Dataset;
   }
   export interface Params$Resource$Datasets$List {
     /**
@@ -2864,10 +2865,11 @@ export namespace bigquery_v2 {
      * Project ID of the dataset being updated
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Dataset;
+    requestBody?: Schema$Dataset;
   }
   export interface Params$Resource$Datasets$Update {
     /**
@@ -2883,10 +2885,11 @@ export namespace bigquery_v2 {
      * Project ID of the dataset being updated
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Dataset;
+    requestBody?: Schema$Dataset;
   }
 
 
@@ -3783,14 +3786,16 @@ export namespace bigquery_v2 {
      * Project ID of the project that will be billed for the job
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -3799,7 +3804,7 @@ export namespace bigquery_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Jobs$List {
@@ -3854,10 +3859,11 @@ export namespace bigquery_v2 {
      * Project ID of the project billed for the query
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$QueryRequest;
+    requestBody?: Schema$QueryRequest;
   }
 
 
@@ -4475,10 +4481,11 @@ export namespace bigquery_v2 {
      * Table ID of the destination table.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TableDataInsertAllRequest;
+    requestBody?: Schema$TableDataInsertAllRequest;
   }
   export interface Params$Resource$Tabledata$List {
     /**
@@ -5379,10 +5386,11 @@ export namespace bigquery_v2 {
      * Project ID of the new table
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Table;
+    requestBody?: Schema$Table;
   }
   export interface Params$Resource$Tables$List {
     /**
@@ -5426,10 +5434,11 @@ export namespace bigquery_v2 {
      * Table ID of the table to update
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Table;
+    requestBody?: Schema$Table;
   }
   export interface Params$Resource$Tables$Update {
     /**
@@ -5449,9 +5458,10 @@ export namespace bigquery_v2 {
      * Table ID of the table to update
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Table;
+    requestBody?: Schema$Table;
   }
 }

--- a/src/apis/bigquerydatatransfer/v1.ts
+++ b/src/apis/bigquerydatatransfer/v1.ts
@@ -165,8 +165,7 @@ export namespace bigquerydatatransfer_v1 {
      */
     supportsCustomSchedule?: boolean;
     /**
-     * Indicates whether the data source supports multiple transfers to
-     * different BigQuery targets.
+     * Deprecated. This field has no effect.
      */
     supportsMultipleTransfers?: boolean;
     /**
@@ -860,10 +859,11 @@ export namespace bigquerydatatransfer_v1 {
      * `projects/{project_id}/dataSources/{data_source_id}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CheckValidCredsRequest;
+    requestBody?: Schema$CheckValidCredsRequest;
   }
   export interface Params$Resource$Projects$Datasources$Get {
     /**
@@ -1325,10 +1325,11 @@ export namespace bigquerydatatransfer_v1 {
      * `projects/{project_id}/dataSources/{data_source_id}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CheckValidCredsRequest;
+    requestBody?: Schema$CheckValidCredsRequest;
   }
   export interface Params$Resource$Projects$Locations$Datasources$Get {
     /**
@@ -1851,10 +1852,11 @@ export namespace bigquerydatatransfer_v1 {
      * will fail.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TransferConfig;
+    requestBody?: Schema$TransferConfig;
   }
   export interface Params$Resource$Projects$Locations$Transferconfigs$Delete {
     /**
@@ -1942,10 +1944,11 @@ export namespace bigquerydatatransfer_v1 {
      * Required list of fields to be updated in this request.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TransferConfig;
+    requestBody?: Schema$TransferConfig;
   }
   export interface Params$Resource$Projects$Locations$Transferconfigs$Scheduleruns {
     /**
@@ -1958,10 +1961,11 @@ export namespace bigquerydatatransfer_v1 {
      * `projects/{project_id}/transferConfigs/{config_id}`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ScheduleTransferRunsRequest;
+    requestBody?: Schema$ScheduleTransferRunsRequest;
   }
 
   export class Resource$Projects$Locations$Transferconfigs$Runs {
@@ -2841,10 +2845,11 @@ export namespace bigquerydatatransfer_v1 {
      * will fail.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TransferConfig;
+    requestBody?: Schema$TransferConfig;
   }
   export interface Params$Resource$Projects$Transferconfigs$Delete {
     /**
@@ -2932,10 +2937,11 @@ export namespace bigquerydatatransfer_v1 {
      * Required list of fields to be updated in this request.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TransferConfig;
+    requestBody?: Schema$TransferConfig;
   }
   export interface Params$Resource$Projects$Transferconfigs$Scheduleruns {
     /**
@@ -2948,10 +2954,11 @@ export namespace bigquerydatatransfer_v1 {
      * `projects/{project_id}/transferConfigs/{config_id}`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ScheduleTransferRunsRequest;
+    requestBody?: Schema$ScheduleTransferRunsRequest;
   }
 
   export class Resource$Projects$Transferconfigs$Runs {

--- a/src/apis/blogger/v3.ts
+++ b/src/apis/blogger/v3.ts
@@ -2182,10 +2182,11 @@ export namespace blogger_v3 {
      * Whether to create the page as a draft (default: false).
      */
     isDraft?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Page;
+    requestBody?: Schema$Page;
   }
   export interface Params$Resource$Pages$List {
     /**
@@ -2243,10 +2244,11 @@ export namespace blogger_v3 {
      * (default: false).
      */
     revert?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Page;
+    requestBody?: Schema$Page;
   }
   export interface Params$Resource$Pages$Publish {
     /**
@@ -2302,10 +2304,11 @@ export namespace blogger_v3 {
      * (default: false).
      */
     revert?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Page;
+    requestBody?: Schema$Page;
   }
 
 
@@ -3193,10 +3196,11 @@ export namespace blogger_v3 {
      * Whether to create the post as a draft (default: false).
      */
     isDraft?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Post;
+    requestBody?: Schema$Post;
   }
   export interface Params$Resource$Posts$List {
     /**
@@ -3290,10 +3294,11 @@ export namespace blogger_v3 {
      * (default: false).
      */
     revert?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Post;
+    requestBody?: Schema$Post;
   }
   export interface Params$Resource$Posts$Publish {
     /**
@@ -3395,10 +3400,11 @@ export namespace blogger_v3 {
      * (default: false).
      */
     revert?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Post;
+    requestBody?: Schema$Post;
   }
 
 

--- a/src/apis/books/v1.ts
+++ b/src/apis/books/v1.ts
@@ -1442,6 +1442,12 @@ export namespace books_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$BooksCloudloadingResource;
   }
 
 
@@ -3022,6 +3028,12 @@ export namespace books_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Usersettings;
   }
 
 
@@ -3444,10 +3456,11 @@ export namespace books_v1 {
      * String to identify the originator of this request.
      */
     source?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Annotation;
+    requestBody?: Schema$Annotation;
   }
   export interface Params$Resource$Mylibrary$Annotations$List {
     /**
@@ -3528,10 +3541,11 @@ export namespace books_v1 {
      * String to identify the originator of this request.
      */
     source?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Annotation;
+    requestBody?: Schema$Annotation;
   }
 
 

--- a/src/apis/calendar/v3.ts
+++ b/src/apis/calendar/v3.ts
@@ -1681,10 +1681,11 @@ export namespace calendar_v3 {
      * Optional. The default is True.
      */
     sendNotifications?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AclRule;
+    requestBody?: Schema$AclRule;
   }
   export interface Params$Resource$Acl$List {
     /**
@@ -1749,10 +1750,11 @@ export namespace calendar_v3 {
      * is True.
      */
     sendNotifications?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AclRule;
+    requestBody?: Schema$AclRule;
   }
   export interface Params$Resource$Acl$Update {
     /**
@@ -1776,10 +1778,11 @@ export namespace calendar_v3 {
      * is True.
      */
     sendNotifications?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AclRule;
+    requestBody?: Schema$AclRule;
   }
   export interface Params$Resource$Acl$Watch {
     /**
@@ -1821,10 +1824,11 @@ export namespace calendar_v3 {
      * Optional. The default is to return all entries.
      */
     syncToken?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -2354,10 +2358,11 @@ export namespace calendar_v3 {
      * Optional. The default is False.
      */
     colorRgbFormat?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CalendarListEntry;
+    requestBody?: Schema$CalendarListEntry;
   }
   export interface Params$Resource$Calendarlist$List {
     /**
@@ -2425,10 +2430,11 @@ export namespace calendar_v3 {
      * Optional. The default is False.
      */
     colorRgbFormat?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CalendarListEntry;
+    requestBody?: Schema$CalendarListEntry;
   }
   export interface Params$Resource$Calendarlist$Update {
     /**
@@ -2449,10 +2455,11 @@ export namespace calendar_v3 {
      * Optional. The default is False.
      */
     colorRgbFormat?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CalendarListEntry;
+    requestBody?: Schema$CalendarListEntry;
   }
   export interface Params$Resource$Calendarlist$Watch {
     /**
@@ -2500,10 +2507,11 @@ export namespace calendar_v3 {
      * return all entries.
      */
     syncToken?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -2947,6 +2955,12 @@ export namespace calendar_v3 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Calendar;
   }
   export interface Params$Resource$Calendars$Patch {
     /**
@@ -2960,10 +2974,11 @@ export namespace calendar_v3 {
      * logged in user, use the "primary" keyword.
      */
     calendarId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Calendar;
+    requestBody?: Schema$Calendar;
   }
   export interface Params$Resource$Calendars$Update {
     /**
@@ -2977,10 +2992,11 @@ export namespace calendar_v3 {
      * logged in user, use the "primary" keyword.
      */
     calendarId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Calendar;
+    requestBody?: Schema$Calendar;
   }
 
 
@@ -3064,6 +3080,12 @@ export namespace calendar_v3 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Channel;
   }
 
 
@@ -4004,10 +4026,11 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
      * Optional. The default is False.
      */
     supportsAttachments?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Event;
+    requestBody?: Schema$Event;
   }
   export interface Params$Resource$Events$Insert {
     /**
@@ -4045,10 +4068,11 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
      * Optional. The default is False.
      */
     supportsAttachments?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Event;
+    requestBody?: Schema$Event;
   }
   export interface Params$Resource$Events$Instances {
     /**
@@ -4326,10 +4350,11 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
      * Optional. The default is False.
      */
     supportsAttachments?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Event;
+    requestBody?: Schema$Event;
   }
   export interface Params$Resource$Events$Quickadd {
     /**
@@ -4402,10 +4427,11 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
      * Optional. The default is False.
      */
     supportsAttachments?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Event;
+    requestBody?: Schema$Event;
   }
   export interface Params$Resource$Events$Watch {
     /**
@@ -4538,10 +4564,11 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
      * is not to filter by last modification time.
      */
     updatedMin?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -4627,6 +4654,12 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$FreeBusyRequest;
   }
 
 
@@ -4900,9 +4933,10 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
      * synchronization. Optional. The default is to return all entries.
      */
     syncToken?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 }

--- a/src/apis/chat/v1.ts
+++ b/src/apis/chat/v1.ts
@@ -1191,10 +1191,11 @@ export namespace chat_v1 {
      * if thread field, corresponding to an existing thread, is set in message.
      */
     threadKey?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Message;
+    requestBody?: Schema$Message;
   }
   export interface Params$Resource$Spaces$Messages$Delete {
     /**
@@ -1238,9 +1239,10 @@ export namespace chat_v1 {
      * paths: "text", "cards".
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Message;
+    requestBody?: Schema$Message;
   }
 }

--- a/src/apis/civicinfo/v2.ts
+++ b/src/apis/civicinfo/v2.ts
@@ -936,10 +936,11 @@ export namespace civicinfo_v2 {
      * http://lucene.apache.org/core/2_9_4/queryparsersyntax.html
      */
     query?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DivisionSearchRequest;
+    requestBody?: Schema$DivisionSearchRequest;
   }
 
 
@@ -1102,6 +1103,12 @@ export namespace civicinfo_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ElectionsQueryRequest;
   }
   export interface Params$Resource$Elections$Voterinfoquery {
     /**
@@ -1128,10 +1135,11 @@ export namespace civicinfo_v2 {
      * unable to determine the election for electionId=0 queries.
      */
     returnAllAvailableData?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VoterInfoRequest;
+    requestBody?: Schema$VoterInfoRequest;
   }
 
 
@@ -1332,10 +1340,11 @@ export namespace civicinfo_v2 {
      * will not be returned.
      */
     roles?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RepresentativeInfoRequest;
+    requestBody?: Schema$RepresentativeInfoRequest;
   }
   export interface Params$Resource$Representatives$Representativeinfobydivision {
     /**
@@ -1366,9 +1375,10 @@ export namespace civicinfo_v2 {
      * will not be returned.
      */
     roles?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DivisionRepresentativeInfoRequest;
+    requestBody?: Schema$DivisionRepresentativeInfoRequest;
   }
 }

--- a/src/apis/classroom/v1.ts
+++ b/src/apis/classroom/v1.ts
@@ -1730,10 +1730,11 @@ export namespace classroom_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Course;
+    requestBody?: Schema$Course;
   }
   export interface Params$Resource$Courses$Delete {
     /**
@@ -1819,10 +1820,11 @@ export namespace classroom_v1 {
      * field should be specified as  `updateMask=<field1>,<field2>,...`
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Course;
+    requestBody?: Schema$Course;
   }
   export interface Params$Resource$Courses$Update {
     /**
@@ -1835,10 +1837,11 @@ export namespace classroom_v1 {
      * Classroom-assigned identifier or an alias.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Course;
+    requestBody?: Schema$Course;
   }
 
   export class Resource$Courses$Aliases {
@@ -2085,10 +2088,11 @@ export namespace classroom_v1 {
      * Classroom-assigned identifier or an alias.
      */
     courseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CourseAlias;
+    requestBody?: Schema$CourseAlias;
   }
   export interface Params$Resource$Courses$Aliases$Delete {
     /**
@@ -2606,10 +2610,11 @@ export namespace classroom_v1 {
      * Classroom-assigned identifier or an alias.
      */
     courseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Announcement;
+    requestBody?: Schema$Announcement;
   }
   export interface Params$Resource$Courses$Announcements$Delete {
     /**
@@ -2696,10 +2701,11 @@ export namespace classroom_v1 {
      * Identifier of the announcement.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyAnnouncementAssigneesRequest;
+    requestBody?: Schema$ModifyAnnouncementAssigneesRequest;
   }
   export interface Params$Resource$Courses$Announcements$Patch {
     /**
@@ -2727,10 +2733,11 @@ export namespace classroom_v1 {
      * `text` * `state` * `scheduled_time`
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Announcement;
+    requestBody?: Schema$Announcement;
   }
 
 
@@ -3218,10 +3225,11 @@ export namespace classroom_v1 {
      * Classroom-assigned identifier or an alias.
      */
     courseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CourseWork;
+    requestBody?: Schema$CourseWork;
   }
   export interface Params$Resource$Courses$Coursework$Delete {
     /**
@@ -3309,10 +3317,11 @@ export namespace classroom_v1 {
      * Identifier of the coursework.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyCourseWorkAssigneesRequest;
+    requestBody?: Schema$ModifyCourseWorkAssigneesRequest;
   }
   export interface Params$Resource$Courses$Coursework$Patch {
     /**
@@ -3341,10 +3350,11 @@ export namespace classroom_v1 {
      * `scheduled_time` * `submission_modification_mode`
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CourseWork;
+    requestBody?: Schema$CourseWork;
   }
 
   export class Resource$Courses$Coursework$Studentsubmissions {
@@ -4043,10 +4053,11 @@ export namespace classroom_v1 {
      * Identifier of the student submission.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyAttachmentsRequest;
+    requestBody?: Schema$ModifyAttachmentsRequest;
   }
   export interface Params$Resource$Courses$Coursework$Studentsubmissions$Patch {
     /**
@@ -4074,10 +4085,11 @@ export namespace classroom_v1 {
      * * `draft_grade` * `assigned_grade`
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StudentSubmission;
+    requestBody?: Schema$StudentSubmission;
   }
   export interface Params$Resource$Courses$Coursework$Studentsubmissions$Reclaim {
     /**
@@ -4098,10 +4110,11 @@ export namespace classroom_v1 {
      * Identifier of the student submission.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReclaimStudentSubmissionRequest;
+    requestBody?: Schema$ReclaimStudentSubmissionRequest;
   }
   export interface Params$Resource$Courses$Coursework$Studentsubmissions$Return {
     /**
@@ -4122,10 +4135,11 @@ export namespace classroom_v1 {
      * Identifier of the student submission.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReturnStudentSubmissionRequest;
+    requestBody?: Schema$ReturnStudentSubmissionRequest;
   }
   export interface Params$Resource$Courses$Coursework$Studentsubmissions$Turnin {
     /**
@@ -4146,10 +4160,11 @@ export namespace classroom_v1 {
      * Identifier of the student submission.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TurnInStudentSubmissionRequest;
+    requestBody?: Schema$TurnInStudentSubmissionRequest;
   }
 
 
@@ -4471,10 +4486,11 @@ export namespace classroom_v1 {
      * for any user.
      */
     enrollmentCode?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Student;
+    requestBody?: Schema$Student;
   }
   export interface Params$Resource$Courses$Students$Delete {
     /**
@@ -4847,10 +4863,11 @@ export namespace classroom_v1 {
      * Classroom-assigned identifier or an alias.
      */
     courseId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Teacher;
+    requestBody?: Schema$Teacher;
   }
   export interface Params$Resource$Courses$Teachers$Delete {
     /**
@@ -5297,10 +5314,11 @@ export namespace classroom_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Invitation;
+    requestBody?: Schema$Invitation;
   }
   export interface Params$Resource$Invitations$Delete {
     /**
@@ -5527,10 +5545,11 @@ export namespace classroom_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Registration;
+    requestBody?: Schema$Registration;
   }
   export interface Params$Resource$Registrations$Delete {
     /**
@@ -6012,10 +6031,11 @@ export namespace classroom_v1 {
      * ID of the student (in standard format)
      */
     studentId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GuardianInvitation;
+    requestBody?: Schema$GuardianInvitation;
   }
   export interface Params$Resource$Userprofiles$Guardianinvitations$Get {
     /**
@@ -6093,10 +6113,11 @@ export namespace classroom_v1 {
      * `updateMask=<field1>,<field2>,...`
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GuardianInvitation;
+    requestBody?: Schema$GuardianInvitation;
   }
 
 

--- a/src/apis/cloudbilling/v1.ts
+++ b/src/apis/cloudbilling/v1.ts
@@ -1241,10 +1241,11 @@ export namespace cloudbilling_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BillingAccount;
+    requestBody?: Schema$BillingAccount;
   }
   export interface Params$Resource$Billingaccounts$Get {
     /**
@@ -1313,10 +1314,11 @@ export namespace cloudbilling_v1 {
      * supported.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BillingAccount;
+    requestBody?: Schema$BillingAccount;
   }
   export interface Params$Resource$Billingaccounts$Setiampolicy {
     /**
@@ -1329,10 +1331,11 @@ export namespace cloudbilling_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Billingaccounts$Testiampermissions {
     /**
@@ -1345,10 +1348,11 @@ export namespace cloudbilling_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Billingaccounts$Projects {
@@ -1852,10 +1856,11 @@ export namespace cloudbilling_v1 {
      * that you want to update. For example, `projects/tokyo-rain-123`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectBillingInfo;
+    requestBody?: Schema$ProjectBillingInfo;
   }
 
 

--- a/src/apis/cloudbuild/v1.ts
+++ b/src/apis/cloudbuild/v1.ts
@@ -1025,10 +1025,11 @@ export namespace cloudbuild_v1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Get {
     /**
@@ -1470,10 +1471,11 @@ export namespace cloudbuild_v1 {
      * ID of the project.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelBuildRequest;
+    requestBody?: Schema$CancelBuildRequest;
   }
   export interface Params$Resource$Projects$Builds$Create {
     /**
@@ -1485,10 +1487,11 @@ export namespace cloudbuild_v1 {
      * ID of the project.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Build;
+    requestBody?: Schema$Build;
   }
   export interface Params$Resource$Projects$Builds$Get {
     /**
@@ -1542,10 +1545,11 @@ export namespace cloudbuild_v1 {
      * ID of the project.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RetryBuildRequest;
+    requestBody?: Schema$RetryBuildRequest;
   }
 
 
@@ -1979,10 +1983,11 @@ export namespace cloudbuild_v1 {
      * ID of the project for which to configure automatic builds.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BuildTrigger;
+    requestBody?: Schema$BuildTrigger;
   }
   export interface Params$Resource$Projects$Triggers$Delete {
     /**
@@ -2039,10 +2044,11 @@ export namespace cloudbuild_v1 {
      * ID of the `BuildTrigger` to update.
      */
     triggerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BuildTrigger;
+    requestBody?: Schema$BuildTrigger;
   }
   export interface Params$Resource$Projects$Triggers$Run {
     /**
@@ -2058,9 +2064,10 @@ export namespace cloudbuild_v1 {
      * ID of the trigger.
      */
     triggerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RepoSource;
+    requestBody?: Schema$RepoSource;
   }
 }

--- a/src/apis/clouddebugger/v2.ts
+++ b/src/apis/clouddebugger/v2.ts
@@ -863,10 +863,11 @@ export namespace clouddebugger_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegisterDebuggeeRequest;
+    requestBody?: Schema$RegisterDebuggeeRequest;
   }
 
   export class Resource$Controller$Debuggees$Breakpoints {
@@ -1206,10 +1207,11 @@ export namespace clouddebugger_v2 {
      * Breakpoint identifier, unique in the scope of the debuggee.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateActiveBreakpointRequest;
+    requestBody?: Schema$UpdateActiveBreakpointRequest;
   }
 
 
@@ -1989,9 +1991,10 @@ export namespace clouddebugger_v2 {
      * ID of the debuggee where the breakpoint is to be set.
      */
     debuggeeId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Breakpoint;
+    requestBody?: Schema$Breakpoint;
   }
 }

--- a/src/apis/clouderrorreporting/v1beta1.ts
+++ b/src/apis/clouderrorreporting/v1beta1.ts
@@ -755,10 +755,11 @@ export namespace clouderrorreporting_v1beta1 {
      * `projects/my-project-123`.
      */
     projectName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReportedErrorEvent;
+    requestBody?: Schema$ReportedErrorEvent;
   }
 
 
@@ -935,10 +936,11 @@ export namespace clouderrorreporting_v1beta1 {
      * <code>projects/my-project-123/groups/my-groupid</code>
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ErrorGroup;
+    requestBody?: Schema$ErrorGroup;
   }
 
 

--- a/src/apis/cloudfunctions/v1.ts
+++ b/src/apis/cloudfunctions/v1.ts
@@ -1442,10 +1442,11 @@ export namespace cloudfunctions_v1 {
      * The name of the function to be called.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CallFunctionRequest;
+    requestBody?: Schema$CallFunctionRequest;
   }
   export interface Params$Resource$Projects$Locations$Functions$Create {
     /**
@@ -1458,10 +1459,11 @@ export namespace cloudfunctions_v1 {
      * specified in the format `projects/x/locations/x`
      */
     location?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CloudFunction;
+    requestBody?: Schema$CloudFunction;
   }
   export interface Params$Resource$Projects$Locations$Functions$Delete {
     /**
@@ -1485,10 +1487,11 @@ export namespace cloudfunctions_v1 {
      * URL should be generated.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GenerateDownloadUrlRequest;
+    requestBody?: Schema$GenerateDownloadUrlRequest;
   }
   export interface Params$Resource$Projects$Locations$Functions$Generateuploadurl {
     /**
@@ -1501,10 +1504,11 @@ export namespace cloudfunctions_v1 {
      * should be generated, specified in the format `projects/x/locations/x`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GenerateUploadUrlRequest;
+    requestBody?: Schema$GenerateUploadUrlRequest;
   }
   export interface Params$Resource$Projects$Locations$Functions$Get {
     /**
@@ -1555,9 +1559,10 @@ export namespace cloudfunctions_v1 {
      * Required list of fields to be updated in this request.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CloudFunction;
+    requestBody?: Schema$CloudFunction;
   }
 }

--- a/src/apis/cloudfunctions/v1beta2.ts
+++ b/src/apis/cloudfunctions/v1beta2.ts
@@ -1464,10 +1464,11 @@ export namespace cloudfunctions_v1beta2 {
      * The name of the function to be called.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CallFunctionRequest;
+    requestBody?: Schema$CallFunctionRequest;
   }
   export interface Params$Resource$Projects$Locations$Functions$Create {
     /**
@@ -1480,10 +1481,11 @@ export namespace cloudfunctions_v1beta2 {
      * specified in the format `projects/x/locations/x`
      */
     location?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CloudFunction;
+    requestBody?: Schema$CloudFunction;
   }
   export interface Params$Resource$Projects$Locations$Functions$Delete {
     /**
@@ -1507,10 +1509,11 @@ export namespace cloudfunctions_v1beta2 {
      * URL should be generated.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GenerateDownloadUrlRequest;
+    requestBody?: Schema$GenerateDownloadUrlRequest;
   }
   export interface Params$Resource$Projects$Locations$Functions$Generateuploadurl {
     /**
@@ -1523,10 +1526,11 @@ export namespace cloudfunctions_v1beta2 {
      * should be generated, specified in the format `projects/x/locations/x`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GenerateUploadUrlRequest;
+    requestBody?: Schema$GenerateUploadUrlRequest;
   }
   export interface Params$Resource$Projects$Locations$Functions$Get {
     /**
@@ -1572,9 +1576,10 @@ export namespace cloudfunctions_v1beta2 {
      * The name of the function to be updated.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CloudFunction;
+    requestBody?: Schema$CloudFunction;
   }
 }

--- a/src/apis/cloudiot/v1.ts
+++ b/src/apis/cloudiot/v1.ts
@@ -1419,10 +1419,11 @@ export namespace cloudiot_v1 {
      * For example, `projects/example-project/locations/us-central1`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeviceRegistry;
+    requestBody?: Schema$DeviceRegistry;
   }
   export interface Params$Resource$Projects$Locations$Registries$Delete {
     /**
@@ -1459,10 +1460,11 @@ export namespace cloudiot_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Registries$List {
     /**
@@ -1508,10 +1510,11 @@ export namespace cloudiot_v1 {
      * `state_notification_config`.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeviceRegistry;
+    requestBody?: Schema$DeviceRegistry;
   }
   export interface Params$Resource$Projects$Locations$Registries$Setiampolicy {
     /**
@@ -1524,10 +1527,11 @@ export namespace cloudiot_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Registries$Testiampermissions {
     /**
@@ -1540,10 +1544,11 @@ export namespace cloudiot_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Locations$Registries$Devices {
@@ -1998,10 +2003,11 @@ export namespace cloudiot_v1 {
      * `projects/example-project/locations/us-central1/registries/my-registry`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Device;
+    requestBody?: Schema$Device;
   }
   export interface Params$Resource$Projects$Locations$Registries$Devices$Delete {
     /**
@@ -2091,10 +2097,11 @@ export namespace cloudiot_v1 {
      * `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyCloudToDeviceConfigRequest;
+    requestBody?: Schema$ModifyCloudToDeviceConfigRequest;
   }
   export interface Params$Resource$Projects$Locations$Registries$Devices$Patch {
     /**
@@ -2117,10 +2124,11 @@ export namespace cloudiot_v1 {
      * `blocked`, and `metadata`
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Device;
+    requestBody?: Schema$Device;
   }
 
   export class Resource$Projects$Locations$Registries$Devices$Configversions {
@@ -2606,10 +2614,11 @@ export namespace cloudiot_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Registries$Groups$Setiampolicy {
     /**
@@ -2622,10 +2631,11 @@ export namespace cloudiot_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Registries$Groups$Testiampermissions {
     /**
@@ -2638,10 +2648,11 @@ export namespace cloudiot_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Locations$Registries$Groups$Devices {
@@ -2997,10 +3008,11 @@ export namespace cloudiot_v1 {
      * `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyCloudToDeviceConfigRequest;
+    requestBody?: Schema$ModifyCloudToDeviceConfigRequest;
   }
   export interface Params$Resource$Projects$Locations$Registries$Groups$Devices$Patch {
     /**
@@ -3023,10 +3035,11 @@ export namespace cloudiot_v1 {
      * `blocked`, and `metadata`
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Device;
+    requestBody?: Schema$Device;
   }
 
   export class

--- a/src/apis/cloudkms/v1.ts
+++ b/src/apis/cloudkms/v1.ts
@@ -1144,10 +1144,11 @@ export namespace cloudkms_v1 {
      * in the format `projects/x/locations/x`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$KeyRing;
+    requestBody?: Schema$KeyRing;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Get {
     /**
@@ -1207,10 +1208,11 @@ export namespace cloudkms_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Testiampermissions {
     /**
@@ -1223,10 +1225,11 @@ export namespace cloudkms_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Locations$Keyrings$Cryptokeys {
@@ -1985,10 +1988,11 @@ export namespace cloudkms_v1 {
      * Required. The name of the KeyRing associated with the CryptoKeys.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CryptoKey;
+    requestBody?: Schema$CryptoKey;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Decrypt {
     /**
@@ -2001,10 +2005,11 @@ export namespace cloudkms_v1 {
      * server will choose the appropriate version.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DecryptRequest;
+    requestBody?: Schema$DecryptRequest;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Encrypt {
     /**
@@ -2018,10 +2023,11 @@ export namespace cloudkms_v1 {
      * primary version.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EncryptRequest;
+    requestBody?: Schema$EncryptRequest;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Get {
     /**
@@ -2085,10 +2091,11 @@ export namespace cloudkms_v1 {
      * Required list of fields to be updated in this request.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CryptoKey;
+    requestBody?: Schema$CryptoKey;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Setiampolicy {
     /**
@@ -2101,10 +2108,11 @@ export namespace cloudkms_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Testiampermissions {
     /**
@@ -2117,10 +2125,11 @@ export namespace cloudkms_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Updateprimaryversion {
     /**
@@ -2132,10 +2141,11 @@ export namespace cloudkms_v1 {
      * The resource name of the CryptoKey to update.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateCryptoKeyPrimaryVersionRequest;
+    requestBody?: Schema$UpdateCryptoKeyPrimaryVersionRequest;
   }
 
   export class
@@ -2618,10 +2628,11 @@ export namespace cloudkms_v1 {
      * CryptoKeyVersions.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CryptoKeyVersion;
+    requestBody?: Schema$CryptoKeyVersion;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions$Destroy {
     /**
@@ -2633,10 +2644,11 @@ export namespace cloudkms_v1 {
      * The resource name of the CryptoKeyVersion to destroy.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DestroyCryptoKeyVersionRequest;
+    requestBody?: Schema$DestroyCryptoKeyVersionRequest;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions$Get {
     /**
@@ -2689,10 +2701,11 @@ export namespace cloudkms_v1 {
      * Required list of fields to be updated in this request.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CryptoKeyVersion;
+    requestBody?: Schema$CryptoKeyVersion;
   }
   export interface Params$Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions$Restore {
     /**
@@ -2704,9 +2717,10 @@ export namespace cloudkms_v1 {
      * The resource name of the CryptoKeyVersion to restore.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RestoreCryptoKeyVersionRequest;
+    requestBody?: Schema$RestoreCryptoKeyVersionRequest;
   }
 }

--- a/src/apis/cloudresourcemanager/v1.ts
+++ b/src/apis/cloudresourcemanager/v1.ts
@@ -1859,10 +1859,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource for the `Policy` to clear.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ClearOrgPolicyRequest;
+    requestBody?: Schema$ClearOrgPolicyRequest;
   }
   export interface Params$Resource$Folders$Geteffectiveorgpolicy {
     /**
@@ -1874,10 +1875,11 @@ export namespace cloudresourcemanager_v1 {
      * The name of the resource to start computing the effective `Policy`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetEffectiveOrgPolicyRequest;
+    requestBody?: Schema$GetEffectiveOrgPolicyRequest;
   }
   export interface Params$Resource$Folders$Getorgpolicy {
     /**
@@ -1889,10 +1891,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource the `Policy` is set on.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetOrgPolicyRequest;
+    requestBody?: Schema$GetOrgPolicyRequest;
   }
   export interface Params$Resource$Folders$Listavailableorgpolicyconstraints {
     /**
@@ -1904,10 +1907,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource to list `Constraints` for.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ListAvailableOrgPolicyConstraintsRequest;
+    requestBody?: Schema$ListAvailableOrgPolicyConstraintsRequest;
   }
   export interface Params$Resource$Folders$Listorgpolicies {
     /**
@@ -1919,10 +1923,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource to list Policies for.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ListOrgPoliciesRequest;
+    requestBody?: Schema$ListOrgPoliciesRequest;
   }
   export interface Params$Resource$Folders$Setorgpolicy {
     /**
@@ -1934,10 +1939,11 @@ export namespace cloudresourcemanager_v1 {
      * Resource name of the resource to attach the `Policy`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetOrgPolicyRequest;
+    requestBody?: Schema$SetOrgPolicyRequest;
   }
 
 
@@ -2331,10 +2337,11 @@ export namespace cloudresourcemanager_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Lien;
+    requestBody?: Schema$Lien;
   }
   export interface Params$Resource$Liens$Delete {
     /**
@@ -4002,10 +4009,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource for the `Policy` to clear.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ClearOrgPolicyRequest;
+    requestBody?: Schema$ClearOrgPolicyRequest;
   }
   export interface Params$Resource$Organizations$Get {
     /**
@@ -4029,10 +4037,11 @@ export namespace cloudresourcemanager_v1 {
      * The name of the resource to start computing the effective `Policy`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetEffectiveOrgPolicyRequest;
+    requestBody?: Schema$GetEffectiveOrgPolicyRequest;
   }
   export interface Params$Resource$Organizations$Getiampolicy {
     /**
@@ -4045,10 +4054,11 @@ export namespace cloudresourcemanager_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Organizations$Getorgpolicy {
     /**
@@ -4060,10 +4070,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource the `Policy` is set on.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetOrgPolicyRequest;
+    requestBody?: Schema$GetOrgPolicyRequest;
   }
   export interface Params$Resource$Organizations$Listavailableorgpolicyconstraints {
     /**
@@ -4075,10 +4086,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource to list `Constraints` for.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ListAvailableOrgPolicyConstraintsRequest;
+    requestBody?: Schema$ListAvailableOrgPolicyConstraintsRequest;
   }
   export interface Params$Resource$Organizations$Listorgpolicies {
     /**
@@ -4090,10 +4102,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource to list Policies for.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ListOrgPoliciesRequest;
+    requestBody?: Schema$ListOrgPoliciesRequest;
   }
   export interface Params$Resource$Organizations$Search {
     /**
@@ -4101,10 +4114,11 @@ export namespace cloudresourcemanager_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchOrganizationsRequest;
+    requestBody?: Schema$SearchOrganizationsRequest;
   }
   export interface Params$Resource$Organizations$Setiampolicy {
     /**
@@ -4117,10 +4131,11 @@ export namespace cloudresourcemanager_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Organizations$Setorgpolicy {
     /**
@@ -4132,10 +4147,11 @@ export namespace cloudresourcemanager_v1 {
      * Resource name of the resource to attach the `Policy`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetOrgPolicyRequest;
+    requestBody?: Schema$SetOrgPolicyRequest;
   }
   export interface Params$Resource$Organizations$Testiampermissions {
     /**
@@ -4148,10 +4164,11 @@ export namespace cloudresourcemanager_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -6286,10 +6303,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource for the `Policy` to clear.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ClearOrgPolicyRequest;
+    requestBody?: Schema$ClearOrgPolicyRequest;
   }
   export interface Params$Resource$Projects$Create {
     /**
@@ -6297,10 +6315,11 @@ export namespace cloudresourcemanager_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Project;
+    requestBody?: Schema$Project;
   }
   export interface Params$Resource$Projects$Delete {
     /**
@@ -6334,10 +6353,11 @@ export namespace cloudresourcemanager_v1 {
      * The Project ID (for example, `my-project-123`).  Required.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetAncestryRequest;
+    requestBody?: Schema$GetAncestryRequest;
   }
   export interface Params$Resource$Projects$Geteffectiveorgpolicy {
     /**
@@ -6349,10 +6369,11 @@ export namespace cloudresourcemanager_v1 {
      * The name of the resource to start computing the effective `Policy`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetEffectiveOrgPolicyRequest;
+    requestBody?: Schema$GetEffectiveOrgPolicyRequest;
   }
   export interface Params$Resource$Projects$Getiampolicy {
     /**
@@ -6365,10 +6386,11 @@ export namespace cloudresourcemanager_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Getorgpolicy {
     /**
@@ -6380,10 +6402,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource the `Policy` is set on.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetOrgPolicyRequest;
+    requestBody?: Schema$GetOrgPolicyRequest;
   }
   export interface Params$Resource$Projects$List {
     /**
@@ -6435,10 +6458,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource to list `Constraints` for.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ListAvailableOrgPolicyConstraintsRequest;
+    requestBody?: Schema$ListAvailableOrgPolicyConstraintsRequest;
   }
   export interface Params$Resource$Projects$Listorgpolicies {
     /**
@@ -6450,10 +6474,11 @@ export namespace cloudresourcemanager_v1 {
      * Name of the resource to list Policies for.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ListOrgPoliciesRequest;
+    requestBody?: Schema$ListOrgPoliciesRequest;
   }
   export interface Params$Resource$Projects$Setiampolicy {
     /**
@@ -6466,10 +6491,11 @@ export namespace cloudresourcemanager_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Setorgpolicy {
     /**
@@ -6481,10 +6507,11 @@ export namespace cloudresourcemanager_v1 {
      * Resource name of the resource to attach the `Policy`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetOrgPolicyRequest;
+    requestBody?: Schema$SetOrgPolicyRequest;
   }
   export interface Params$Resource$Projects$Testiampermissions {
     /**
@@ -6497,10 +6524,11 @@ export namespace cloudresourcemanager_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Undelete {
     /**
@@ -6512,10 +6540,11 @@ export namespace cloudresourcemanager_v1 {
      * The project ID (for example, `foo-bar-123`).  Required.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteProjectRequest;
+    requestBody?: Schema$UndeleteProjectRequest;
   }
   export interface Params$Resource$Projects$Update {
     /**
@@ -6527,9 +6556,10 @@ export namespace cloudresourcemanager_v1 {
      * The project ID (for example, `my-project-123`).  Required.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Project;
+    requestBody?: Schema$Project;
   }
 }

--- a/src/apis/cloudresourcemanager/v1beta1.ts
+++ b/src/apis/cloudresourcemanager/v1beta1.ts
@@ -1318,10 +1318,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Organizations$List {
     /**
@@ -1363,10 +1364,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Organizations$Testiampermissions {
     /**
@@ -1379,10 +1381,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Organizations$Update {
     /**
@@ -1396,10 +1399,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * "organizations/[organization_id]". For example, "organizations/1234".
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Organization;
+    requestBody?: Schema$Organization;
   }
 
 
@@ -2722,10 +2726,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * A safety hatch to opt out of the new reliable project creation process.
      */
     useLegacyStack?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Project;
+    requestBody?: Schema$Project;
   }
   export interface Params$Resource$Projects$Delete {
     /**
@@ -2759,10 +2764,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * The Project ID (for example, `my-project-123`).  Required.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetAncestryRequest;
+    requestBody?: Schema$GetAncestryRequest;
   }
   export interface Params$Resource$Projects$Getiampolicy {
     /**
@@ -2775,10 +2781,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$List {
     /**
@@ -2831,10 +2838,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Testiampermissions {
     /**
@@ -2847,10 +2855,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Undelete {
     /**
@@ -2862,10 +2871,11 @@ export namespace cloudresourcemanager_v1beta1 {
      * The project ID (for example, `foo-bar-123`).  Required.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteProjectRequest;
+    requestBody?: Schema$UndeleteProjectRequest;
   }
   export interface Params$Resource$Projects$Update {
     /**
@@ -2877,9 +2887,10 @@ export namespace cloudresourcemanager_v1beta1 {
      * The project ID (for example, `my-project-123`).  Required.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Project;
+    requestBody?: Schema$Project;
   }
 }

--- a/src/apis/cloudresourcemanager/v2.ts
+++ b/src/apis/cloudresourcemanager/v2.ts
@@ -1331,10 +1331,11 @@ export namespace cloudresourcemanager_v2 {
      * `folders/{folder_id}` or `organizations/{org_id}`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
   export interface Params$Resource$Folders$Delete {
     /**
@@ -1371,10 +1372,11 @@ export namespace cloudresourcemanager_v2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Folders$List {
     /**
@@ -1417,10 +1419,11 @@ export namespace cloudresourcemanager_v2 {
      * folders/{folder_id}
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$MoveFolderRequest;
+    requestBody?: Schema$MoveFolderRequest;
   }
   export interface Params$Resource$Folders$Patch {
     /**
@@ -1437,10 +1440,11 @@ export namespace cloudresourcemanager_v2 {
      * Fields to be updated. Only the `display_name` can be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
   export interface Params$Resource$Folders$Search {
     /**
@@ -1448,10 +1452,11 @@ export namespace cloudresourcemanager_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchFoldersRequest;
+    requestBody?: Schema$SearchFoldersRequest;
   }
   export interface Params$Resource$Folders$Setiampolicy {
     /**
@@ -1464,10 +1469,11 @@ export namespace cloudresourcemanager_v2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Folders$Testiampermissions {
     /**
@@ -1480,10 +1486,11 @@ export namespace cloudresourcemanager_v2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Folders$Undelete {
     /**
@@ -1496,9 +1503,10 @@ export namespace cloudresourcemanager_v2 {
      * `folders/{folder_id}`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteFolderRequest;
+    requestBody?: Schema$UndeleteFolderRequest;
   }
 }

--- a/src/apis/cloudresourcemanager/v2beta1.ts
+++ b/src/apis/cloudresourcemanager/v2beta1.ts
@@ -1333,10 +1333,11 @@ export namespace cloudresourcemanager_v2beta1 {
      * `folders/{folder_id}` or `organizations/{org_id}`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
   export interface Params$Resource$Folders$Delete {
     /**
@@ -1373,10 +1374,11 @@ export namespace cloudresourcemanager_v2beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Folders$List {
     /**
@@ -1419,10 +1421,11 @@ export namespace cloudresourcemanager_v2beta1 {
      * folders/{folder_id}
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$MoveFolderRequest;
+    requestBody?: Schema$MoveFolderRequest;
   }
   export interface Params$Resource$Folders$Patch {
     /**
@@ -1439,10 +1442,11 @@ export namespace cloudresourcemanager_v2beta1 {
      * Fields to be updated. Only the `display_name` can be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
   export interface Params$Resource$Folders$Search {
     /**
@@ -1450,10 +1454,11 @@ export namespace cloudresourcemanager_v2beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchFoldersRequest;
+    requestBody?: Schema$SearchFoldersRequest;
   }
   export interface Params$Resource$Folders$Setiampolicy {
     /**
@@ -1466,10 +1471,11 @@ export namespace cloudresourcemanager_v2beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Folders$Testiampermissions {
     /**
@@ -1482,10 +1488,11 @@ export namespace cloudresourcemanager_v2beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Folders$Undelete {
     /**
@@ -1498,9 +1505,10 @@ export namespace cloudresourcemanager_v2beta1 {
      * `folders/{folder_id}`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteFolderRequest;
+    requestBody?: Schema$UndeleteFolderRequest;
   }
 }

--- a/src/apis/cloudshell/v1.ts
+++ b/src/apis/cloudshell/v1.ts
@@ -586,10 +586,11 @@ export namespace cloudshell_v1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Delete {
     /**

--- a/src/apis/cloudshell/v1alpha1.ts
+++ b/src/apis/cloudshell/v1alpha1.ts
@@ -544,10 +544,11 @@ export namespace cloudshell_v1alpha1 {
      * Mask specifying which fields in the environment should be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
   export interface Params$Resource$Users$Environments$Start {
     /**
@@ -561,10 +562,11 @@ export namespace cloudshell_v1alpha1 {
      * `users/someone@example.com/environments/default`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartEnvironmentRequest;
+    requestBody?: Schema$StartEnvironmentRequest;
   }
 
   export class Resource$Users$Environments$Publickeys {
@@ -728,10 +730,11 @@ export namespace cloudshell_v1alpha1 {
      * Parent resource name, e.g. `users/me/environments/default`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreatePublicKeyRequest;
+    requestBody?: Schema$CreatePublicKeyRequest;
   }
   export interface Params$Resource$Users$Environments$Publickeys$Delete {
     /**

--- a/src/apis/cloudtasks/v2beta2.ts
+++ b/src/apis/cloudtasks/v2beta2.ts
@@ -675,7 +675,8 @@ export namespace cloudtasks_v2beta2 {
   /**
    * Rate limits.  This message determines the maximum rate that tasks can be
    * dispatched by a queue, regardless of whether the dispatch is a first task
-   * attempt or a retry.
+   * attempt or a retry.  Note: The debugging command, RunTask, will run a task
+   * even if the queue has reached its RateLimits.
    */
   export interface Schema$RateLimits {
     /**
@@ -706,10 +707,11 @@ export namespace cloudtasks_v2beta2 {
      * dispatched for this queue. After this threshold has been reached, Cloud
      * Tasks stops dispatching tasks until the number of concurrent requests
      * decreases.  If unspecified when the queue is created, Cloud Tasks will
-     * pick the default.   The maximum allowed value is 5,000. -1 indicates no
-     * limit.  This field is output only for [pull
-     * queues](google.cloud.tasks.v2beta2.PullTarget).   This field has the same
-     * meaning as [max_concurrent_requests in
+     * pick the default.   The maximum allowed value is 5,000.  This field is
+     * output only for [pull queues](google.cloud.tasks.v2beta2.PullTarget) and
+     * always -1, which indicates no limit. No other queue types can have
+     * `max_concurrent_tasks` set to -1.   This field has the same meaning as
+     * [max_concurrent_requests in
      * queue.yaml/xml](/appengine/docs/standard/python/config/queueref#max_concurrent_requests).
      */
     maxConcurrentTasks?: number;
@@ -2800,10 +2802,11 @@ export namespace cloudtasks_v2beta2 {
      * ListLocations.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Queue;
+    requestBody?: Schema$Queue;
   }
   export interface Params$Resource$Projects$Locations$Queues$Delete {
     /**
@@ -2840,10 +2843,11 @@ export namespace cloudtasks_v2beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$List {
     /**
@@ -2908,10 +2912,11 @@ export namespace cloudtasks_v2beta2 {
      * empty, then all fields will be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Queue;
+    requestBody?: Schema$Queue;
   }
   export interface Params$Resource$Projects$Locations$Queues$Pause {
     /**
@@ -2924,10 +2929,11 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PauseQueueRequest;
+    requestBody?: Schema$PauseQueueRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Purge {
     /**
@@ -2940,10 +2946,11 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PurgeQueueRequest;
+    requestBody?: Schema$PurgeQueueRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Resume {
     /**
@@ -2956,10 +2963,11 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResumeQueueRequest;
+    requestBody?: Schema$ResumeQueueRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Setiampolicy {
     /**
@@ -2972,10 +2980,11 @@ export namespace cloudtasks_v2beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Testiampermissions {
     /**
@@ -2988,10 +2997,11 @@ export namespace cloudtasks_v2beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Locations$Queues$Tasks {
@@ -4001,20 +4011,19 @@ export namespace cloudtasks_v2beta2 {
 
     /**
      * cloudtasks.projects.locations.queues.tasks.run
-     * @desc Forces a task to run now.  This command is meant to be used for
-     * manual debugging. For example, RunTask can be used to retry a failed task
-     * after a fix has been made or to manually force a task to be dispatched
-     * now.  When this method is called, Cloud Tasks will dispatch the task to
-     * its target, even if the queue is PAUSED.  The dispatched task is
-     * returned. That is, the task that is returned contains the status after
-     * the task is dispatched but before the task is received by its target.  If
-     * Cloud Tasks receives a successful response from the task's handler, then
-     * the task will be deleted; otherwise the task's schedule_time will be
-     * reset to the time that RunTask was called plus the retry delay specified
-     * in the queue and task's RetryConfig.  RunTask returns NOT_FOUND when it
-     * is called on a task that has already succeeded or permanently failed.
-     * FAILED_PRECONDITION is returned when RunTask is called on task that is
-     * dispatched or already running.  RunTask cannot be called on pull tasks.
+     * @desc Forces a task to run now.  When this method is called, Cloud Tasks
+     * will dispatch the task, even if the task is already running, the queue
+     * has reached its RateLimits or is PAUSED.  This command is meant to be
+     * used for manual debugging. For example, RunTask can be used to retry a
+     * failed task after a fix has been made or to manually force a task to be
+     * dispatched now.  The dispatched task is returned. That is, the task that
+     * is returned contains the status after the task is dispatched but before
+     * the task is received by its target.  If Cloud Tasks receives a successful
+     * response from the task's target, then the task will be deleted; otherwise
+     * the task's schedule_time will be reset to the time that RunTask was
+     * called plus the retry delay specified in the queue's RetryConfig. RunTask
+     * returns NOT_FOUND when it is called on a task that has already succeeded
+     * or permanently failed.  RunTask cannot be called on a pull task.
      * @example
      * * // BEFORE RUNNING:
      * // ---------------
@@ -4146,10 +4155,11 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AcknowledgeTaskRequest;
+    requestBody?: Schema$AcknowledgeTaskRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Tasks$Cancellease {
     /**
@@ -4162,10 +4172,11 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelLeaseRequest;
+    requestBody?: Schema$CancelLeaseRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Tasks$Create {
     /**
@@ -4179,10 +4190,11 @@ export namespace cloudtasks_v2beta2 {
      * must already exist.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateTaskRequest;
+    requestBody?: Schema$CreateTaskRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Tasks$Delete {
     /**
@@ -4229,10 +4241,11 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LeaseTasksRequest;
+    requestBody?: Schema$LeaseTasksRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Tasks$List {
     /**
@@ -4290,10 +4303,11 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RenewLeaseRequest;
+    requestBody?: Schema$RenewLeaseRequest;
   }
   export interface Params$Resource$Projects$Locations$Queues$Tasks$Run {
     /**
@@ -4306,9 +4320,10 @@ export namespace cloudtasks_v2beta2 {
      * `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunTaskRequest;
+    requestBody?: Schema$RunTaskRequest;
   }
 }

--- a/src/apis/cloudtrace/v1.ts
+++ b/src/apis/cloudtrace/v1.ts
@@ -89,7 +89,7 @@ export namespace cloudtrace_v1 {
      */
     nextPageToken?: string;
     /**
-     * List of trace records returned.
+     * List of trace records as specified by the view parameter.
      */
     traces?: Schema$Trace[];
   }
@@ -334,10 +334,11 @@ export namespace cloudtrace_v1 {
      * ID of the Cloud project where the trace data is stored.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Traces;
+    requestBody?: Schema$Traces;
   }
 
   export class Resource$Projects$Traces {

--- a/src/apis/cloudtrace/v2.ts
+++ b/src/apis/cloudtrace/v2.ts
@@ -593,10 +593,11 @@ export namespace cloudtrace_v2 {
      * `projects/[PROJECT_ID]`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchWriteSpansRequest;
+    requestBody?: Schema$BatchWriteSpansRequest;
   }
 
   export class Resource$Projects$Traces$Spans {
@@ -692,9 +693,10 @@ export namespace cloudtrace_v2 {
      * array.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Span;
+    requestBody?: Schema$Span;
   }
 }

--- a/src/apis/composer/v1beta1.ts
+++ b/src/apis/composer/v1beta1.ts
@@ -841,10 +841,11 @@ export namespace composer_v1beta1 {
      * `projects/{projectId}/locations/{locationId}`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
   export interface Params$Resource$Projects$Locations$Environments$Delete {
     /**
@@ -977,10 +978,11 @@ export namespace composer_v1beta1 {
      * individual environment variables.</td>  </tr>  </tbody>  </table>
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
 
 

--- a/src/apis/compute/alpha.ts
+++ b/src/apis/compute/alpha.ts
@@ -13233,10 +13233,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Address;
+    requestBody?: Schema$Address;
   }
   export interface Params$Resource$Addresses$List {
     /**
@@ -13327,10 +13328,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Addresses$Testiampermissions {
     /**
@@ -13350,10 +13352,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -14082,10 +14085,11 @@ export namespace compute_alpha {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Autoscalers$List {
     /**
@@ -14176,10 +14180,11 @@ export namespace compute_alpha {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Autoscalers$Testiampermissions {
     /**
@@ -14199,10 +14204,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Autoscalers$Update {
     /**
@@ -14235,10 +14241,11 @@ export namespace compute_alpha {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
 
 
@@ -15068,10 +15075,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SignedUrlKey;
+    requestBody?: Schema$SignedUrlKey;
   }
   export interface Params$Resource$Backendbuckets$Delete {
     /**
@@ -15187,10 +15195,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
   export interface Params$Resource$Backendbuckets$List {
     /**
@@ -15273,10 +15282,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
   export interface Params$Resource$Backendbuckets$Setiampolicy {
     /**
@@ -15292,10 +15302,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Backendbuckets$Testiampermissions {
     /**
@@ -15311,10 +15322,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Backendbuckets$Update {
     /**
@@ -15343,10 +15355,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
 
 
@@ -16272,10 +16285,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SignedUrlKey;
+    requestBody?: Schema$SignedUrlKey;
   }
   export interface Params$Resource$Backendservices$Aggregatedlist {
     /**
@@ -16422,10 +16436,11 @@ export namespace compute_alpha {
      *
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceGroupReference;
+    requestBody?: Schema$ResourceGroupReference;
   }
   export interface Params$Resource$Backendservices$Insert {
     /**
@@ -16450,10 +16465,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Backendservices$List {
     /**
@@ -16536,10 +16552,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Backendservices$Setsecuritypolicy {
     /**
@@ -16569,10 +16586,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicyReference;
+    requestBody?: Schema$SecurityPolicyReference;
   }
   export interface Params$Resource$Backendservices$Testiampermissions {
     /**
@@ -16588,10 +16606,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Backendservices$Update {
     /**
@@ -16620,10 +16639,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
 
 
@@ -17612,10 +17632,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisksAddResourcePoliciesRequest;
+    requestBody?: Schema$DisksAddResourcePoliciesRequest;
   }
   export interface Params$Resource$Disks$Aggregatedlist {
     /**
@@ -17706,10 +17727,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Snapshot;
+    requestBody?: Schema$Snapshot;
   }
   export interface Params$Resource$Disks$Delete {
     /**
@@ -17812,10 +17834,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Disk;
+    requestBody?: Schema$Disk;
   }
   export interface Params$Resource$Disks$List {
     /**
@@ -17906,10 +17929,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisksRemoveResourcePoliciesRequest;
+    requestBody?: Schema$DisksRemoveResourcePoliciesRequest;
   }
   export interface Params$Resource$Disks$Resize {
     /**
@@ -17942,10 +17966,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisksResizeRequest;
+    requestBody?: Schema$DisksResizeRequest;
   }
   export interface Params$Resource$Disks$Setiampolicy {
     /**
@@ -17965,10 +17990,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Disks$Setlabels {
     /**
@@ -18001,10 +18027,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ZoneSetLabelsRequest;
+    requestBody?: Schema$ZoneSetLabelsRequest;
   }
   export interface Params$Resource$Disks$Testiampermissions {
     /**
@@ -18024,10 +18051,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -18955,10 +18983,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
   export interface Params$Resource$Firewalls$List {
     /**
@@ -19041,10 +19070,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
   export interface Params$Resource$Firewalls$Testiampermissions {
     /**
@@ -19060,10 +19090,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Firewalls$Update {
     /**
@@ -19092,10 +19123,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
 
 
@@ -19909,10 +19941,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Forwardingrules$List {
     /**
@@ -20003,10 +20036,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Forwardingrules$Setlabels {
     /**
@@ -20039,10 +20073,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Forwardingrules$Settarget {
     /**
@@ -20075,10 +20110,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
   export interface Params$Resource$Forwardingrules$Testiampermissions {
     /**
@@ -20098,10 +20134,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -20608,10 +20645,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Address;
+    requestBody?: Schema$Address;
   }
   export interface Params$Resource$Globaladdresses$List {
     /**
@@ -20681,10 +20719,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Globaladdresses$Testiampermissions {
     /**
@@ -20700,10 +20739,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -21361,10 +21401,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Globalforwardingrules$List {
     /**
@@ -21447,10 +21488,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Globalforwardingrules$Setlabels {
     /**
@@ -21466,10 +21508,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Globalforwardingrules$Settarget {
     /**
@@ -21498,10 +21541,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
   export interface Params$Resource$Globalforwardingrules$Testiampermissions {
     /**
@@ -21517,10 +21561,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -22762,10 +22807,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Healthchecks$List {
     /**
@@ -22848,10 +22894,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Healthchecks$Testiampermissions {
     /**
@@ -22867,10 +22914,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Healthchecks$Update {
     /**
@@ -22899,10 +22947,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
 
 
@@ -23635,10 +23684,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Host;
+    requestBody?: Schema$Host;
   }
   export interface Params$Resource$Hosts$List {
     /**
@@ -23716,10 +23766,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Hosts$Testiampermissions {
     /**
@@ -23739,10 +23790,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -24682,10 +24734,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
   export interface Params$Resource$Httphealthchecks$List {
     /**
@@ -24768,10 +24821,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
   export interface Params$Resource$Httphealthchecks$Testiampermissions {
     /**
@@ -24787,10 +24841,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Httphealthchecks$Update {
     /**
@@ -24819,10 +24874,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
 
 
@@ -25409,10 +25465,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
   export interface Params$Resource$Httpshealthchecks$List {
     /**
@@ -25495,10 +25552,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
   export interface Params$Resource$Httpshealthchecks$Testiampermissions {
     /**
@@ -25514,10 +25572,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Httpshealthchecks$Update {
     /**
@@ -25546,10 +25605,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
 
 
@@ -26322,10 +26382,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeprecationStatus;
+    requestBody?: Schema$DeprecationStatus;
   }
   export interface Params$Resource$Images$Get {
     /**
@@ -26399,10 +26460,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Image;
+    requestBody?: Schema$Image;
   }
   export interface Params$Resource$Images$List {
     /**
@@ -26472,10 +26534,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Images$Setlabels {
     /**
@@ -26491,10 +26554,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Images$Testiampermissions {
     /**
@@ -26510,10 +26574,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -28240,10 +28305,11 @@ export namespace compute_alpha {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersAbandonInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersAbandonInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Aggregatedlist {
     /**
@@ -28318,10 +28384,11 @@ export namespace compute_alpha {
      * conform to RFC1035.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersApplyUpdatesRequest;
+    requestBody?: Schema$InstanceGroupManagersApplyUpdatesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Delete {
     /**
@@ -28386,10 +28453,11 @@ export namespace compute_alpha {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersDeleteInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersDeleteInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Deleteperinstanceconfigs {
     /**
@@ -28410,10 +28478,11 @@ export namespace compute_alpha {
      * should conform to RFC1035.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersDeletePerInstanceConfigsReq;
+    requestBody?: Schema$InstanceGroupManagersDeletePerInstanceConfigsReq;
   }
   export interface Params$Resource$Instancegroupmanagers$Get {
     /**
@@ -28461,10 +28530,11 @@ export namespace compute_alpha {
      * The name of the zone where you want to create the managed instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Instancegroupmanagers$List {
     /**
@@ -28653,10 +28723,11 @@ export namespace compute_alpha {
      * The name of the zone where you want to create the managed instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Instancegroupmanagers$Recreateinstances {
     /**
@@ -28689,10 +28760,11 @@ export namespace compute_alpha {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersRecreateInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersRecreateInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Resize {
     /**
@@ -28764,10 +28836,11 @@ export namespace compute_alpha {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersResizeAdvancedRequest;
+    requestBody?: Schema$InstanceGroupManagersResizeAdvancedRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Setautohealingpolicies {
     /**
@@ -28800,10 +28873,11 @@ export namespace compute_alpha {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetAutoHealingRequest;
+    requestBody?: Schema$InstanceGroupManagersSetAutoHealingRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Setinstancetemplate {
     /**
@@ -28836,10 +28910,11 @@ export namespace compute_alpha {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
+    requestBody?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Settargetpools {
     /**
@@ -28872,10 +28947,11 @@ export namespace compute_alpha {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
+    requestBody?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Testiampermissions {
     /**
@@ -28895,10 +28971,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Update {
     /**
@@ -28931,10 +29008,11 @@ export namespace compute_alpha {
      * The name of the zone where you want to create the managed instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Instancegroupmanagers$Updateperinstanceconfigs {
     /**
@@ -28968,10 +29046,11 @@ export namespace compute_alpha {
      * should conform to RFC1035.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersUpdatePerInstanceConfigsReq;
+    requestBody?: Schema$InstanceGroupManagersUpdatePerInstanceConfigsReq;
   }
 
 
@@ -29769,10 +29848,11 @@ export namespace compute_alpha {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsAddInstancesRequest;
+    requestBody?: Schema$InstanceGroupsAddInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Aggregatedlist {
     /**
@@ -29906,10 +29986,11 @@ export namespace compute_alpha {
      * The name of the zone where you want to create the instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroup;
+    requestBody?: Schema$InstanceGroup;
   }
   export interface Params$Resource$Instancegroups$List {
     /**
@@ -30031,10 +30112,11 @@ export namespace compute_alpha {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsListInstancesRequest;
+    requestBody?: Schema$InstanceGroupsListInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Removeinstances {
     /**
@@ -30068,10 +30150,11 @@ export namespace compute_alpha {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsRemoveInstancesRequest;
+    requestBody?: Schema$InstanceGroupsRemoveInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Setnamedports {
     /**
@@ -30104,10 +30187,11 @@ export namespace compute_alpha {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsSetNamedPortsRequest;
+    requestBody?: Schema$InstanceGroupsSetNamedPortsRequest;
   }
   export interface Params$Resource$Instancegroups$Testiampermissions {
     /**
@@ -30127,10 +30211,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -32987,10 +33072,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccessConfig;
+    requestBody?: Schema$AccessConfig;
   }
   export interface Params$Resource$Instances$Addresourcepolicies {
     /**
@@ -33023,10 +33109,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesAddResourcePoliciesRequest;
+    requestBody?: Schema$InstancesAddResourcePoliciesRequest;
   }
   export interface Params$Resource$Instances$Aggregatedlist {
     /**
@@ -33118,10 +33205,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AttachedDisk;
+    requestBody?: Schema$AttachedDisk;
   }
   export interface Params$Resource$Instances$Delete {
     /**
@@ -33359,10 +33447,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Instance;
+    requestBody?: Schema$Instance;
   }
   export interface Params$Resource$Instances$List {
     /**
@@ -33516,10 +33605,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesRemoveResourcePoliciesRequest;
+    requestBody?: Schema$InstancesRemoveResourcePoliciesRequest;
   }
   export interface Params$Resource$Instances$Reset {
     /**
@@ -33584,10 +33674,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesResumeRequest;
+    requestBody?: Schema$InstancesResumeRequest;
   }
   export interface Params$Resource$Instances$Setdeletionprotection {
     /**
@@ -33683,10 +33774,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Instances$Setlabels {
     /**
@@ -33719,10 +33811,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetLabelsRequest;
+    requestBody?: Schema$InstancesSetLabelsRequest;
   }
   export interface Params$Resource$Instances$Setmachineresources {
     /**
@@ -33755,10 +33848,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMachineResourcesRequest;
+    requestBody?: Schema$InstancesSetMachineResourcesRequest;
   }
   export interface Params$Resource$Instances$Setmachinetype {
     /**
@@ -33791,10 +33885,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMachineTypeRequest;
+    requestBody?: Schema$InstancesSetMachineTypeRequest;
   }
   export interface Params$Resource$Instances$Setmetadata {
     /**
@@ -33827,10 +33922,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Metadata;
+    requestBody?: Schema$Metadata;
   }
   export interface Params$Resource$Instances$Setmincpuplatform {
     /**
@@ -33863,10 +33959,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMinCpuPlatformRequest;
+    requestBody?: Schema$InstancesSetMinCpuPlatformRequest;
   }
   export interface Params$Resource$Instances$Setscheduling {
     /**
@@ -33899,10 +33996,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Scheduling;
+    requestBody?: Schema$Scheduling;
   }
   export interface Params$Resource$Instances$Setserviceaccount {
     /**
@@ -33935,10 +34033,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetServiceAccountRequest;
+    requestBody?: Schema$InstancesSetServiceAccountRequest;
   }
   export interface Params$Resource$Instances$Setshieldedvmintegritypolicy {
     /**
@@ -33971,10 +34070,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ShieldedVmIntegrityPolicy;
+    requestBody?: Schema$ShieldedVmIntegrityPolicy;
   }
   export interface Params$Resource$Instances$Settags {
     /**
@@ -34007,10 +34107,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Tags;
+    requestBody?: Schema$Tags;
   }
   export interface Params$Resource$Instances$Simulatemaintenanceevent {
     /**
@@ -34094,10 +34195,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesStartWithEncryptionKeyRequest;
+    requestBody?: Schema$InstancesStartWithEncryptionKeyRequest;
   }
   export interface Params$Resource$Instances$Stop {
     /**
@@ -34191,10 +34293,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Instances$Updateaccessconfig {
     /**
@@ -34231,10 +34334,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccessConfig;
+    requestBody?: Schema$AccessConfig;
   }
   export interface Params$Resource$Instances$Updatenetworkinterface {
     /**
@@ -34271,10 +34375,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworkInterface;
+    requestBody?: Schema$NetworkInterface;
   }
   export interface Params$Resource$Instances$Updateshieldedvmconfig {
     /**
@@ -34307,10 +34412,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ShieldedVmConfig;
+    requestBody?: Schema$ShieldedVmConfig;
   }
 
 
@@ -34755,10 +34861,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceTemplate;
+    requestBody?: Schema$InstanceTemplate;
   }
   export interface Params$Resource$Instancetemplates$List {
     /**
@@ -34828,10 +34935,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -35746,10 +35854,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InterconnectAttachment;
+    requestBody?: Schema$InterconnectAttachment;
   }
   export interface Params$Resource$Interconnectattachments$List {
     /**
@@ -35840,10 +35949,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InterconnectAttachment;
+    requestBody?: Schema$InterconnectAttachment;
   }
   export interface Params$Resource$Interconnectattachments$Setiampolicy {
     /**
@@ -35863,10 +35973,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Interconnectattachments$Setlabels {
     /**
@@ -35899,10 +36010,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Interconnectattachments$Testiampermissions {
     /**
@@ -35922,10 +36034,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -36241,10 +36354,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -36982,10 +37096,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Interconnect;
+    requestBody?: Schema$Interconnect;
   }
   export interface Params$Resource$Interconnects$List {
     /**
@@ -37068,10 +37183,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Interconnect;
+    requestBody?: Schema$Interconnect;
   }
   export interface Params$Resource$Interconnects$Setiampolicy {
     /**
@@ -37087,10 +37203,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Interconnects$Setlabels {
     /**
@@ -37106,10 +37223,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Interconnects$Testiampermissions {
     /**
@@ -37125,10 +37243,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -37468,10 +37587,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Licensecodes$Testiampermissions {
     /**
@@ -37487,10 +37607,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -38078,10 +38199,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$License;
+    requestBody?: Schema$License;
   }
   export interface Params$Resource$Licenses$List {
     /**
@@ -38151,10 +38273,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Licenses$Testiampermissions {
     /**
@@ -38170,10 +38293,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -39334,10 +39458,11 @@ export namespace compute_alpha {
      * should comply with RFC1035.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworkEndpointGroupsAttachEndpointsRequest;
+    requestBody?: Schema$NetworkEndpointGroupsAttachEndpointsRequest;
   }
   export interface Params$Resource$Networkendpointgroups$Delete {
     /**
@@ -39406,10 +39531,11 @@ export namespace compute_alpha {
      * should comply with RFC1035.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworkEndpointGroupsDetachEndpointsRequest;
+    requestBody?: Schema$NetworkEndpointGroupsDetachEndpointsRequest;
   }
   export interface Params$Resource$Networkendpointgroups$Get {
     /**
@@ -39459,10 +39585,11 @@ export namespace compute_alpha {
      * It should comply with RFC1035.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworkEndpointGroup;
+    requestBody?: Schema$NetworkEndpointGroup;
   }
   export interface Params$Resource$Networkendpointgroups$List {
     /**
@@ -39586,10 +39713,11 @@ export namespace compute_alpha {
      * should comply with RFC1035.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworkEndpointGroupsListEndpointsRequest;
+    requestBody?: Schema$NetworkEndpointGroupsListEndpointsRequest;
   }
   export interface Params$Resource$Networkendpointgroups$Testiampermissions {
     /**
@@ -39609,10 +39737,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -40368,10 +40497,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworksAddPeeringRequest;
+    requestBody?: Schema$NetworksAddPeeringRequest;
   }
   export interface Params$Resource$Networks$Delete {
     /**
@@ -40439,10 +40569,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Network;
+    requestBody?: Schema$Network;
   }
   export interface Params$Resource$Networks$List {
     /**
@@ -40603,10 +40734,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Network;
+    requestBody?: Schema$Network;
   }
   export interface Params$Resource$Networks$Removepeering {
     /**
@@ -40635,10 +40767,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworksRemovePeeringRequest;
+    requestBody?: Schema$NetworksRemovePeeringRequest;
   }
   export interface Params$Resource$Networks$Switchtocustommode {
     /**
@@ -40682,10 +40815,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -41523,10 +41657,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NodeGroupsAddNodesRequest;
+    requestBody?: Schema$NodeGroupsAddNodesRequest;
   }
   export interface Params$Resource$Nodegroups$Aggregatedlist {
     /**
@@ -41645,10 +41780,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NodeGroupsDeleteNodesRequest;
+    requestBody?: Schema$NodeGroupsDeleteNodesRequest;
   }
   export interface Params$Resource$Nodegroups$Get {
     /**
@@ -41719,10 +41855,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NodeGroup;
+    requestBody?: Schema$NodeGroup;
   }
   export interface Params$Resource$Nodegroups$List {
     /**
@@ -41800,10 +41937,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Nodegroups$Setnodetemplate {
     /**
@@ -41836,10 +41974,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NodeGroupsSetNodeTemplateRequest;
+    requestBody?: Schema$NodeGroupsSetNodeTemplateRequest;
   }
   export interface Params$Resource$Nodegroups$Testiampermissions {
     /**
@@ -41859,10 +41998,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -42613,10 +42753,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NodeTemplate;
+    requestBody?: Schema$NodeTemplate;
   }
   export interface Params$Resource$Nodetemplates$List {
     /**
@@ -42694,10 +42835,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Nodetemplates$Testiampermissions {
     /**
@@ -42717,10 +42859,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -44127,10 +44270,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsDisableXpnResourceRequest;
+    requestBody?: Schema$ProjectsDisableXpnResourceRequest;
   }
   export interface Params$Resource$Projects$Enablexpnhost {
     /**
@@ -44179,10 +44323,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsEnableXpnResourceRequest;
+    requestBody?: Schema$ProjectsEnableXpnResourceRequest;
   }
   export interface Params$Resource$Projects$Get {
     /**
@@ -44259,10 +44404,11 @@ export namespace compute_alpha {
      * Project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsListXpnHostsRequest;
+    requestBody?: Schema$ProjectsListXpnHostsRequest;
   }
   export interface Params$Resource$Projects$Movedisk {
     /**
@@ -44287,10 +44433,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DiskMoveRequest;
+    requestBody?: Schema$DiskMoveRequest;
   }
   export interface Params$Resource$Projects$Moveinstance {
     /**
@@ -44315,10 +44462,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceMoveRequest;
+    requestBody?: Schema$InstanceMoveRequest;
   }
   export interface Params$Resource$Projects$Setcommoninstancemetadata {
     /**
@@ -44343,10 +44491,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Metadata;
+    requestBody?: Schema$Metadata;
   }
   export interface Params$Resource$Projects$Setdefaultnetworktier {
     /**
@@ -44371,10 +44520,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsSetDefaultNetworkTierRequest;
+    requestBody?: Schema$ProjectsSetDefaultNetworkTierRequest;
   }
   export interface Params$Resource$Projects$Setdefaultserviceaccount {
     /**
@@ -44399,10 +44549,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsSetDefaultServiceAccountRequest;
+    requestBody?: Schema$ProjectsSetDefaultServiceAccountRequest;
   }
   export interface Params$Resource$Projects$Setusageexportbucket {
     /**
@@ -44427,10 +44578,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UsageExportLocation;
+    requestBody?: Schema$UsageExportLocation;
   }
 
 
@@ -45035,10 +45187,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Regionautoscalers$List {
     /**
@@ -45129,10 +45282,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Regionautoscalers$Testiampermissions {
     /**
@@ -45152,10 +45306,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regionautoscalers$Update {
     /**
@@ -45188,10 +45343,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
 
 
@@ -45871,10 +46027,11 @@ export namespace compute_alpha {
      * Name of the region scoping this request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceGroupReference;
+    requestBody?: Schema$ResourceGroupReference;
   }
   export interface Params$Resource$Regionbackendservices$Insert {
     /**
@@ -45903,10 +46060,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Regionbackendservices$List {
     /**
@@ -45997,10 +46155,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Regionbackendservices$Testiampermissions {
     /**
@@ -46020,10 +46179,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regionbackendservices$Update {
     /**
@@ -46056,10 +46216,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
 
 
@@ -46539,10 +46700,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Commitment;
+    requestBody?: Schema$Commitment;
   }
   export interface Params$Resource$Regioncommitments$List {
     /**
@@ -46620,10 +46782,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -47252,10 +47415,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Snapshot;
+    requestBody?: Schema$Snapshot;
   }
   export interface Params$Resource$Regiondisks$Delete {
     /**
@@ -47339,10 +47503,11 @@ export namespace compute_alpha {
      * Optional. Source image to restore onto a disk.
      */
     sourceImage?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Disk;
+    requestBody?: Schema$Disk;
   }
   export interface Params$Resource$Regiondisks$List {
     /**
@@ -47433,10 +47598,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionDisksResizeRequest;
+    requestBody?: Schema$RegionDisksResizeRequest;
   }
   export interface Params$Resource$Regiondisks$Setlabels {
     /**
@@ -47469,10 +47635,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Regiondisks$Testiampermissions {
     /**
@@ -47492,10 +47659,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -48334,10 +48502,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Regionhealthchecks$List {
     /**
@@ -48428,10 +48597,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Regionhealthchecks$Testiampermissions {
     /**
@@ -48451,10 +48621,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regionhealthchecks$Update {
     /**
@@ -48487,10 +48658,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
 
 
@@ -50069,10 +50241,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersAbandonInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersAbandonInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Applyupdatestoinstances {
     /**
@@ -50092,10 +50265,11 @@ export namespace compute_alpha {
      * Name of the region scoping this request, should conform to RFC1035.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersApplyUpdatesRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersApplyUpdatesRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Delete {
     /**
@@ -50160,10 +50334,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersDeleteInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersDeleteInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Deleteperinstanceconfigs {
     /**
@@ -50183,10 +50358,11 @@ export namespace compute_alpha {
      * Name of the region scoping this request, should conform to RFC1035.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagerDeleteInstanceConfigReq;
+    requestBody?: Schema$RegionInstanceGroupManagerDeleteInstanceConfigReq;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Get {
     /**
@@ -50234,10 +50410,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$List {
     /**
@@ -50425,10 +50602,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Recreateinstances {
     /**
@@ -50461,10 +50639,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersRecreateRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersRecreateRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Resize {
     /**
@@ -50533,10 +50712,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetAutoHealingRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetAutoHealingRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Setinstancetemplate {
     /**
@@ -50569,10 +50749,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetTemplateRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetTemplateRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Settargetpools {
     /**
@@ -50605,10 +50786,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetTargetPoolsRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetTargetPoolsRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Testiampermissions {
     /**
@@ -50628,10 +50810,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Update {
     /**
@@ -50664,10 +50847,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Updateperinstanceconfigs {
     /**
@@ -50687,10 +50871,11 @@ export namespace compute_alpha {
      * Name of the region scoping this request, should conform to RFC1035.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagerUpdateInstanceConfigReq;
+    requestBody?: Schema$RegionInstanceGroupManagerUpdateInstanceConfigReq;
   }
 
 
@@ -51227,10 +51412,11 @@ export namespace compute_alpha {
      * Name of the region scoping this request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupsListInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupsListInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroups$Setnamedports {
     /**
@@ -51264,10 +51450,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupsSetNamedPortsRequest;
+    requestBody?: Schema$RegionInstanceGroupsSetNamedPortsRequest;
   }
   export interface Params$Resource$Regioninstancegroups$Testiampermissions {
     /**
@@ -51287,10 +51474,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -52459,10 +52647,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpProxy;
+    requestBody?: Schema$TargetHttpProxy;
   }
   export interface Params$Resource$Regiontargethttpproxies$List {
     /**
@@ -52553,10 +52742,11 @@ export namespace compute_alpha {
      * Name of the TargetHttpProxy to set a URL map for.
      */
     targetHttpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapReference;
+    requestBody?: Schema$UrlMapReference;
   }
   export interface Params$Resource$Regiontargethttpproxies$Testiampermissions {
     /**
@@ -52576,10 +52766,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -53242,10 +53433,11 @@ export namespace compute_alpha {
      * idempotency.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Regionurlmaps$List {
     /**
@@ -53328,10 +53520,11 @@ export namespace compute_alpha {
      * Name of the UrlMap resource to patch.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Regionurlmaps$Testiampermissions {
     /**
@@ -53351,10 +53544,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regionurlmaps$Update {
     /**
@@ -53379,10 +53573,11 @@ export namespace compute_alpha {
      * Name of the UrlMap resource to update.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Regionurlmaps$Validate {
     /**
@@ -53402,10 +53597,11 @@ export namespace compute_alpha {
      * Name of the UrlMap resource to be validated as.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionUrlMapsValidateRequest;
+    requestBody?: Schema$RegionUrlMapsValidateRequest;
   }
 
 
@@ -54157,10 +54353,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourcePolicy;
+    requestBody?: Schema$ResourcePolicy;
   }
   export interface Params$Resource$Resourcepolicies$List {
     /**
@@ -54238,10 +54435,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Resourcepolicies$Testiampermissions {
     /**
@@ -54261,10 +54459,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -55150,10 +55349,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$List {
     /**
@@ -55244,10 +55444,11 @@ export namespace compute_alpha {
      * Name of the Router resource to patch.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$Preview {
     /**
@@ -55267,10 +55468,11 @@ export namespace compute_alpha {
      * Name of the Router resource to query.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$Testiampermissions {
     /**
@@ -55290,10 +55492,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Routers$Update {
     /**
@@ -55326,10 +55529,11 @@ export namespace compute_alpha {
      * Name of the Router resource to update.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
 
 
@@ -55754,10 +55958,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Route;
+    requestBody?: Schema$Route;
   }
   export interface Params$Resource$Routes$List {
     /**
@@ -55827,10 +56032,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -56578,10 +56784,11 @@ export namespace compute_alpha {
      * If true, the request will not be committed.
      */
     validateOnly?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicyRule;
+    requestBody?: Schema$SecurityPolicyRule;
   }
   export interface Params$Resource$Securitypolicies$Delete {
     /**
@@ -56672,10 +56879,11 @@ export namespace compute_alpha {
      * If true, the request will not be committed.
      */
     validateOnly?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicy;
+    requestBody?: Schema$SecurityPolicy;
   }
   export interface Params$Resource$Securitypolicies$List {
     /**
@@ -56758,10 +56966,11 @@ export namespace compute_alpha {
      * Name of the security policy to update.
      */
     securityPolicy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicy;
+    requestBody?: Schema$SecurityPolicy;
   }
   export interface Params$Resource$Securitypolicies$Patchrule {
     /**
@@ -56785,10 +56994,11 @@ export namespace compute_alpha {
      * If true, the request will not be committed.
      */
     validateOnly?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicyRule;
+    requestBody?: Schema$SecurityPolicyRule;
   }
   export interface Params$Resource$Securitypolicies$Removerule {
     /**
@@ -56823,10 +57033,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -57463,10 +57674,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Snapshots$Setlabels {
     /**
@@ -57482,10 +57694,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Snapshots$Testiampermissions {
     /**
@@ -57501,10 +57714,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -57941,10 +58155,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslCertificate;
+    requestBody?: Schema$SslCertificate;
   }
   export interface Params$Resource$Sslcertificates$List {
     /**
@@ -58014,10 +58229,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -58610,10 +58826,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicy;
+    requestBody?: Schema$SslPolicy;
   }
   export interface Params$Resource$Sslpolicies$List {
     /**
@@ -58751,10 +58968,11 @@ export namespace compute_alpha {
      * and comply with RFC1035.
      */
     sslPolicy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicy;
+    requestBody?: Schema$SslPolicy;
   }
   export interface Params$Resource$Sslpolicies$Testiampermissions {
     /**
@@ -58770,10 +58988,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -59787,10 +60006,11 @@ export namespace compute_alpha {
      * Name of the Subnetwork resource to update.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubnetworksExpandIpCidrRangeRequest;
+    requestBody?: Schema$SubnetworksExpandIpCidrRangeRequest;
   }
   export interface Params$Resource$Subnetworks$Get {
     /**
@@ -59857,10 +60077,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subnetwork;
+    requestBody?: Schema$Subnetwork;
   }
   export interface Params$Resource$Subnetworks$List {
     /**
@@ -60005,10 +60226,11 @@ export namespace compute_alpha {
      * Name of the Subnetwork resource to patch.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subnetwork;
+    requestBody?: Schema$Subnetwork;
   }
   export interface Params$Resource$Subnetworks$Setiampolicy {
     /**
@@ -60028,10 +60250,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Subnetworks$Setprivateipgoogleaccess {
     /**
@@ -60064,10 +60287,11 @@ export namespace compute_alpha {
      * Name of the Subnetwork resource.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubnetworksSetPrivateIpGoogleAccessRequest;
+    requestBody?: Schema$SubnetworksSetPrivateIpGoogleAccessRequest;
   }
   export interface Params$Resource$Subnetworks$Testiampermissions {
     /**
@@ -60087,10 +60311,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -60737,10 +60962,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpProxy;
+    requestBody?: Schema$TargetHttpProxy;
   }
   export interface Params$Resource$Targethttpproxies$List {
     /**
@@ -60823,10 +61049,11 @@ export namespace compute_alpha {
      * Name of the TargetHttpProxy to set a URL map for.
      */
     targetHttpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapReference;
+    requestBody?: Schema$UrlMapReference;
   }
   export interface Params$Resource$Targethttpproxies$Testiampermissions {
     /**
@@ -60842,10 +61069,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -61578,10 +61806,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxy;
+    requestBody?: Schema$TargetHttpsProxy;
   }
   export interface Params$Resource$Targethttpsproxies$List {
     /**
@@ -61665,10 +61894,11 @@ export namespace compute_alpha {
      * for. The name should conform to RFC1035.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxiesSetQuicOverrideRequest;
+    requestBody?: Schema$TargetHttpsProxiesSetQuicOverrideRequest;
   }
   export interface Params$Resource$Targethttpsproxies$Setsslcertificates {
     /**
@@ -61698,10 +61928,11 @@ export namespace compute_alpha {
      * for.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxiesSetSslCertificatesRequest;
+    requestBody?: Schema$TargetHttpsProxiesSetSslCertificatesRequest;
   }
   export interface Params$Resource$Targethttpsproxies$Setsslpolicy {
     /**
@@ -61731,10 +61962,11 @@ export namespace compute_alpha {
      * name must be 1-63 characters long, and comply with RFC1035.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicyReference;
+    requestBody?: Schema$SslPolicyReference;
   }
   export interface Params$Resource$Targethttpsproxies$Seturlmap {
     /**
@@ -61763,10 +61995,11 @@ export namespace compute_alpha {
      * Name of the TargetHttpsProxy resource whose URL map is to be set.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapReference;
+    requestBody?: Schema$UrlMapReference;
   }
   export interface Params$Resource$Targethttpsproxies$Testiampermissions {
     /**
@@ -61782,10 +62015,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -62376,10 +62610,11 @@ export namespace compute_alpha {
      * Name of the zone scoping this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetInstance;
+    requestBody?: Schema$TargetInstance;
   }
   export interface Params$Resource$Targetinstances$List {
     /**
@@ -62457,10 +62692,11 @@ export namespace compute_alpha {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -63381,10 +63617,11 @@ export namespace compute_alpha {
      * Name of the target pool to add a health check to.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsAddHealthCheckRequest;
+    requestBody?: Schema$TargetPoolsAddHealthCheckRequest;
   }
   export interface Params$Resource$Targetpools$Addinstance {
     /**
@@ -63417,10 +63654,11 @@ export namespace compute_alpha {
      * Name of the TargetPool resource to add instances to.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsAddInstanceRequest;
+    requestBody?: Schema$TargetPoolsAddInstanceRequest;
   }
   export interface Params$Resource$Targetpools$Aggregatedlist {
     /**
@@ -63545,10 +63783,11 @@ export namespace compute_alpha {
      * Name of the TargetPool resource to which the queried instance belongs.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceReference;
+    requestBody?: Schema$InstanceReference;
   }
   export interface Params$Resource$Targetpools$Insert {
     /**
@@ -63577,10 +63816,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPool;
+    requestBody?: Schema$TargetPool;
   }
   export interface Params$Resource$Targetpools$List {
     /**
@@ -63671,10 +63911,11 @@ export namespace compute_alpha {
      * Name of the target pool to remove health checks from.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsRemoveHealthCheckRequest;
+    requestBody?: Schema$TargetPoolsRemoveHealthCheckRequest;
   }
   export interface Params$Resource$Targetpools$Removeinstance {
     /**
@@ -63707,10 +63948,11 @@ export namespace compute_alpha {
      * Name of the TargetPool resource to remove instances from.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsRemoveInstanceRequest;
+    requestBody?: Schema$TargetPoolsRemoveInstanceRequest;
   }
   export interface Params$Resource$Targetpools$Setbackup {
     /**
@@ -63747,10 +63989,11 @@ export namespace compute_alpha {
      * Name of the TargetPool resource to set a backup pool for.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
   export interface Params$Resource$Targetpools$Testiampermissions {
     /**
@@ -63770,10 +64013,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -64501,10 +64745,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxy;
+    requestBody?: Schema$TargetSslProxy;
   }
   export interface Params$Resource$Targetsslproxies$List {
     /**
@@ -64588,10 +64833,11 @@ export namespace compute_alpha {
      * be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetBackendServiceRequest;
+    requestBody?: Schema$TargetSslProxiesSetBackendServiceRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setproxyheader {
     /**
@@ -64620,10 +64866,11 @@ export namespace compute_alpha {
      * Name of the TargetSslProxy resource whose ProxyHeader is to be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetProxyHeaderRequest;
+    requestBody?: Schema$TargetSslProxiesSetProxyHeaderRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setsslcertificates {
     /**
@@ -64653,10 +64900,11 @@ export namespace compute_alpha {
      * be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetSslCertificatesRequest;
+    requestBody?: Schema$TargetSslProxiesSetSslCertificatesRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setsslpolicy {
     /**
@@ -64686,10 +64934,11 @@ export namespace compute_alpha {
      * name must be 1-63 characters long, and comply with RFC1035.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicyReference;
+    requestBody?: Schema$SslPolicyReference;
   }
   export interface Params$Resource$Targetsslproxies$Testiampermissions {
     /**
@@ -64705,10 +64954,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -65289,10 +65539,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxy;
+    requestBody?: Schema$TargetTcpProxy;
   }
   export interface Params$Resource$Targettcpproxies$List {
     /**
@@ -65376,10 +65627,11 @@ export namespace compute_alpha {
      * be set.
      */
     targetTcpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxiesSetBackendServiceRequest;
+    requestBody?: Schema$TargetTcpProxiesSetBackendServiceRequest;
   }
   export interface Params$Resource$Targettcpproxies$Setproxyheader {
     /**
@@ -65408,10 +65660,11 @@ export namespace compute_alpha {
      * Name of the TargetTcpProxy resource whose ProxyHeader is to be set.
      */
     targetTcpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxiesSetProxyHeaderRequest;
+    requestBody?: Schema$TargetTcpProxiesSetProxyHeaderRequest;
   }
   export interface Params$Resource$Targettcpproxies$Testiampermissions {
     /**
@@ -65427,10 +65680,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -66096,10 +66350,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetVpnGateway;
+    requestBody?: Schema$TargetVpnGateway;
   }
   export interface Params$Resource$Targetvpngateways$List {
     /**
@@ -66190,10 +66445,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Targetvpngateways$Testiampermissions {
     /**
@@ -66213,10 +66469,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -66931,10 +67188,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Invalidatecache {
     /**
@@ -66963,10 +67221,11 @@ export namespace compute_alpha {
      * Name of the UrlMap scoping this request.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CacheInvalidationRule;
+    requestBody?: Schema$CacheInvalidationRule;
   }
   export interface Params$Resource$Urlmaps$List {
     /**
@@ -67049,10 +67308,11 @@ export namespace compute_alpha {
      * Name of the UrlMap resource to patch.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Testiampermissions {
     /**
@@ -67068,10 +67328,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Urlmaps$Update {
     /**
@@ -67100,10 +67361,11 @@ export namespace compute_alpha {
      * Name of the UrlMap resource to update.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Validate {
     /**
@@ -67119,10 +67381,11 @@ export namespace compute_alpha {
      * Name of the UrlMap resource to be validated as.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapsValidateRequest;
+    requestBody?: Schema$UrlMapsValidateRequest;
   }
 
 
@@ -67775,10 +68038,11 @@ export namespace compute_alpha {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VpnTunnel;
+    requestBody?: Schema$VpnTunnel;
   }
   export interface Params$Resource$Vpntunnels$List {
     /**
@@ -67869,10 +68133,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Vpntunnels$Testiampermissions {
     /**
@@ -67892,10 +68157,11 @@ export namespace compute_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 

--- a/src/apis/compute/beta.ts
+++ b/src/apis/compute/beta.ts
@@ -11476,10 +11476,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Address;
+    requestBody?: Schema$Address;
   }
   export interface Params$Resource$Addresses$List {
     /**
@@ -11570,10 +11571,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Addresses$Testiampermissions {
     /**
@@ -11593,10 +11595,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -12820,10 +12823,11 @@ export namespace compute_beta {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Autoscalers$List {
     /**
@@ -12914,10 +12918,11 @@ export namespace compute_beta {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Autoscalers$Testiampermissions {
     /**
@@ -12937,10 +12942,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Autoscalers$Update {
     /**
@@ -12973,10 +12979,11 @@ export namespace compute_beta {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
 
 
@@ -13955,10 +13962,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SignedUrlKey;
+    requestBody?: Schema$SignedUrlKey;
   }
   export interface Params$Resource$Backendbuckets$Delete {
     /**
@@ -14059,10 +14067,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
   export interface Params$Resource$Backendbuckets$List {
     /**
@@ -14145,10 +14154,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
   export interface Params$Resource$Backendbuckets$Update {
     /**
@@ -14177,10 +14187,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
 
 
@@ -15715,10 +15726,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SignedUrlKey;
+    requestBody?: Schema$SignedUrlKey;
   }
   export interface Params$Resource$Backendservices$Aggregatedlist {
     /**
@@ -15865,10 +15877,11 @@ export namespace compute_beta {
      *
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceGroupReference;
+    requestBody?: Schema$ResourceGroupReference;
   }
   export interface Params$Resource$Backendservices$Insert {
     /**
@@ -15893,10 +15906,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Backendservices$List {
     /**
@@ -15979,10 +15993,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Backendservices$Setsecuritypolicy {
     /**
@@ -16012,10 +16027,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicyReference;
+    requestBody?: Schema$SecurityPolicyReference;
   }
   export interface Params$Resource$Backendservices$Testiampermissions {
     /**
@@ -16031,10 +16047,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Backendservices$Update {
     /**
@@ -16063,10 +16080,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
 
 
@@ -17387,10 +17405,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Snapshot;
+    requestBody?: Schema$Snapshot;
   }
   export interface Params$Resource$Disks$Delete {
     /**
@@ -17474,10 +17493,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Disk;
+    requestBody?: Schema$Disk;
   }
   export interface Params$Resource$Disks$List {
     /**
@@ -17568,10 +17588,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisksResizeRequest;
+    requestBody?: Schema$DisksResizeRequest;
   }
   export interface Params$Resource$Disks$Setlabels {
     /**
@@ -17604,10 +17625,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ZoneSetLabelsRequest;
+    requestBody?: Schema$ZoneSetLabelsRequest;
   }
   export interface Params$Resource$Disks$Testiampermissions {
     /**
@@ -17627,10 +17649,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -19172,10 +19195,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
   export interface Params$Resource$Firewalls$List {
     /**
@@ -19258,10 +19282,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
   export interface Params$Resource$Firewalls$Testiampermissions {
     /**
@@ -19277,10 +19302,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Firewalls$Update {
     /**
@@ -19309,10 +19335,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
 
 
@@ -20554,10 +20581,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Forwardingrules$List {
     /**
@@ -20648,10 +20676,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Forwardingrules$Settarget {
     /**
@@ -20684,10 +20713,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
   export interface Params$Resource$Forwardingrules$Testiampermissions {
     /**
@@ -20707,10 +20737,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -21570,10 +21601,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Address;
+    requestBody?: Schema$Address;
   }
   export interface Params$Resource$Globaladdresses$List {
     /**
@@ -21643,10 +21675,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Globaladdresses$Testiampermissions {
     /**
@@ -21662,10 +21695,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -22660,10 +22694,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Globalforwardingrules$List {
     /**
@@ -22733,10 +22768,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Globalforwardingrules$Settarget {
     /**
@@ -22765,10 +22801,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
   export interface Params$Resource$Globalforwardingrules$Testiampermissions {
     /**
@@ -22784,10 +22821,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -24461,10 +24499,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Healthchecks$List {
     /**
@@ -24547,10 +24586,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Healthchecks$Testiampermissions {
     /**
@@ -24566,10 +24606,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Healthchecks$Update {
     /**
@@ -24598,10 +24639,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
 
 
@@ -25606,10 +25648,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
   export interface Params$Resource$Httphealthchecks$List {
     /**
@@ -25692,10 +25735,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
   export interface Params$Resource$Httphealthchecks$Testiampermissions {
     /**
@@ -25711,10 +25755,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Httphealthchecks$Update {
     /**
@@ -25743,10 +25788,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
 
 
@@ -26752,10 +26798,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
   export interface Params$Resource$Httpshealthchecks$List {
     /**
@@ -26838,10 +26885,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
   export interface Params$Resource$Httpshealthchecks$Testiampermissions {
     /**
@@ -26857,10 +26905,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Httpshealthchecks$Update {
     /**
@@ -26889,10 +26938,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
 
 
@@ -27995,10 +28045,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeprecationStatus;
+    requestBody?: Schema$DeprecationStatus;
   }
   export interface Params$Resource$Images$Get {
     /**
@@ -28057,10 +28108,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Image;
+    requestBody?: Schema$Image;
   }
   export interface Params$Resource$Images$List {
     /**
@@ -28130,10 +28182,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Images$Testiampermissions {
     /**
@@ -28149,10 +28202,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -30646,10 +30700,11 @@ export namespace compute_beta {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersAbandonInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersAbandonInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Aggregatedlist {
     /**
@@ -30768,10 +30823,11 @@ export namespace compute_beta {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersDeleteInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersDeleteInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Get {
     /**
@@ -30819,10 +30875,11 @@ export namespace compute_beta {
      * The name of the zone where you want to create the managed instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Instancegroupmanagers$List {
     /**
@@ -30948,10 +31005,11 @@ export namespace compute_beta {
      * The name of the zone where you want to create the managed instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Instancegroupmanagers$Recreateinstances {
     /**
@@ -30984,10 +31042,11 @@ export namespace compute_beta {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersRecreateInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersRecreateInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Resize {
     /**
@@ -31059,10 +31118,11 @@ export namespace compute_beta {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersResizeAdvancedRequest;
+    requestBody?: Schema$InstanceGroupManagersResizeAdvancedRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Setautohealingpolicies {
     /**
@@ -31095,10 +31155,11 @@ export namespace compute_beta {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetAutoHealingRequest;
+    requestBody?: Schema$InstanceGroupManagersSetAutoHealingRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Setinstancetemplate {
     /**
@@ -31131,10 +31192,11 @@ export namespace compute_beta {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
+    requestBody?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Settargetpools {
     /**
@@ -31167,10 +31229,11 @@ export namespace compute_beta {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
+    requestBody?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Testiampermissions {
     /**
@@ -31190,10 +31253,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Update {
     /**
@@ -31226,10 +31290,11 @@ export namespace compute_beta {
      * The name of the zone where you want to create the managed instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
 
 
@@ -32671,10 +32736,11 @@ export namespace compute_beta {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsAddInstancesRequest;
+    requestBody?: Schema$InstanceGroupsAddInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Aggregatedlist {
     /**
@@ -32808,10 +32874,11 @@ export namespace compute_beta {
      * The name of the zone where you want to create the instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroup;
+    requestBody?: Schema$InstanceGroup;
   }
   export interface Params$Resource$Instancegroups$List {
     /**
@@ -32933,10 +33000,11 @@ export namespace compute_beta {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsListInstancesRequest;
+    requestBody?: Schema$InstanceGroupsListInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Removeinstances {
     /**
@@ -32970,10 +33038,11 @@ export namespace compute_beta {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsRemoveInstancesRequest;
+    requestBody?: Schema$InstanceGroupsRemoveInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Setnamedports {
     /**
@@ -33006,10 +33075,11 @@ export namespace compute_beta {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsSetNamedPortsRequest;
+    requestBody?: Schema$InstanceGroupsSetNamedPortsRequest;
   }
   export interface Params$Resource$Instancegroups$Testiampermissions {
     /**
@@ -33029,10 +33099,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -36978,10 +37049,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccessConfig;
+    requestBody?: Schema$AccessConfig;
   }
   export interface Params$Resource$Instances$Aggregatedlist {
     /**
@@ -37073,10 +37145,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AttachedDisk;
+    requestBody?: Schema$AttachedDisk;
   }
   export interface Params$Resource$Instances$Delete {
     /**
@@ -37272,10 +37345,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Instance;
+    requestBody?: Schema$Instance;
   }
   export interface Params$Resource$Instances$List {
     /**
@@ -37537,10 +37611,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetLabelsRequest;
+    requestBody?: Schema$InstancesSetLabelsRequest;
   }
   export interface Params$Resource$Instances$Setmachineresources {
     /**
@@ -37573,10 +37648,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMachineResourcesRequest;
+    requestBody?: Schema$InstancesSetMachineResourcesRequest;
   }
   export interface Params$Resource$Instances$Setmachinetype {
     /**
@@ -37609,10 +37685,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMachineTypeRequest;
+    requestBody?: Schema$InstancesSetMachineTypeRequest;
   }
   export interface Params$Resource$Instances$Setmetadata {
     /**
@@ -37645,10 +37722,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Metadata;
+    requestBody?: Schema$Metadata;
   }
   export interface Params$Resource$Instances$Setmincpuplatform {
     /**
@@ -37681,10 +37759,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMinCpuPlatformRequest;
+    requestBody?: Schema$InstancesSetMinCpuPlatformRequest;
   }
   export interface Params$Resource$Instances$Setscheduling {
     /**
@@ -37717,10 +37796,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Scheduling;
+    requestBody?: Schema$Scheduling;
   }
   export interface Params$Resource$Instances$Setserviceaccount {
     /**
@@ -37753,10 +37833,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetServiceAccountRequest;
+    requestBody?: Schema$InstancesSetServiceAccountRequest;
   }
   export interface Params$Resource$Instances$Settags {
     /**
@@ -37789,10 +37870,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Tags;
+    requestBody?: Schema$Tags;
   }
   export interface Params$Resource$Instances$Simulatemaintenanceevent {
     /**
@@ -37876,10 +37958,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesStartWithEncryptionKeyRequest;
+    requestBody?: Schema$InstancesStartWithEncryptionKeyRequest;
   }
   export interface Params$Resource$Instances$Stop {
     /**
@@ -37931,10 +38014,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Instances$Updateaccessconfig {
     /**
@@ -37971,10 +38055,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccessConfig;
+    requestBody?: Schema$AccessConfig;
   }
   export interface Params$Resource$Instances$Updatenetworkinterface {
     /**
@@ -38011,10 +38096,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworkInterface;
+    requestBody?: Schema$NetworkInterface;
   }
 
 
@@ -38752,10 +38838,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceTemplate;
+    requestBody?: Schema$InstanceTemplate;
   }
   export interface Params$Resource$Instancetemplates$List {
     /**
@@ -38825,10 +38912,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -39955,10 +40043,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InterconnectAttachment;
+    requestBody?: Schema$InterconnectAttachment;
   }
   export interface Params$Resource$Interconnectattachments$List {
     /**
@@ -40049,10 +40138,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InterconnectAttachment;
+    requestBody?: Schema$InterconnectAttachment;
   }
   export interface Params$Resource$Interconnectattachments$Setlabels {
     /**
@@ -40085,10 +40175,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Interconnectattachments$Testiampermissions {
     /**
@@ -40108,10 +40199,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -41397,10 +41489,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Interconnect;
+    requestBody?: Schema$Interconnect;
   }
   export interface Params$Resource$Interconnects$List {
     /**
@@ -41483,10 +41576,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Interconnect;
+    requestBody?: Schema$Interconnect;
   }
   export interface Params$Resource$Interconnects$Setlabels {
     /**
@@ -41502,10 +41596,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Interconnects$Testiampermissions {
     /**
@@ -41521,10 +41616,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -42034,10 +42130,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$License;
+    requestBody?: Schema$License;
   }
   export interface Params$Resource$Licenses$List {
     /**
@@ -43858,10 +43955,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworksAddPeeringRequest;
+    requestBody?: Schema$NetworksAddPeeringRequest;
   }
   export interface Params$Resource$Networks$Delete {
     /**
@@ -43929,10 +44027,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Network;
+    requestBody?: Schema$Network;
   }
   export interface Params$Resource$Networks$List {
     /**
@@ -44015,10 +44114,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Network;
+    requestBody?: Schema$Network;
   }
   export interface Params$Resource$Networks$Removepeering {
     /**
@@ -44047,10 +44147,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworksRemovePeeringRequest;
+    requestBody?: Schema$NetworksRemovePeeringRequest;
   }
   export interface Params$Resource$Networks$Switchtocustommode {
     /**
@@ -44094,10 +44195,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -45759,10 +45861,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsDisableXpnResourceRequest;
+    requestBody?: Schema$ProjectsDisableXpnResourceRequest;
   }
   export interface Params$Resource$Projects$Enablexpnhost {
     /**
@@ -45811,10 +45914,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsEnableXpnResourceRequest;
+    requestBody?: Schema$ProjectsEnableXpnResourceRequest;
   }
   export interface Params$Resource$Projects$Get {
     /**
@@ -45891,10 +45995,11 @@ export namespace compute_beta {
      * Project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsListXpnHostsRequest;
+    requestBody?: Schema$ProjectsListXpnHostsRequest;
   }
   export interface Params$Resource$Projects$Movedisk {
     /**
@@ -45919,10 +46024,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DiskMoveRequest;
+    requestBody?: Schema$DiskMoveRequest;
   }
   export interface Params$Resource$Projects$Moveinstance {
     /**
@@ -45947,10 +46053,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceMoveRequest;
+    requestBody?: Schema$InstanceMoveRequest;
   }
   export interface Params$Resource$Projects$Setcommoninstancemetadata {
     /**
@@ -45975,10 +46082,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Metadata;
+    requestBody?: Schema$Metadata;
   }
   export interface Params$Resource$Projects$Setdefaultnetworktier {
     /**
@@ -46003,10 +46111,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsSetDefaultNetworkTierRequest;
+    requestBody?: Schema$ProjectsSetDefaultNetworkTierRequest;
   }
   export interface Params$Resource$Projects$Setusageexportbucket {
     /**
@@ -46031,10 +46140,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UsageExportLocation;
+    requestBody?: Schema$UsageExportLocation;
   }
 
 
@@ -47071,10 +47181,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Regionautoscalers$List {
     /**
@@ -47165,10 +47276,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Regionautoscalers$Testiampermissions {
     /**
@@ -47188,10 +47300,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regionautoscalers$Update {
     /**
@@ -47224,10 +47337,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
 
 
@@ -48410,10 +48524,11 @@ export namespace compute_beta {
      * Name of the region scoping this request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceGroupReference;
+    requestBody?: Schema$ResourceGroupReference;
   }
   export interface Params$Resource$Regionbackendservices$Insert {
     /**
@@ -48442,10 +48557,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Regionbackendservices$List {
     /**
@@ -48536,10 +48652,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Regionbackendservices$Testiampermissions {
     /**
@@ -48559,10 +48676,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regionbackendservices$Update {
     /**
@@ -48595,10 +48713,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
 
 
@@ -49259,10 +49378,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Commitment;
+    requestBody?: Schema$Commitment;
   }
   export interface Params$Resource$Regioncommitments$List {
     /**
@@ -49944,10 +50064,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Snapshot;
+    requestBody?: Schema$Snapshot;
   }
   export interface Params$Resource$Regiondisks$Delete {
     /**
@@ -50031,10 +50152,11 @@ export namespace compute_beta {
      * Optional. Source image to restore onto a disk.
      */
     sourceImage?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Disk;
+    requestBody?: Schema$Disk;
   }
   export interface Params$Resource$Regiondisks$List {
     /**
@@ -50125,10 +50247,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionDisksResizeRequest;
+    requestBody?: Schema$RegionDisksResizeRequest;
   }
   export interface Params$Resource$Regiondisks$Setlabels {
     /**
@@ -50161,10 +50284,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Regiondisks$Testiampermissions {
     /**
@@ -50184,10 +50308,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -52609,10 +52734,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersAbandonInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersAbandonInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Delete {
     /**
@@ -52677,10 +52803,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersDeleteInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersDeleteInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Get {
     /**
@@ -52728,10 +52855,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$List {
     /**
@@ -52857,10 +52985,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Recreateinstances {
     /**
@@ -52893,10 +53022,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersRecreateRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersRecreateRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Resize {
     /**
@@ -52965,10 +53095,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetAutoHealingRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetAutoHealingRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Setinstancetemplate {
     /**
@@ -53001,10 +53132,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetTemplateRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetTemplateRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Settargetpools {
     /**
@@ -53037,10 +53169,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetTargetPoolsRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetTargetPoolsRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Testiampermissions {
     /**
@@ -53060,10 +53193,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Update {
     /**
@@ -53096,10 +53230,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
 
 
@@ -53965,10 +54100,11 @@ export namespace compute_beta {
      * Name of the region scoping this request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupsListInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupsListInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroups$Setnamedports {
     /**
@@ -54002,10 +54138,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupsSetNamedPortsRequest;
+    requestBody?: Schema$RegionInstanceGroupsSetNamedPortsRequest;
   }
   export interface Params$Resource$Regioninstancegroups$Testiampermissions {
     /**
@@ -54025,10 +54162,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -56385,10 +56523,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$List {
     /**
@@ -56479,10 +56618,11 @@ export namespace compute_beta {
      * Name of the Router resource to patch.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$Preview {
     /**
@@ -56502,10 +56642,11 @@ export namespace compute_beta {
      * Name of the Router resource to query.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$Testiampermissions {
     /**
@@ -56525,10 +56666,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Routers$Update {
     /**
@@ -56561,10 +56703,11 @@ export namespace compute_beta {
      * Name of the Router resource to update.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
 
 
@@ -57284,10 +57427,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Route;
+    requestBody?: Schema$Route;
   }
   export interface Params$Resource$Routes$List {
     /**
@@ -57357,10 +57501,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -58459,10 +58604,11 @@ export namespace compute_beta {
      * Name of the security policy to update.
      */
     securityPolicy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicyRule;
+    requestBody?: Schema$SecurityPolicyRule;
   }
   export interface Params$Resource$Securitypolicies$Delete {
     /**
@@ -58549,10 +58695,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicy;
+    requestBody?: Schema$SecurityPolicy;
   }
   export interface Params$Resource$Securitypolicies$List {
     /**
@@ -58635,10 +58782,11 @@ export namespace compute_beta {
      * Name of the security policy to update.
      */
     securityPolicy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicy;
+    requestBody?: Schema$SecurityPolicy;
   }
   export interface Params$Resource$Securitypolicies$Patchrule {
     /**
@@ -58658,10 +58806,11 @@ export namespace compute_beta {
      * Name of the security policy to update.
      */
     securityPolicy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SecurityPolicyRule;
+    requestBody?: Schema$SecurityPolicyRule;
   }
   export interface Params$Resource$Securitypolicies$Removerule {
     /**
@@ -58696,10 +58845,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -59478,10 +59628,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
   export interface Params$Resource$Snapshots$Testiampermissions {
     /**
@@ -59497,10 +59648,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -60232,10 +60384,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslCertificate;
+    requestBody?: Schema$SslCertificate;
   }
   export interface Params$Resource$Sslcertificates$List {
     /**
@@ -60305,10 +60458,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -60901,10 +61055,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicy;
+    requestBody?: Schema$SslPolicy;
   }
   export interface Params$Resource$Sslpolicies$List {
     /**
@@ -61042,10 +61197,11 @@ export namespace compute_beta {
      * and comply with RFC1035.
      */
     sslPolicy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicy;
+    requestBody?: Schema$SslPolicy;
   }
   export interface Params$Resource$Sslpolicies$Testiampermissions {
     /**
@@ -61061,10 +61217,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -62762,10 +62919,11 @@ export namespace compute_beta {
      * Name of the Subnetwork resource to update.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubnetworksExpandIpCidrRangeRequest;
+    requestBody?: Schema$SubnetworksExpandIpCidrRangeRequest;
   }
   export interface Params$Resource$Subnetworks$Get {
     /**
@@ -62832,10 +62990,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subnetwork;
+    requestBody?: Schema$Subnetwork;
   }
   export interface Params$Resource$Subnetworks$List {
     /**
@@ -62980,10 +63139,11 @@ export namespace compute_beta {
      * Name of the Subnetwork resource to patch.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subnetwork;
+    requestBody?: Schema$Subnetwork;
   }
   export interface Params$Resource$Subnetworks$Setiampolicy {
     /**
@@ -63003,10 +63163,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Subnetworks$Setprivateipgoogleaccess {
     /**
@@ -63039,10 +63200,11 @@ export namespace compute_beta {
      * Name of the Subnetwork resource.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubnetworksSetPrivateIpGoogleAccessRequest;
+    requestBody?: Schema$SubnetworksSetPrivateIpGoogleAccessRequest;
   }
   export interface Params$Resource$Subnetworks$Testiampermissions {
     /**
@@ -63062,10 +63224,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -63930,10 +64093,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpProxy;
+    requestBody?: Schema$TargetHttpProxy;
   }
   export interface Params$Resource$Targethttpproxies$List {
     /**
@@ -64016,10 +64180,11 @@ export namespace compute_beta {
      * Name of the TargetHttpProxy to set a URL map for.
      */
     targetHttpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapReference;
+    requestBody?: Schema$UrlMapReference;
   }
   export interface Params$Resource$Targethttpproxies$Testiampermissions {
     /**
@@ -64035,10 +64200,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -65186,10 +65352,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxy;
+    requestBody?: Schema$TargetHttpsProxy;
   }
   export interface Params$Resource$Targethttpsproxies$List {
     /**
@@ -65273,10 +65440,11 @@ export namespace compute_beta {
      * for. The name should conform to RFC1035.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxiesSetQuicOverrideRequest;
+    requestBody?: Schema$TargetHttpsProxiesSetQuicOverrideRequest;
   }
   export interface Params$Resource$Targethttpsproxies$Setsslcertificates {
     /**
@@ -65306,10 +65474,11 @@ export namespace compute_beta {
      * for.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxiesSetSslCertificatesRequest;
+    requestBody?: Schema$TargetHttpsProxiesSetSslCertificatesRequest;
   }
   export interface Params$Resource$Targethttpsproxies$Setsslpolicy {
     /**
@@ -65339,10 +65508,11 @@ export namespace compute_beta {
      * name must be 1-63 characters long, and comply with RFC1035.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicyReference;
+    requestBody?: Schema$SslPolicyReference;
   }
   export interface Params$Resource$Targethttpsproxies$Seturlmap {
     /**
@@ -65371,10 +65541,11 @@ export namespace compute_beta {
      * Name of the TargetHttpsProxy resource whose URL map is to be set.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapReference;
+    requestBody?: Schema$UrlMapReference;
   }
   export interface Params$Resource$Targethttpsproxies$Testiampermissions {
     /**
@@ -65390,10 +65561,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -66361,10 +66533,11 @@ export namespace compute_beta {
      * Name of the zone scoping this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetInstance;
+    requestBody?: Schema$TargetInstance;
   }
   export interface Params$Resource$Targetinstances$List {
     /**
@@ -66442,10 +66615,11 @@ export namespace compute_beta {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -68118,10 +68292,11 @@ export namespace compute_beta {
      * Name of the target pool to add a health check to.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsAddHealthCheckRequest;
+    requestBody?: Schema$TargetPoolsAddHealthCheckRequest;
   }
   export interface Params$Resource$Targetpools$Addinstance {
     /**
@@ -68154,10 +68329,11 @@ export namespace compute_beta {
      * Name of the TargetPool resource to add instances to.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsAddInstanceRequest;
+    requestBody?: Schema$TargetPoolsAddInstanceRequest;
   }
   export interface Params$Resource$Targetpools$Aggregatedlist {
     /**
@@ -68282,10 +68458,11 @@ export namespace compute_beta {
      * Name of the TargetPool resource to which the queried instance belongs.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceReference;
+    requestBody?: Schema$InstanceReference;
   }
   export interface Params$Resource$Targetpools$Insert {
     /**
@@ -68314,10 +68491,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPool;
+    requestBody?: Schema$TargetPool;
   }
   export interface Params$Resource$Targetpools$List {
     /**
@@ -68408,10 +68586,11 @@ export namespace compute_beta {
      * Name of the target pool to remove health checks from.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsRemoveHealthCheckRequest;
+    requestBody?: Schema$TargetPoolsRemoveHealthCheckRequest;
   }
   export interface Params$Resource$Targetpools$Removeinstance {
     /**
@@ -68444,10 +68623,11 @@ export namespace compute_beta {
      * Name of the TargetPool resource to remove instances from.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsRemoveInstanceRequest;
+    requestBody?: Schema$TargetPoolsRemoveInstanceRequest;
   }
   export interface Params$Resource$Targetpools$Setbackup {
     /**
@@ -68484,10 +68664,11 @@ export namespace compute_beta {
      * Name of the TargetPool resource to set a backup pool for.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
   export interface Params$Resource$Targetpools$Testiampermissions {
     /**
@@ -68507,10 +68688,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -69710,10 +69892,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxy;
+    requestBody?: Schema$TargetSslProxy;
   }
   export interface Params$Resource$Targetsslproxies$List {
     /**
@@ -69797,10 +69980,11 @@ export namespace compute_beta {
      * be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetBackendServiceRequest;
+    requestBody?: Schema$TargetSslProxiesSetBackendServiceRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setproxyheader {
     /**
@@ -69829,10 +70013,11 @@ export namespace compute_beta {
      * Name of the TargetSslProxy resource whose ProxyHeader is to be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetProxyHeaderRequest;
+    requestBody?: Schema$TargetSslProxiesSetProxyHeaderRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setsslcertificates {
     /**
@@ -69862,10 +70047,11 @@ export namespace compute_beta {
      * be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetSslCertificatesRequest;
+    requestBody?: Schema$TargetSslProxiesSetSslCertificatesRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setsslpolicy {
     /**
@@ -69895,10 +70081,11 @@ export namespace compute_beta {
      * name must be 1-63 characters long, and comply with RFC1035.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicyReference;
+    requestBody?: Schema$SslPolicyReference;
   }
   export interface Params$Resource$Targetsslproxies$Testiampermissions {
     /**
@@ -69914,10 +70101,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -70780,10 +70968,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxy;
+    requestBody?: Schema$TargetTcpProxy;
   }
   export interface Params$Resource$Targettcpproxies$List {
     /**
@@ -70867,10 +71056,11 @@ export namespace compute_beta {
      * be set.
      */
     targetTcpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxiesSetBackendServiceRequest;
+    requestBody?: Schema$TargetTcpProxiesSetBackendServiceRequest;
   }
   export interface Params$Resource$Targettcpproxies$Setproxyheader {
     /**
@@ -70899,10 +71089,11 @@ export namespace compute_beta {
      * Name of the TargetTcpProxy resource whose ProxyHeader is to be set.
      */
     targetTcpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxiesSetProxyHeaderRequest;
+    requestBody?: Schema$TargetTcpProxiesSetProxyHeaderRequest;
   }
 
 
@@ -71945,10 +72136,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetVpnGateway;
+    requestBody?: Schema$TargetVpnGateway;
   }
   export interface Params$Resource$Targetvpngateways$List {
     /**
@@ -72039,10 +72231,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Targetvpngateways$Testiampermissions {
     /**
@@ -72062,10 +72255,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -73317,10 +73511,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Invalidatecache {
     /**
@@ -73349,10 +73544,11 @@ export namespace compute_beta {
      * Name of the UrlMap scoping this request.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CacheInvalidationRule;
+    requestBody?: Schema$CacheInvalidationRule;
   }
   export interface Params$Resource$Urlmaps$List {
     /**
@@ -73435,10 +73631,11 @@ export namespace compute_beta {
      * Name of the UrlMap resource to patch.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Testiampermissions {
     /**
@@ -73454,10 +73651,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Urlmaps$Update {
     /**
@@ -73486,10 +73684,11 @@ export namespace compute_beta {
      * Name of the UrlMap resource to update.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Validate {
     /**
@@ -73505,10 +73704,11 @@ export namespace compute_beta {
      * Name of the UrlMap resource to be validated as.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapsValidateRequest;
+    requestBody?: Schema$UrlMapsValidateRequest;
   }
 
 
@@ -74536,10 +74736,11 @@ export namespace compute_beta {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VpnTunnel;
+    requestBody?: Schema$VpnTunnel;
   }
   export interface Params$Resource$Vpntunnels$List {
     /**
@@ -74630,10 +74831,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$RegionSetLabelsRequest;
+    requestBody?: Schema$RegionSetLabelsRequest;
   }
   export interface Params$Resource$Vpntunnels$Testiampermissions {
     /**
@@ -74653,10 +74855,11 @@ export namespace compute_beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 

--- a/src/apis/compute/v1.ts
+++ b/src/apis/compute/v1.ts
@@ -9812,10 +9812,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Address;
+    requestBody?: Schema$Address;
   }
   export interface Params$Resource$Addresses$List {
     /**
@@ -10962,10 +10963,11 @@ export namespace compute_v1 {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Autoscalers$List {
     /**
@@ -11056,10 +11058,11 @@ export namespace compute_v1 {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Autoscalers$Update {
     /**
@@ -11092,10 +11095,11 @@ export namespace compute_v1 {
      * Name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
 
 
@@ -11968,10 +11972,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
   export interface Params$Resource$Backendbuckets$List {
     /**
@@ -12054,10 +12059,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
   export interface Params$Resource$Backendbuckets$Update {
     /**
@@ -12086,10 +12092,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendBucket;
+    requestBody?: Schema$BackendBucket;
   }
 
 
@@ -13298,10 +13305,11 @@ export namespace compute_v1 {
      *
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceGroupReference;
+    requestBody?: Schema$ResourceGroupReference;
   }
   export interface Params$Resource$Backendservices$Insert {
     /**
@@ -13326,10 +13334,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Backendservices$List {
     /**
@@ -13412,10 +13421,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Backendservices$Update {
     /**
@@ -13444,10 +13454,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
 
 
@@ -14628,10 +14639,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Snapshot;
+    requestBody?: Schema$Snapshot;
   }
   export interface Params$Resource$Disks$Delete {
     /**
@@ -14715,10 +14727,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Disk;
+    requestBody?: Schema$Disk;
   }
   export interface Params$Resource$Disks$List {
     /**
@@ -14809,10 +14822,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisksResizeRequest;
+    requestBody?: Schema$DisksResizeRequest;
   }
   export interface Params$Resource$Disks$Setlabels {
     /**
@@ -14845,10 +14859,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$ZoneSetLabelsRequest;
+    requestBody?: Schema$ZoneSetLabelsRequest;
   }
 
 
@@ -16255,10 +16270,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
   export interface Params$Resource$Firewalls$List {
     /**
@@ -16341,10 +16357,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
   export interface Params$Resource$Firewalls$Update {
     /**
@@ -16373,10 +16390,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Firewall;
+    requestBody?: Schema$Firewall;
   }
 
 
@@ -17345,10 +17363,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Forwardingrules$List {
     /**
@@ -17439,10 +17458,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
 
 
@@ -18035,10 +18055,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Address;
+    requestBody?: Schema$Address;
   }
   export interface Params$Resource$Globaladdresses$List {
     /**
@@ -18825,10 +18846,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingRule;
+    requestBody?: Schema$ForwardingRule;
   }
   export interface Params$Resource$Globalforwardingrules$List {
     /**
@@ -18911,10 +18933,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
 
 
@@ -20457,10 +20480,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Healthchecks$List {
     /**
@@ -20543,10 +20567,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
   export interface Params$Resource$Healthchecks$Update {
     /**
@@ -20575,10 +20600,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HealthCheck;
+    requestBody?: Schema$HealthCheck;
   }
 
 
@@ -21452,10 +21478,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
   export interface Params$Resource$Httphealthchecks$List {
     /**
@@ -21538,10 +21565,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
   export interface Params$Resource$Httphealthchecks$Update {
     /**
@@ -21570,10 +21598,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpHealthCheck;
+    requestBody?: Schema$HttpHealthCheck;
   }
 
 
@@ -22448,10 +22477,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
   export interface Params$Resource$Httpshealthchecks$List {
     /**
@@ -22534,10 +22564,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
   export interface Params$Resource$Httpshealthchecks$Update {
     /**
@@ -22566,10 +22597,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HttpsHealthCheck;
+    requestBody?: Schema$HttpsHealthCheck;
   }
 
 
@@ -23539,10 +23571,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeprecationStatus;
+    requestBody?: Schema$DeprecationStatus;
   }
   export interface Params$Resource$Images$Get {
     /**
@@ -23601,10 +23634,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Image;
+    requestBody?: Schema$Image;
   }
   export interface Params$Resource$Images$List {
     /**
@@ -23674,10 +23708,11 @@ export namespace compute_v1 {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
 
 
@@ -25445,10 +25480,11 @@ export namespace compute_v1 {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersAbandonInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersAbandonInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Aggregatedlist {
     /**
@@ -25567,10 +25603,11 @@ export namespace compute_v1 {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersDeleteInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersDeleteInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Get {
     /**
@@ -25618,10 +25655,11 @@ export namespace compute_v1 {
      * The name of the zone where you want to create the managed instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Instancegroupmanagers$List {
     /**
@@ -25747,10 +25785,11 @@ export namespace compute_v1 {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersRecreateInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersRecreateInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Resize {
     /**
@@ -25822,10 +25861,11 @@ export namespace compute_v1 {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
+    requestBody?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Settargetpools {
     /**
@@ -25858,10 +25898,11 @@ export namespace compute_v1 {
      * The name of the zone where the managed instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
+    requestBody?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
   }
 
 
@@ -27167,10 +27208,11 @@ export namespace compute_v1 {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsAddInstancesRequest;
+    requestBody?: Schema$InstanceGroupsAddInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Aggregatedlist {
     /**
@@ -27304,10 +27346,11 @@ export namespace compute_v1 {
      * The name of the zone where you want to create the instance group.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroup;
+    requestBody?: Schema$InstanceGroup;
   }
   export interface Params$Resource$Instancegroups$List {
     /**
@@ -27429,10 +27472,11 @@ export namespace compute_v1 {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsListInstancesRequest;
+    requestBody?: Schema$InstanceGroupsListInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Removeinstances {
     /**
@@ -27466,10 +27510,11 @@ export namespace compute_v1 {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsRemoveInstancesRequest;
+    requestBody?: Schema$InstanceGroupsRemoveInstancesRequest;
   }
   export interface Params$Resource$Instancegroups$Setnamedports {
     /**
@@ -27502,10 +27547,11 @@ export namespace compute_v1 {
      * The name of the zone where the instance group is located.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupsSetNamedPortsRequest;
+    requestBody?: Schema$InstanceGroupsSetNamedPortsRequest;
   }
 
 
@@ -31035,10 +31081,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccessConfig;
+    requestBody?: Schema$AccessConfig;
   }
   export interface Params$Resource$Instances$Aggregatedlist {
     /**
@@ -31125,10 +31172,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AttachedDisk;
+    requestBody?: Schema$AttachedDisk;
   }
   export interface Params$Resource$Instances$Delete {
     /**
@@ -31324,10 +31372,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Instance;
+    requestBody?: Schema$Instance;
   }
   export interface Params$Resource$Instances$List {
     /**
@@ -31589,10 +31638,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetLabelsRequest;
+    requestBody?: Schema$InstancesSetLabelsRequest;
   }
   export interface Params$Resource$Instances$Setmachineresources {
     /**
@@ -31625,10 +31675,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMachineResourcesRequest;
+    requestBody?: Schema$InstancesSetMachineResourcesRequest;
   }
   export interface Params$Resource$Instances$Setmachinetype {
     /**
@@ -31661,10 +31712,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMachineTypeRequest;
+    requestBody?: Schema$InstancesSetMachineTypeRequest;
   }
   export interface Params$Resource$Instances$Setmetadata {
     /**
@@ -31697,10 +31749,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Metadata;
+    requestBody?: Schema$Metadata;
   }
   export interface Params$Resource$Instances$Setmincpuplatform {
     /**
@@ -31733,10 +31786,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetMinCpuPlatformRequest;
+    requestBody?: Schema$InstancesSetMinCpuPlatformRequest;
   }
   export interface Params$Resource$Instances$Setscheduling {
     /**
@@ -31769,10 +31823,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Scheduling;
+    requestBody?: Schema$Scheduling;
   }
   export interface Params$Resource$Instances$Setserviceaccount {
     /**
@@ -31805,10 +31860,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesSetServiceAccountRequest;
+    requestBody?: Schema$InstancesSetServiceAccountRequest;
   }
   export interface Params$Resource$Instances$Settags {
     /**
@@ -31841,10 +31897,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Tags;
+    requestBody?: Schema$Tags;
   }
   export interface Params$Resource$Instances$Start {
     /**
@@ -31909,10 +31966,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesStartWithEncryptionKeyRequest;
+    requestBody?: Schema$InstancesStartWithEncryptionKeyRequest;
   }
   export interface Params$Resource$Instances$Stop {
     /**
@@ -31981,10 +32039,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccessConfig;
+    requestBody?: Schema$AccessConfig;
   }
   export interface Params$Resource$Instances$Updatenetworkinterface {
     /**
@@ -32021,10 +32080,11 @@ export namespace compute_v1 {
      * The name of the zone for this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworkInterface;
+    requestBody?: Schema$NetworkInterface;
   }
 
 
@@ -32631,10 +32691,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceTemplate;
+    requestBody?: Schema$InstanceTemplate;
   }
   export interface Params$Resource$Instancetemplates$List {
     /**
@@ -33529,10 +33590,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InterconnectAttachment;
+    requestBody?: Schema$InterconnectAttachment;
   }
   export interface Params$Resource$Interconnectattachments$List {
     /**
@@ -34673,10 +34735,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Interconnect;
+    requestBody?: Schema$Interconnect;
   }
   export interface Params$Resource$Interconnects$List {
     /**
@@ -34759,10 +34822,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Interconnect;
+    requestBody?: Schema$Interconnect;
   }
 
 
@@ -34946,10 +35010,11 @@ export namespace compute_v1 {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -35433,10 +35498,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$License;
+    requestBody?: Schema$License;
   }
   export interface Params$Resource$Licenses$List {
     /**
@@ -35506,10 +35572,11 @@ export namespace compute_v1 {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
 
 
@@ -37137,10 +37204,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworksAddPeeringRequest;
+    requestBody?: Schema$NetworksAddPeeringRequest;
   }
   export interface Params$Resource$Networks$Delete {
     /**
@@ -37208,10 +37276,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Network;
+    requestBody?: Schema$Network;
   }
   export interface Params$Resource$Networks$List {
     /**
@@ -37294,10 +37363,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Network;
+    requestBody?: Schema$Network;
   }
   export interface Params$Resource$Networks$Removepeering {
     /**
@@ -37326,10 +37396,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NetworksRemovePeeringRequest;
+    requestBody?: Schema$NetworksRemovePeeringRequest;
   }
   export interface Params$Resource$Networks$Switchtocustommode {
     /**
@@ -38944,10 +39015,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsDisableXpnResourceRequest;
+    requestBody?: Schema$ProjectsDisableXpnResourceRequest;
   }
   export interface Params$Resource$Projects$Enablexpnhost {
     /**
@@ -38996,10 +39068,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsEnableXpnResourceRequest;
+    requestBody?: Schema$ProjectsEnableXpnResourceRequest;
   }
   export interface Params$Resource$Projects$Get {
     /**
@@ -39076,10 +39149,11 @@ export namespace compute_v1 {
      * Project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProjectsListXpnHostsRequest;
+    requestBody?: Schema$ProjectsListXpnHostsRequest;
   }
   export interface Params$Resource$Projects$Movedisk {
     /**
@@ -39104,10 +39178,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DiskMoveRequest;
+    requestBody?: Schema$DiskMoveRequest;
   }
   export interface Params$Resource$Projects$Moveinstance {
     /**
@@ -39132,10 +39207,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceMoveRequest;
+    requestBody?: Schema$InstanceMoveRequest;
   }
   export interface Params$Resource$Projects$Setcommoninstancemetadata {
     /**
@@ -39160,10 +39236,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Metadata;
+    requestBody?: Schema$Metadata;
   }
   export interface Params$Resource$Projects$Setusageexportbucket {
     /**
@@ -39188,10 +39265,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UsageExportLocation;
+    requestBody?: Schema$UsageExportLocation;
   }
 
 
@@ -40093,10 +40171,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Regionautoscalers$List {
     /**
@@ -40187,10 +40266,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
   export interface Params$Resource$Regionautoscalers$Update {
     /**
@@ -40223,10 +40303,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Autoscaler;
+    requestBody?: Schema$Autoscaler;
   }
 
 
@@ -41273,10 +41354,11 @@ export namespace compute_v1 {
      * Name of the region scoping this request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceGroupReference;
+    requestBody?: Schema$ResourceGroupReference;
   }
   export interface Params$Resource$Regionbackendservices$Insert {
     /**
@@ -41305,10 +41387,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Regionbackendservices$List {
     /**
@@ -41399,10 +41482,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
   export interface Params$Resource$Regionbackendservices$Update {
     /**
@@ -41435,10 +41519,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackendService;
+    requestBody?: Schema$BackendService;
   }
 
 
@@ -42099,10 +42184,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Commitment;
+    requestBody?: Schema$Commitment;
   }
   export interface Params$Resource$Regioncommitments$List {
     /**
@@ -43768,10 +43854,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersAbandonInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersAbandonInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Delete {
     /**
@@ -43836,10 +43923,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersDeleteInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersDeleteInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Get {
     /**
@@ -43887,10 +43975,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$List {
     /**
@@ -44016,10 +44105,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersRecreateRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersRecreateRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Resize {
     /**
@@ -44088,10 +44178,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetTemplateRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetTemplateRequest;
   }
   export interface Params$Resource$Regioninstancegroupmanagers$Settargetpools {
     /**
@@ -44124,10 +44215,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupManagersSetTargetPoolsRequest;
+    requestBody?: Schema$RegionInstanceGroupManagersSetTargetPoolsRequest;
   }
 
 
@@ -44857,10 +44949,11 @@ export namespace compute_v1 {
      * Name of the region scoping this request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupsListInstancesRequest;
+    requestBody?: Schema$RegionInstanceGroupsListInstancesRequest;
   }
   export interface Params$Resource$Regioninstancegroups$Setnamedports {
     /**
@@ -44894,10 +44987,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionInstanceGroupsSetNamedPortsRequest;
+    requestBody?: Schema$RegionInstanceGroupsSetNamedPortsRequest;
   }
 
 
@@ -47116,10 +47210,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$List {
     /**
@@ -47210,10 +47305,11 @@ export namespace compute_v1 {
      * Name of the Router resource to patch.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$Preview {
     /**
@@ -47233,10 +47329,11 @@ export namespace compute_v1 {
      * Name of the Router resource to query.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
   export interface Params$Resource$Routers$Update {
     /**
@@ -47269,10 +47366,11 @@ export namespace compute_v1 {
      * Name of the Router resource to update.
      */
     router?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Router;
+    requestBody?: Schema$Router;
   }
 
 
@@ -47859,10 +47957,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Route;
+    requestBody?: Schema$Route;
   }
   export interface Params$Resource$Routes$List {
     /**
@@ -48561,10 +48660,11 @@ export namespace compute_v1 {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GlobalSetLabelsRequest;
+    requestBody?: Schema$GlobalSetLabelsRequest;
   }
 
 
@@ -49165,10 +49265,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslCertificate;
+    requestBody?: Schema$SslCertificate;
   }
   export interface Params$Resource$Sslcertificates$List {
     /**
@@ -49742,10 +49843,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicy;
+    requestBody?: Schema$SslPolicy;
   }
   export interface Params$Resource$Sslpolicies$List {
     /**
@@ -49883,10 +49985,11 @@ export namespace compute_v1 {
      * and comply with RFC1035.
      */
     sslPolicy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicy;
+    requestBody?: Schema$SslPolicy;
   }
 
 
@@ -51037,10 +51140,11 @@ export namespace compute_v1 {
      * Name of the Subnetwork resource to update.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubnetworksExpandIpCidrRangeRequest;
+    requestBody?: Schema$SubnetworksExpandIpCidrRangeRequest;
   }
   export interface Params$Resource$Subnetworks$Get {
     /**
@@ -51088,10 +51192,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subnetwork;
+    requestBody?: Schema$Subnetwork;
   }
   export interface Params$Resource$Subnetworks$List {
     /**
@@ -51182,10 +51287,11 @@ export namespace compute_v1 {
      * Name of the Subnetwork resource to patch.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subnetwork;
+    requestBody?: Schema$Subnetwork;
   }
   export interface Params$Resource$Subnetworks$Setprivateipgoogleaccess {
     /**
@@ -51218,10 +51324,11 @@ export namespace compute_v1 {
      * Name of the Subnetwork resource.
      */
     subnetwork?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubnetworksSetPrivateIpGoogleAccessRequest;
+    requestBody?: Schema$SubnetworksSetPrivateIpGoogleAccessRequest;
   }
 
 
@@ -51955,10 +52062,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpProxy;
+    requestBody?: Schema$TargetHttpProxy;
   }
   export interface Params$Resource$Targethttpproxies$List {
     /**
@@ -52041,10 +52149,11 @@ export namespace compute_v1 {
      * Name of the TargetHttpProxy to set a URL map for.
      */
     targetHttpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapReference;
+    requestBody?: Schema$UrlMapReference;
   }
 
 
@@ -52986,10 +53095,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxy;
+    requestBody?: Schema$TargetHttpsProxy;
   }
   export interface Params$Resource$Targethttpsproxies$List {
     /**
@@ -53073,10 +53183,11 @@ export namespace compute_v1 {
      * for.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetHttpsProxiesSetSslCertificatesRequest;
+    requestBody?: Schema$TargetHttpsProxiesSetSslCertificatesRequest;
   }
   export interface Params$Resource$Targethttpsproxies$Setsslpolicy {
     /**
@@ -53106,10 +53217,11 @@ export namespace compute_v1 {
      * name must be 1-63 characters long, and comply with RFC1035.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicyReference;
+    requestBody?: Schema$SslPolicyReference;
   }
   export interface Params$Resource$Targethttpsproxies$Seturlmap {
     /**
@@ -53138,10 +53250,11 @@ export namespace compute_v1 {
      * Name of the TargetHttpsProxy resource whose URL map is to be set.
      */
     targetHttpsProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapReference;
+    requestBody?: Schema$UrlMapReference;
   }
 
 
@@ -53973,10 +54086,11 @@ export namespace compute_v1 {
      * Name of the zone scoping this request.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetInstance;
+    requestBody?: Schema$TargetInstance;
   }
   export interface Params$Resource$Targetinstances$List {
     /**
@@ -55572,10 +55686,11 @@ export namespace compute_v1 {
      * Name of the target pool to add a health check to.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsAddHealthCheckRequest;
+    requestBody?: Schema$TargetPoolsAddHealthCheckRequest;
   }
   export interface Params$Resource$Targetpools$Addinstance {
     /**
@@ -55608,10 +55723,11 @@ export namespace compute_v1 {
      * Name of the TargetPool resource to add instances to.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsAddInstanceRequest;
+    requestBody?: Schema$TargetPoolsAddInstanceRequest;
   }
   export interface Params$Resource$Targetpools$Aggregatedlist {
     /**
@@ -55736,10 +55852,11 @@ export namespace compute_v1 {
      * Name of the TargetPool resource to which the queried instance belongs.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceReference;
+    requestBody?: Schema$InstanceReference;
   }
   export interface Params$Resource$Targetpools$Insert {
     /**
@@ -55768,10 +55885,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPool;
+    requestBody?: Schema$TargetPool;
   }
   export interface Params$Resource$Targetpools$List {
     /**
@@ -55862,10 +55980,11 @@ export namespace compute_v1 {
      * Name of the target pool to remove health checks from.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsRemoveHealthCheckRequest;
+    requestBody?: Schema$TargetPoolsRemoveHealthCheckRequest;
   }
   export interface Params$Resource$Targetpools$Removeinstance {
     /**
@@ -55898,10 +56017,11 @@ export namespace compute_v1 {
      * Name of the TargetPool resource to remove instances from.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetPoolsRemoveInstanceRequest;
+    requestBody?: Schema$TargetPoolsRemoveInstanceRequest;
   }
   export interface Params$Resource$Targetpools$Setbackup {
     /**
@@ -55938,10 +56058,11 @@ export namespace compute_v1 {
      * Name of the TargetPool resource to set a backup pool for.
      */
     targetPool?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetReference;
+    requestBody?: Schema$TargetReference;
   }
 
 
@@ -57010,10 +57131,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxy;
+    requestBody?: Schema$TargetSslProxy;
   }
   export interface Params$Resource$Targetsslproxies$List {
     /**
@@ -57097,10 +57219,11 @@ export namespace compute_v1 {
      * be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetBackendServiceRequest;
+    requestBody?: Schema$TargetSslProxiesSetBackendServiceRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setproxyheader {
     /**
@@ -57129,10 +57252,11 @@ export namespace compute_v1 {
      * Name of the TargetSslProxy resource whose ProxyHeader is to be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetProxyHeaderRequest;
+    requestBody?: Schema$TargetSslProxiesSetProxyHeaderRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setsslcertificates {
     /**
@@ -57162,10 +57286,11 @@ export namespace compute_v1 {
      * be set.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetSslProxiesSetSslCertificatesRequest;
+    requestBody?: Schema$TargetSslProxiesSetSslCertificatesRequest;
   }
   export interface Params$Resource$Targetsslproxies$Setsslpolicy {
     /**
@@ -57195,10 +57320,11 @@ export namespace compute_v1 {
      * name must be 1-63 characters long, and comply with RFC1035.
      */
     targetSslProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslPolicyReference;
+    requestBody?: Schema$SslPolicyReference;
   }
 
 
@@ -58061,10 +58187,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxy;
+    requestBody?: Schema$TargetTcpProxy;
   }
   export interface Params$Resource$Targettcpproxies$List {
     /**
@@ -58148,10 +58275,11 @@ export namespace compute_v1 {
      * be set.
      */
     targetTcpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxiesSetBackendServiceRequest;
+    requestBody?: Schema$TargetTcpProxiesSetBackendServiceRequest;
   }
   export interface Params$Resource$Targettcpproxies$Setproxyheader {
     /**
@@ -58180,10 +58308,11 @@ export namespace compute_v1 {
      * Name of the TargetTcpProxy resource whose ProxyHeader is to be set.
      */
     targetTcpProxy?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetTcpProxiesSetProxyHeaderRequest;
+    requestBody?: Schema$TargetTcpProxiesSetProxyHeaderRequest;
   }
 
 
@@ -59017,10 +59146,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetVpnGateway;
+    requestBody?: Schema$TargetVpnGateway;
   }
   export interface Params$Resource$Targetvpngateways$List {
     /**
@@ -60197,10 +60327,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Invalidatecache {
     /**
@@ -60229,10 +60360,11 @@ export namespace compute_v1 {
      * Name of the UrlMap scoping this request.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CacheInvalidationRule;
+    requestBody?: Schema$CacheInvalidationRule;
   }
   export interface Params$Resource$Urlmaps$List {
     /**
@@ -60315,10 +60447,11 @@ export namespace compute_v1 {
      * Name of the UrlMap resource to patch.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Update {
     /**
@@ -60347,10 +60480,11 @@ export namespace compute_v1 {
      * Name of the UrlMap resource to update.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMap;
+    requestBody?: Schema$UrlMap;
   }
   export interface Params$Resource$Urlmaps$Validate {
     /**
@@ -60366,10 +60500,11 @@ export namespace compute_v1 {
      * Name of the UrlMap resource to be validated as.
      */
     urlMap?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UrlMapsValidateRequest;
+    requestBody?: Schema$UrlMapsValidateRequest;
   }
 
 
@@ -61188,10 +61323,11 @@ export namespace compute_v1 {
      * (00000000-0000-0000-0000-000000000000).
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VpnTunnel;
+    requestBody?: Schema$VpnTunnel;
   }
   export interface Params$Resource$Vpntunnels$List {
     /**

--- a/src/apis/container/v1.ts
+++ b/src/apis/container/v1.ts
@@ -3099,10 +3099,11 @@ export namespace container_v1 {
      * rotation. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompleteIPRotationRequest;
+    requestBody?: Schema$CompleteIPRotationRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Create {
     /**
@@ -3115,10 +3116,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x'.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateClusterRequest;
+    requestBody?: Schema$CreateClusterRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Delete {
     /**
@@ -3215,10 +3217,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetAddonsConfigRequest;
+    requestBody?: Schema$SetAddonsConfigRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setlegacyabac {
     /**
@@ -3231,10 +3234,11 @@ export namespace container_v1 {
      * abac. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLegacyAbacRequest;
+    requestBody?: Schema$SetLegacyAbacRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setlocations {
     /**
@@ -3247,10 +3251,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLocationsRequest;
+    requestBody?: Schema$SetLocationsRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setlogging {
     /**
@@ -3263,10 +3268,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLoggingServiceRequest;
+    requestBody?: Schema$SetLoggingServiceRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setmaintenancepolicy {
     /**
@@ -3280,10 +3286,11 @@ export namespace container_v1 {
      * 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMaintenancePolicyRequest;
+    requestBody?: Schema$SetMaintenancePolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setmasterauth {
     /**
@@ -3296,10 +3303,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMasterAuthRequest;
+    requestBody?: Schema$SetMasterAuthRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setmonitoring {
     /**
@@ -3312,10 +3320,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMonitoringServiceRequest;
+    requestBody?: Schema$SetMonitoringServiceRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setnetworkpolicy {
     /**
@@ -3328,10 +3337,11 @@ export namespace container_v1 {
      * policy. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNetworkPolicyRequest;
+    requestBody?: Schema$SetNetworkPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setresourcelabels {
     /**
@@ -3344,10 +3354,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLabelsRequest;
+    requestBody?: Schema$SetLabelsRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Startiprotation {
     /**
@@ -3360,10 +3371,11 @@ export namespace container_v1 {
      * rotation. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartIPRotationRequest;
+    requestBody?: Schema$StartIPRotationRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Update {
     /**
@@ -3376,10 +3388,11 @@ export namespace container_v1 {
      * in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateClusterRequest;
+    requestBody?: Schema$UpdateClusterRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Updatemaster {
     /**
@@ -3392,10 +3405,11 @@ export namespace container_v1 {
      * in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateMasterRequest;
+    requestBody?: Schema$UpdateMasterRequest;
   }
 
   export class Resource$Projects$Locations$Clusters$Nodepools {
@@ -4060,10 +4074,11 @@ export namespace container_v1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateNodePoolRequest;
+    requestBody?: Schema$CreateNodePoolRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Delete {
     /**
@@ -4176,10 +4191,11 @@ export namespace container_v1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackNodePoolUpgradeRequest;
+    requestBody?: Schema$RollbackNodePoolUpgradeRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Setautoscaling {
     /**
@@ -4193,10 +4209,11 @@ export namespace container_v1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolAutoscalingRequest;
+    requestBody?: Schema$SetNodePoolAutoscalingRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Setmanagement {
     /**
@@ -4210,10 +4227,11 @@ export namespace container_v1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolManagementRequest;
+    requestBody?: Schema$SetNodePoolManagementRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Setsize {
     /**
@@ -4227,10 +4245,11 @@ export namespace container_v1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolSizeRequest;
+    requestBody?: Schema$SetNodePoolSizeRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Update {
     /**
@@ -4244,10 +4263,11 @@ export namespace container_v1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateNodePoolRequest;
+    requestBody?: Schema$UpdateNodePoolRequest;
   }
 
 
@@ -4477,10 +4497,11 @@ export namespace container_v1 {
      * Specified in the format 'projects/x/locations/x/operations/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Projects$Locations$Operations$Get {
     /**
@@ -7059,10 +7080,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetAddonsConfigRequest;
+    requestBody?: Schema$SetAddonsConfigRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Completeiprotation {
     /**
@@ -7087,10 +7109,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompleteIPRotationRequest;
+    requestBody?: Schema$CompleteIPRotationRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Create {
     /**
@@ -7110,10 +7133,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the parent field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateClusterRequest;
+    requestBody?: Schema$CreateClusterRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Delete {
     /**
@@ -7196,10 +7220,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLegacyAbacRequest;
+    requestBody?: Schema$SetLegacyAbacRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$List {
     /**
@@ -7250,10 +7275,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLocationsRequest;
+    requestBody?: Schema$SetLocationsRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Logging {
     /**
@@ -7278,10 +7304,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLoggingServiceRequest;
+    requestBody?: Schema$SetLoggingServiceRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Master {
     /**
@@ -7306,10 +7333,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateMasterRequest;
+    requestBody?: Schema$UpdateMasterRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Monitoring {
     /**
@@ -7334,10 +7362,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMonitoringServiceRequest;
+    requestBody?: Schema$SetMonitoringServiceRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Resourcelabels {
     /**
@@ -7362,10 +7391,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLabelsRequest;
+    requestBody?: Schema$SetLabelsRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Setmaintenancepolicy {
     /**
@@ -7387,10 +7417,11 @@ export namespace container_v1 {
      * [zone](/compute/docs/zones#available) in which the cluster resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMaintenancePolicyRequest;
+    requestBody?: Schema$SetMaintenancePolicyRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Setmasterauth {
     /**
@@ -7415,10 +7446,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMasterAuthRequest;
+    requestBody?: Schema$SetMasterAuthRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Setnetworkpolicy {
     /**
@@ -7443,10 +7475,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNetworkPolicyRequest;
+    requestBody?: Schema$SetNetworkPolicyRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Startiprotation {
     /**
@@ -7471,10 +7504,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartIPRotationRequest;
+    requestBody?: Schema$StartIPRotationRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Update {
     /**
@@ -7499,10 +7533,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateClusterRequest;
+    requestBody?: Schema$UpdateClusterRequest;
   }
 
   export class Resource$Projects$Zones$Clusters$Nodepools {
@@ -8800,10 +8835,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolAutoscalingRequest;
+    requestBody?: Schema$SetNodePoolAutoscalingRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Create {
     /**
@@ -8828,10 +8864,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the parent field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateNodePoolRequest;
+    requestBody?: Schema$CreateNodePoolRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Delete {
     /**
@@ -8960,10 +8997,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackNodePoolUpgradeRequest;
+    requestBody?: Schema$RollbackNodePoolUpgradeRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Setmanagement {
     /**
@@ -8993,10 +9031,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolManagementRequest;
+    requestBody?: Schema$SetNodePoolManagementRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Setsize {
     /**
@@ -9026,10 +9065,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolSizeRequest;
+    requestBody?: Schema$SetNodePoolSizeRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Update {
     /**
@@ -9059,10 +9099,11 @@ export namespace container_v1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateNodePoolRequest;
+    requestBody?: Schema$UpdateNodePoolRequest;
   }
 
 
@@ -9491,10 +9532,11 @@ export namespace container_v1 {
      * This field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Projects$Zones$Operations$Get {
     /**

--- a/src/apis/container/v1beta1.ts
+++ b/src/apis/container/v1beta1.ts
@@ -3376,10 +3376,11 @@ export namespace container_v1beta1 {
      * rotation. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompleteIPRotationRequest;
+    requestBody?: Schema$CompleteIPRotationRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Create {
     /**
@@ -3392,10 +3393,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x'.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateClusterRequest;
+    requestBody?: Schema$CreateClusterRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Delete {
     /**
@@ -3492,10 +3494,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetAddonsConfigRequest;
+    requestBody?: Schema$SetAddonsConfigRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setlegacyabac {
     /**
@@ -3508,10 +3511,11 @@ export namespace container_v1beta1 {
      * abac. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLegacyAbacRequest;
+    requestBody?: Schema$SetLegacyAbacRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setlocations {
     /**
@@ -3524,10 +3528,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLocationsRequest;
+    requestBody?: Schema$SetLocationsRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setlogging {
     /**
@@ -3540,10 +3545,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLoggingServiceRequest;
+    requestBody?: Schema$SetLoggingServiceRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setmaintenancepolicy {
     /**
@@ -3557,10 +3563,11 @@ export namespace container_v1beta1 {
      * 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMaintenancePolicyRequest;
+    requestBody?: Schema$SetMaintenancePolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setmasterauth {
     /**
@@ -3573,10 +3580,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMasterAuthRequest;
+    requestBody?: Schema$SetMasterAuthRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setmonitoring {
     /**
@@ -3589,10 +3597,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMonitoringServiceRequest;
+    requestBody?: Schema$SetMonitoringServiceRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setnetworkpolicy {
     /**
@@ -3605,10 +3614,11 @@ export namespace container_v1beta1 {
      * policy. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNetworkPolicyRequest;
+    requestBody?: Schema$SetNetworkPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Setresourcelabels {
     /**
@@ -3621,10 +3631,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLabelsRequest;
+    requestBody?: Schema$SetLabelsRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Startiprotation {
     /**
@@ -3637,10 +3648,11 @@ export namespace container_v1beta1 {
      * rotation. Specified in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartIPRotationRequest;
+    requestBody?: Schema$StartIPRotationRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Update {
     /**
@@ -3653,10 +3665,11 @@ export namespace container_v1beta1 {
      * in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateClusterRequest;
+    requestBody?: Schema$UpdateClusterRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Updatemaster {
     /**
@@ -3669,10 +3682,11 @@ export namespace container_v1beta1 {
      * in the format 'projects/x/locations/x/clusters/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateMasterRequest;
+    requestBody?: Schema$UpdateMasterRequest;
   }
 
   export class Resource$Projects$Locations$Clusters$Nodepools {
@@ -4337,10 +4351,11 @@ export namespace container_v1beta1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateNodePoolRequest;
+    requestBody?: Schema$CreateNodePoolRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Delete {
     /**
@@ -4453,10 +4468,11 @@ export namespace container_v1beta1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackNodePoolUpgradeRequest;
+    requestBody?: Schema$RollbackNodePoolUpgradeRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Setautoscaling {
     /**
@@ -4470,10 +4486,11 @@ export namespace container_v1beta1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolAutoscalingRequest;
+    requestBody?: Schema$SetNodePoolAutoscalingRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Setmanagement {
     /**
@@ -4487,10 +4504,11 @@ export namespace container_v1beta1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolManagementRequest;
+    requestBody?: Schema$SetNodePoolManagementRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Setsize {
     /**
@@ -4504,10 +4522,11 @@ export namespace container_v1beta1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolSizeRequest;
+    requestBody?: Schema$SetNodePoolSizeRequest;
   }
   export interface Params$Resource$Projects$Locations$Clusters$Nodepools$Update {
     /**
@@ -4521,10 +4540,11 @@ export namespace container_v1beta1 {
      * 'projects/x/locations/x/clusters/x/nodePools/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateNodePoolRequest;
+    requestBody?: Schema$UpdateNodePoolRequest;
   }
 
 
@@ -4754,10 +4774,11 @@ export namespace container_v1beta1 {
      * Specified in the format 'projects/x/locations/x/operations/x'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Projects$Locations$Operations$Get {
     /**
@@ -6206,10 +6227,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetAddonsConfigRequest;
+    requestBody?: Schema$SetAddonsConfigRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Completeiprotation {
     /**
@@ -6234,10 +6256,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompleteIPRotationRequest;
+    requestBody?: Schema$CompleteIPRotationRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Create {
     /**
@@ -6257,10 +6280,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the parent field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateClusterRequest;
+    requestBody?: Schema$CreateClusterRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Delete {
     /**
@@ -6343,10 +6367,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLegacyAbacRequest;
+    requestBody?: Schema$SetLegacyAbacRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$List {
     /**
@@ -6397,10 +6422,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLocationsRequest;
+    requestBody?: Schema$SetLocationsRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Logging {
     /**
@@ -6425,10 +6451,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLoggingServiceRequest;
+    requestBody?: Schema$SetLoggingServiceRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Master {
     /**
@@ -6453,10 +6480,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateMasterRequest;
+    requestBody?: Schema$UpdateMasterRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Monitoring {
     /**
@@ -6481,10 +6509,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMonitoringServiceRequest;
+    requestBody?: Schema$SetMonitoringServiceRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Resourcelabels {
     /**
@@ -6509,10 +6538,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetLabelsRequest;
+    requestBody?: Schema$SetLabelsRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Setmaintenancepolicy {
     /**
@@ -6534,10 +6564,11 @@ export namespace container_v1beta1 {
      * [zone](/compute/docs/zones#available) in which the cluster resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMaintenancePolicyRequest;
+    requestBody?: Schema$SetMaintenancePolicyRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Setmasterauth {
     /**
@@ -6562,10 +6593,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetMasterAuthRequest;
+    requestBody?: Schema$SetMasterAuthRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Setnetworkpolicy {
     /**
@@ -6590,10 +6622,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNetworkPolicyRequest;
+    requestBody?: Schema$SetNetworkPolicyRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Startiprotation {
     /**
@@ -6618,10 +6651,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartIPRotationRequest;
+    requestBody?: Schema$StartIPRotationRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Update {
     /**
@@ -6646,10 +6680,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateClusterRequest;
+    requestBody?: Schema$UpdateClusterRequest;
   }
 
   export class Resource$Projects$Zones$Clusters$Nodepools {
@@ -7358,10 +7393,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolAutoscalingRequest;
+    requestBody?: Schema$SetNodePoolAutoscalingRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Create {
     /**
@@ -7386,10 +7422,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the parent field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateNodePoolRequest;
+    requestBody?: Schema$CreateNodePoolRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Delete {
     /**
@@ -7518,10 +7555,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackNodePoolUpgradeRequest;
+    requestBody?: Schema$RollbackNodePoolUpgradeRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Setmanagement {
     /**
@@ -7551,10 +7589,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolManagementRequest;
+    requestBody?: Schema$SetNodePoolManagementRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Setsize {
     /**
@@ -7584,10 +7623,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetNodePoolSizeRequest;
+    requestBody?: Schema$SetNodePoolSizeRequest;
   }
   export interface Params$Resource$Projects$Zones$Clusters$Nodepools$Update {
     /**
@@ -7617,10 +7657,11 @@ export namespace container_v1beta1 {
      * field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateNodePoolRequest;
+    requestBody?: Schema$UpdateNodePoolRequest;
   }
 
 
@@ -7870,10 +7911,11 @@ export namespace container_v1beta1 {
      * This field has been deprecated and replaced by the name field.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Projects$Zones$Operations$Get {
     /**

--- a/src/apis/content/v2.ts
+++ b/src/apis/content/v2.ts
@@ -5495,10 +5495,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountsCustomBatchRequest;
+    requestBody?: Schema$AccountsCustomBatchRequest;
   }
   export interface Params$Resource$Accounts$Delete {
     /**
@@ -5555,10 +5556,11 @@ export namespace content_v2 {
      * The ID of the managing account. This must be a multi-client account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
   export interface Params$Resource$Accounts$List {
     /**
@@ -5600,10 +5602,11 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
   export interface Params$Resource$Accounts$Update {
     /**
@@ -5625,10 +5628,11 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
 
@@ -5869,6 +5873,12 @@ export namespace content_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$AccountstatusesCustomBatchRequest;
   }
   export interface Params$Resource$Accountstatuses$Get {
     /**
@@ -6288,10 +6298,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccounttaxCustomBatchRequest;
+    requestBody?: Schema$AccounttaxCustomBatchRequest;
   }
   export interface Params$Resource$Accounttax$Get {
     /**
@@ -6350,10 +6361,11 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountTax;
+    requestBody?: Schema$AccountTax;
   }
   export interface Params$Resource$Accounttax$Update {
     /**
@@ -6375,10 +6387,11 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountTax;
+    requestBody?: Schema$AccountTax;
   }
 
 
@@ -6951,10 +6964,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DatafeedsCustomBatchRequest;
+    requestBody?: Schema$DatafeedsCustomBatchRequest;
   }
   export interface Params$Resource$Datafeeds$Delete {
     /**
@@ -7027,10 +7041,11 @@ export namespace content_v2 {
      * multi-client account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Datafeed;
+    requestBody?: Schema$Datafeed;
   }
   export interface Params$Resource$Datafeeds$List {
     /**
@@ -7072,10 +7087,11 @@ export namespace content_v2 {
      * multi-client account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Datafeed;
+    requestBody?: Schema$Datafeed;
   }
   export interface Params$Resource$Datafeeds$Update {
     /**
@@ -7096,10 +7112,11 @@ export namespace content_v2 {
      * multi-client account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Datafeed;
+    requestBody?: Schema$Datafeed;
   }
 
 
@@ -7343,6 +7360,12 @@ export namespace content_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$DatafeedstatusesCustomBatchRequest;
   }
   export interface Params$Resource$Datafeedstatuses$Get {
     /**
@@ -7567,10 +7590,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InventoryCustomBatchRequest;
+    requestBody?: Schema$InventoryCustomBatchRequest;
   }
   export interface Params$Resource$Inventory$Set {
     /**
@@ -7596,10 +7620,11 @@ export namespace content_v2 {
      * online to update price and availability of an online product.
      */
     storeCode?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InventorySetRequest;
+    requestBody?: Schema$InventorySetRequest;
   }
 
 
@@ -8312,10 +8337,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiasettingsCustomBatchRequest;
+    requestBody?: Schema$LiasettingsCustomBatchRequest;
   }
   export interface Params$Resource$Liasettings$Get {
     /**
@@ -8392,10 +8418,11 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiaSettings;
+    requestBody?: Schema$LiaSettings;
   }
   export interface Params$Resource$Liasettings$Requestgmbaccess {
     /**
@@ -8494,10 +8521,11 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiaSettings;
+    requestBody?: Schema$LiaSettings;
   }
 
 
@@ -10069,10 +10097,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersAcknowledgeRequest;
+    requestBody?: Schema$OrdersAcknowledgeRequest;
   }
   export interface Params$Resource$Orders$Advancetestorder {
     /**
@@ -10105,10 +10134,11 @@ export namespace content_v2 {
      * The ID of the order to cancel.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersCancelRequest;
+    requestBody?: Schema$OrdersCancelRequest;
   }
   export interface Params$Resource$Orders$Cancellineitem {
     /**
@@ -10125,10 +10155,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersCancelLineItemRequest;
+    requestBody?: Schema$OrdersCancelLineItemRequest;
   }
   export interface Params$Resource$Orders$Createtestorder {
     /**
@@ -10141,16 +10172,23 @@ export namespace content_v2 {
      * multi-client account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersCreateTestOrderRequest;
+    requestBody?: Schema$OrdersCreateTestOrderRequest;
   }
   export interface Params$Resource$Orders$Custombatch {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$OrdersCustomBatchRequest;
   }
   export interface Params$Resource$Orders$Get {
     /**
@@ -10215,10 +10253,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersInStoreRefundLineItemRequest;
+    requestBody?: Schema$OrdersInStoreRefundLineItemRequest;
   }
   export interface Params$Resource$Orders$List {
     /**
@@ -10291,10 +10330,11 @@ export namespace content_v2 {
      * The ID of the order to refund.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersRefundRequest;
+    requestBody?: Schema$OrdersRefundRequest;
   }
   export interface Params$Resource$Orders$Rejectreturnlineitem {
     /**
@@ -10311,10 +10351,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersRejectReturnLineItemRequest;
+    requestBody?: Schema$OrdersRejectReturnLineItemRequest;
   }
   export interface Params$Resource$Orders$Returnlineitem {
     /**
@@ -10331,10 +10372,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersReturnLineItemRequest;
+    requestBody?: Schema$OrdersReturnLineItemRequest;
   }
   export interface Params$Resource$Orders$Returnrefundlineitem {
     /**
@@ -10351,10 +10393,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersReturnRefundLineItemRequest;
+    requestBody?: Schema$OrdersReturnRefundLineItemRequest;
   }
   export interface Params$Resource$Orders$Setlineitemmetadata {
     /**
@@ -10371,10 +10414,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersSetLineItemMetadataRequest;
+    requestBody?: Schema$OrdersSetLineItemMetadataRequest;
   }
   export interface Params$Resource$Orders$Shiplineitems {
     /**
@@ -10391,10 +10435,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersShipLineItemsRequest;
+    requestBody?: Schema$OrdersShipLineItemsRequest;
   }
   export interface Params$Resource$Orders$Updatelineitemshippingdetails {
     /**
@@ -10411,10 +10456,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersUpdateLineItemShippingDetailsRequest;
+    requestBody?: Schema$OrdersUpdateLineItemShippingDetailsRequest;
   }
   export interface Params$Resource$Orders$Updatemerchantorderid {
     /**
@@ -10431,10 +10477,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersUpdateMerchantOrderIdRequest;
+    requestBody?: Schema$OrdersUpdateMerchantOrderIdRequest;
   }
   export interface Params$Resource$Orders$Updateshipment {
     /**
@@ -10451,10 +10498,11 @@ export namespace content_v2 {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersUpdateShipmentRequest;
+    requestBody?: Schema$OrdersUpdateShipmentRequest;
   }
 
 
@@ -10957,10 +11005,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PosCustomBatchRequest;
+    requestBody?: Schema$PosCustomBatchRequest;
   }
   export interface Params$Resource$Pos$Delete {
     /**
@@ -11022,10 +11071,11 @@ export namespace content_v2 {
      * The ID of the target merchant.
      */
     targetMerchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PosStore;
+    requestBody?: Schema$PosStore;
   }
   export interface Params$Resource$Pos$Inventory {
     /**
@@ -11045,10 +11095,11 @@ export namespace content_v2 {
      * The ID of the target merchant.
      */
     targetMerchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PosInventoryRequest;
+    requestBody?: Schema$PosInventoryRequest;
   }
   export interface Params$Resource$Pos$List {
     /**
@@ -11083,10 +11134,11 @@ export namespace content_v2 {
      * The ID of the target merchant.
      */
     targetMerchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PosSaleRequest;
+    requestBody?: Schema$PosSaleRequest;
   }
 
 
@@ -11451,10 +11503,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProductsCustomBatchRequest;
+    requestBody?: Schema$ProductsCustomBatchRequest;
   }
   export interface Params$Resource$Products$Delete {
     /**
@@ -11507,10 +11560,11 @@ export namespace content_v2 {
      * multi-client account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Product;
+    requestBody?: Schema$Product;
   }
   export interface Params$Resource$Products$List {
     /**
@@ -11788,10 +11842,11 @@ export namespace content_v2 {
      * default value is false.
      */
     includeAttributes?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ProductstatusesCustomBatchRequest;
+    requestBody?: Schema$ProductstatusesCustomBatchRequest;
   }
   export interface Params$Resource$Productstatuses$Get {
     /**
@@ -12402,10 +12457,11 @@ export namespace content_v2 {
      * Flag to run the request in dry-run mode.
      */
     dryRun?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ShippingsettingsCustomBatchRequest;
+    requestBody?: Schema$ShippingsettingsCustomBatchRequest;
   }
   export interface Params$Resource$Shippingsettings$Get {
     /**
@@ -12486,10 +12542,11 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ShippingSettings;
+    requestBody?: Schema$ShippingSettings;
   }
   export interface Params$Resource$Shippingsettings$Update {
     /**
@@ -12511,9 +12568,10 @@ export namespace content_v2 {
      * must be the ID of a sub-account of this account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ShippingSettings;
+    requestBody?: Schema$ShippingSettings;
   }
 }

--- a/src/apis/content/v2sandbox.ts
+++ b/src/apis/content/v2sandbox.ts
@@ -3379,10 +3379,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersAcknowledgeRequest;
+    requestBody?: Schema$OrdersAcknowledgeRequest;
   }
   export interface Params$Resource$Orders$Advancetestorder {
     /**
@@ -3415,10 +3416,11 @@ export namespace content_v2sandbox {
      * The ID of the order to cancel.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersCancelRequest;
+    requestBody?: Schema$OrdersCancelRequest;
   }
   export interface Params$Resource$Orders$Cancellineitem {
     /**
@@ -3435,10 +3437,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersCancelLineItemRequest;
+    requestBody?: Schema$OrdersCancelLineItemRequest;
   }
   export interface Params$Resource$Orders$Createtestorder {
     /**
@@ -3451,16 +3454,23 @@ export namespace content_v2sandbox {
      * multi-client account.
      */
     merchantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersCreateTestOrderRequest;
+    requestBody?: Schema$OrdersCreateTestOrderRequest;
   }
   export interface Params$Resource$Orders$Custombatch {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$OrdersCustomBatchRequest;
   }
   export interface Params$Resource$Orders$Get {
     /**
@@ -3525,10 +3535,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersInStoreRefundLineItemRequest;
+    requestBody?: Schema$OrdersInStoreRefundLineItemRequest;
   }
   export interface Params$Resource$Orders$List {
     /**
@@ -3601,10 +3612,11 @@ export namespace content_v2sandbox {
      * The ID of the order to refund.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersRefundRequest;
+    requestBody?: Schema$OrdersRefundRequest;
   }
   export interface Params$Resource$Orders$Rejectreturnlineitem {
     /**
@@ -3621,10 +3633,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersRejectReturnLineItemRequest;
+    requestBody?: Schema$OrdersRejectReturnLineItemRequest;
   }
   export interface Params$Resource$Orders$Returnlineitem {
     /**
@@ -3641,10 +3654,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersReturnLineItemRequest;
+    requestBody?: Schema$OrdersReturnLineItemRequest;
   }
   export interface Params$Resource$Orders$Returnrefundlineitem {
     /**
@@ -3661,10 +3675,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersReturnRefundLineItemRequest;
+    requestBody?: Schema$OrdersReturnRefundLineItemRequest;
   }
   export interface Params$Resource$Orders$Setlineitemmetadata {
     /**
@@ -3681,10 +3696,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersSetLineItemMetadataRequest;
+    requestBody?: Schema$OrdersSetLineItemMetadataRequest;
   }
   export interface Params$Resource$Orders$Shiplineitems {
     /**
@@ -3701,10 +3717,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersShipLineItemsRequest;
+    requestBody?: Schema$OrdersShipLineItemsRequest;
   }
   export interface Params$Resource$Orders$Updatelineitemshippingdetails {
     /**
@@ -3721,10 +3738,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersUpdateLineItemShippingDetailsRequest;
+    requestBody?: Schema$OrdersUpdateLineItemShippingDetailsRequest;
   }
   export interface Params$Resource$Orders$Updatemerchantorderid {
     /**
@@ -3741,10 +3759,11 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersUpdateMerchantOrderIdRequest;
+    requestBody?: Schema$OrdersUpdateMerchantOrderIdRequest;
   }
   export interface Params$Resource$Orders$Updateshipment {
     /**
@@ -3761,9 +3780,10 @@ export namespace content_v2sandbox {
      * The ID of the order.
      */
     orderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$OrdersUpdateShipmentRequest;
+    requestBody?: Schema$OrdersUpdateShipmentRequest;
   }
 }

--- a/src/apis/dataflow/v1b3.ts
+++ b/src/apis/dataflow/v1b3.ts
@@ -3353,10 +3353,11 @@ export namespace dataflow_v1b3 {
      * The project to send the WorkerMessages to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendWorkerMessagesRequest;
+    requestBody?: Schema$SendWorkerMessagesRequest;
   }
 
   export class Resource$Projects$Jobs {
@@ -3851,10 +3852,11 @@ export namespace dataflow_v1b3 {
      * The level of information requested in response.
      */
     view?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
   }
   export interface Params$Resource$Projects$Jobs$Get {
     /**
@@ -3956,10 +3958,11 @@ export namespace dataflow_v1b3 {
      * The ID of the Cloud Platform project that the job belongs to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
   }
 
   export class Resource$Projects$Jobs$Debug {
@@ -4132,10 +4135,11 @@ export namespace dataflow_v1b3 {
      * The project id.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetDebugConfigRequest;
+    requestBody?: Schema$GetDebugConfigRequest;
   }
   export interface Params$Resource$Projects$Jobs$Debug$Sendcapture {
     /**
@@ -4151,10 +4155,11 @@ export namespace dataflow_v1b3 {
      * The project id.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendDebugCaptureRequest;
+    requestBody?: Schema$SendDebugCaptureRequest;
   }
 
 
@@ -4468,10 +4473,11 @@ export namespace dataflow_v1b3 {
      * Identifies the project this worker belongs to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LeaseWorkItemRequest;
+    requestBody?: Schema$LeaseWorkItemRequest;
   }
   export interface Params$Resource$Projects$Jobs$Workitems$Reportstatus {
     /**
@@ -4487,10 +4493,11 @@ export namespace dataflow_v1b3 {
      * The project which owns the WorkItem's job.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReportWorkItemStatusRequest;
+    requestBody?: Schema$ReportWorkItemStatusRequest;
   }
 
 
@@ -4603,10 +4610,11 @@ export namespace dataflow_v1b3 {
      * The project to send the WorkerMessages to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendWorkerMessagesRequest;
+    requestBody?: Schema$SendWorkerMessagesRequest;
   }
 
   export class Resource$Projects$Locations$Jobs {
@@ -5003,10 +5011,11 @@ export namespace dataflow_v1b3 {
      * The level of information requested in response.
      */
     view?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
   }
   export interface Params$Resource$Projects$Locations$Jobs$Get {
     /**
@@ -5108,10 +5117,11 @@ export namespace dataflow_v1b3 {
      * The ID of the Cloud Platform project that the job belongs to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
   }
 
   export class Resource$Projects$Locations$Jobs$Debug {
@@ -5295,10 +5305,11 @@ export namespace dataflow_v1b3 {
      * The project id.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetDebugConfigRequest;
+    requestBody?: Schema$GetDebugConfigRequest;
   }
   export interface Params$Resource$Projects$Locations$Jobs$Debug$Sendcapture {
     /**
@@ -5318,10 +5329,11 @@ export namespace dataflow_v1b3 {
      * The project id.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendDebugCaptureRequest;
+    requestBody?: Schema$SendDebugCaptureRequest;
   }
 
 
@@ -5647,10 +5659,11 @@ export namespace dataflow_v1b3 {
      * Identifies the project this worker belongs to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LeaseWorkItemRequest;
+    requestBody?: Schema$LeaseWorkItemRequest;
   }
   export interface Params$Resource$Projects$Locations$Jobs$Workitems$Reportstatus {
     /**
@@ -5670,10 +5683,11 @@ export namespace dataflow_v1b3 {
      * The project which owns the WorkItem's job.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReportWorkItemStatusRequest;
+    requestBody?: Schema$ReportWorkItemStatusRequest;
   }
 
 
@@ -5915,10 +5929,11 @@ export namespace dataflow_v1b3 {
      * Required. The ID of the Cloud Platform project that the job belongs to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateJobFromTemplateRequest;
+    requestBody?: Schema$CreateJobFromTemplateRequest;
   }
   export interface Params$Resource$Projects$Locations$Templates$Get {
     /**
@@ -5968,10 +5983,11 @@ export namespace dataflow_v1b3 {
      * false.
      */
     validateOnly?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LaunchTemplateParameters;
+    requestBody?: Schema$LaunchTemplateParameters;
   }
 
 
@@ -6203,10 +6219,11 @@ export namespace dataflow_v1b3 {
      * Required. The ID of the Cloud Platform project that the job belongs to.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateJobFromTemplateRequest;
+    requestBody?: Schema$CreateJobFromTemplateRequest;
   }
   export interface Params$Resource$Projects$Templates$Get {
     /**
@@ -6256,9 +6273,10 @@ export namespace dataflow_v1b3 {
      * false.
      */
     validateOnly?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LaunchTemplateParameters;
+    requestBody?: Schema$LaunchTemplateParameters;
   }
 }

--- a/src/apis/dataproc/v1.ts
+++ b/src/apis/dataproc/v1.ts
@@ -2000,10 +2000,11 @@ export namespace dataproc_v1 {
      * hyphens (-). The maximum length is 40 characters.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Cluster;
+    requestBody?: Schema$Cluster;
   }
   export interface Params$Resource$Projects$Regions$Clusters$Delete {
     /**
@@ -2060,10 +2061,11 @@ export namespace dataproc_v1 {
      * Required. The Cloud Dataproc region in which to handle the request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DiagnoseClusterRequest;
+    requestBody?: Schema$DiagnoseClusterRequest;
   }
   export interface Params$Resource$Projects$Regions$Clusters$Get {
     /**
@@ -2185,10 +2187,11 @@ export namespace dataproc_v1 {
      * <td>Resize secondary worker group</td>  </tr>  </tbody>  </table>
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Cluster;
+    requestBody?: Schema$Cluster;
   }
 
 
@@ -3018,10 +3021,11 @@ export namespace dataproc_v1 {
      * Required. The Cloud Dataproc region in which to handle the request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelJobRequest;
+    requestBody?: Schema$CancelJobRequest;
   }
   export interface Params$Resource$Projects$Regions$Jobs$Delete {
     /**
@@ -3137,10 +3141,11 @@ export namespace dataproc_v1 {
      * field that can be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
   }
   export interface Params$Resource$Projects$Regions$Jobs$Submit {
     /**
@@ -3157,10 +3162,11 @@ export namespace dataproc_v1 {
      * Required. The Cloud Dataproc region in which to handle the request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubmitJobRequest;
+    requestBody?: Schema$SubmitJobRequest;
   }
 
 

--- a/src/apis/dataproc/v1beta2.ts
+++ b/src/apis/dataproc/v1beta2.ts
@@ -588,9 +588,8 @@ export namespace dataproc_v1beta2 {
      */
     imageUri?: string;
     /**
-     * Optional. The list of instance names. Cloud Dataproc derives the names
-     * from cluster_name, num_instances, and the instance group if not set by
-     * user (recommended practice is to let Cloud Dataproc derive the name).
+     * Output only. The list of instance names. Cloud Dataproc derives the names
+     * from cluster_name, num_instances, and the instance group.
      */
     instanceNames?: string[];
     /**
@@ -2362,10 +2361,11 @@ export namespace dataproc_v1beta2 {
      * projects/{project_id}/regions/{region}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WorkflowTemplate;
+    requestBody?: Schema$WorkflowTemplate;
   }
   export interface Params$Resource$Projects$Locations$Workflowtemplates$Delete {
     /**
@@ -2429,10 +2429,11 @@ export namespace dataproc_v1beta2 {
      * projects/{project_id}/regions/{region}/workflowTemplates/{template_id}
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstantiateWorkflowTemplateRequest;
+    requestBody?: Schema$InstantiateWorkflowTemplateRequest;
   }
   export interface Params$Resource$Projects$Locations$Workflowtemplates$Instantiateinline {
     /**
@@ -2455,10 +2456,11 @@ export namespace dataproc_v1beta2 {
      * form projects/{project_id}/regions/{region}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WorkflowTemplate;
+    requestBody?: Schema$WorkflowTemplate;
   }
   export interface Params$Resource$Projects$Locations$Workflowtemplates$List {
     /**
@@ -2493,10 +2495,11 @@ export namespace dataproc_v1beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Locations$Workflowtemplates$Testiampermissions {
     /**
@@ -2509,10 +2512,11 @@ export namespace dataproc_v1beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Locations$Workflowtemplates$Update {
     /**
@@ -2526,10 +2530,11 @@ export namespace dataproc_v1beta2 {
      * projects/{project_id}/regions/{region}/workflowTemplates/{template_id}
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WorkflowTemplate;
+    requestBody?: Schema$WorkflowTemplate;
   }
 
 
@@ -3243,10 +3248,11 @@ export namespace dataproc_v1beta2 {
      * hyphens (-). The maximum length is 40 characters.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Cluster;
+    requestBody?: Schema$Cluster;
   }
   export interface Params$Resource$Projects$Regions$Clusters$Delete {
     /**
@@ -3303,10 +3309,11 @@ export namespace dataproc_v1beta2 {
      * Required. The Cloud Dataproc region in which to handle the request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DiagnoseClusterRequest;
+    requestBody?: Schema$DiagnoseClusterRequest;
   }
   export interface Params$Resource$Projects$Regions$Clusters$Get {
     /**
@@ -3445,10 +3452,11 @@ export namespace dataproc_v1beta2 {
      * duration</td> </tr> </table>
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Cluster;
+    requestBody?: Schema$Cluster;
   }
   export interface Params$Resource$Projects$Regions$Clusters$Setiampolicy {
     /**
@@ -3461,10 +3469,11 @@ export namespace dataproc_v1beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Regions$Clusters$Testiampermissions {
     /**
@@ -3477,10 +3486,11 @@ export namespace dataproc_v1beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -4156,10 +4166,11 @@ export namespace dataproc_v1beta2 {
      * Required. The Cloud Dataproc region in which to handle the request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelJobRequest;
+    requestBody?: Schema$CancelJobRequest;
   }
   export interface Params$Resource$Projects$Regions$Jobs$Delete {
     /**
@@ -4287,10 +4298,11 @@ export namespace dataproc_v1beta2 {
      * field that can be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
   }
   export interface Params$Resource$Projects$Regions$Jobs$Setiampolicy {
     /**
@@ -4303,10 +4315,11 @@ export namespace dataproc_v1beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Regions$Jobs$Submit {
     /**
@@ -4323,10 +4336,11 @@ export namespace dataproc_v1beta2 {
      * Required. The Cloud Dataproc region in which to handle the request.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubmitJobRequest;
+    requestBody?: Schema$SubmitJobRequest;
   }
   export interface Params$Resource$Projects$Regions$Jobs$Testiampermissions {
     /**
@@ -4339,10 +4353,11 @@ export namespace dataproc_v1beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -4939,10 +4954,11 @@ export namespace dataproc_v1beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Regions$Operations$Testiampermissions {
     /**
@@ -4955,10 +4971,11 @@ export namespace dataproc_v1beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -5721,10 +5738,11 @@ export namespace dataproc_v1beta2 {
      * projects/{project_id}/regions/{region}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WorkflowTemplate;
+    requestBody?: Schema$WorkflowTemplate;
   }
   export interface Params$Resource$Projects$Regions$Workflowtemplates$Delete {
     /**
@@ -5788,10 +5806,11 @@ export namespace dataproc_v1beta2 {
      * projects/{project_id}/regions/{region}/workflowTemplates/{template_id}
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstantiateWorkflowTemplateRequest;
+    requestBody?: Schema$InstantiateWorkflowTemplateRequest;
   }
   export interface Params$Resource$Projects$Regions$Workflowtemplates$Instantiateinline {
     /**
@@ -5814,10 +5833,11 @@ export namespace dataproc_v1beta2 {
      * form projects/{project_id}/regions/{region}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WorkflowTemplate;
+    requestBody?: Schema$WorkflowTemplate;
   }
   export interface Params$Resource$Projects$Regions$Workflowtemplates$List {
     /**
@@ -5852,10 +5872,11 @@ export namespace dataproc_v1beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Regions$Workflowtemplates$Testiampermissions {
     /**
@@ -5868,10 +5889,11 @@ export namespace dataproc_v1beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Regions$Workflowtemplates$Update {
     /**
@@ -5885,9 +5907,10 @@ export namespace dataproc_v1beta2 {
      * projects/{project_id}/regions/{region}/workflowTemplates/{template_id}
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WorkflowTemplate;
+    requestBody?: Schema$WorkflowTemplate;
   }
 }

--- a/src/apis/datastore/v1.ts
+++ b/src/apis/datastore/v1.ts
@@ -1848,10 +1848,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AllocateIdsRequest;
+    requestBody?: Schema$AllocateIdsRequest;
   }
   export interface Params$Resource$Projects$Begintransaction {
     /**
@@ -1863,10 +1864,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BeginTransactionRequest;
+    requestBody?: Schema$BeginTransactionRequest;
   }
   export interface Params$Resource$Projects$Commit {
     /**
@@ -1878,10 +1880,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommitRequest;
+    requestBody?: Schema$CommitRequest;
   }
   export interface Params$Resource$Projects$Export {
     /**
@@ -1893,10 +1896,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * Project ID against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleDatastoreAdminV1ExportEntitiesRequest;
+    requestBody?: Schema$GoogleDatastoreAdminV1ExportEntitiesRequest;
   }
   export interface Params$Resource$Projects$Import {
     /**
@@ -1908,10 +1912,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * Project ID against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleDatastoreAdminV1ImportEntitiesRequest;
+    requestBody?: Schema$GoogleDatastoreAdminV1ImportEntitiesRequest;
   }
   export interface Params$Resource$Projects$Lookup {
     /**
@@ -1923,10 +1928,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LookupRequest;
+    requestBody?: Schema$LookupRequest;
   }
   export interface Params$Resource$Projects$Reserveids {
     /**
@@ -1938,10 +1944,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReserveIdsRequest;
+    requestBody?: Schema$ReserveIdsRequest;
   }
   export interface Params$Resource$Projects$Rollback {
     /**
@@ -1953,10 +1960,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackRequest;
+    requestBody?: Schema$RollbackRequest;
   }
   export interface Params$Resource$Projects$Runquery {
     /**
@@ -1968,10 +1976,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunQueryRequest;
+    requestBody?: Schema$RunQueryRequest;
   }
 
   export class Resource$Projects$Operations {

--- a/src/apis/datastore/v1beta1.ts
+++ b/src/apis/datastore/v1beta1.ts
@@ -654,11 +654,13 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
                * Project ID against which to make the request.
                */
               projectId?: string;
-                                      /**
-               * Request body metadata
-               */
-              resource?: Schema$GoogleDatastoreAdminV1beta1ExportEntitiesRequest;
-                                          }
+                      
+                       /**
+              * Request body metadata
+              */
+            requestBody?: Schema$GoogleDatastoreAdminV1beta1ExportEntitiesRequest;
+          
+                  }
               export interface Params$Resource$Projects$Import {
           /**
            * Auth client or API Key for the request
@@ -669,11 +671,13 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
                * Project ID against which to make the request.
                */
               projectId?: string;
-                                      /**
-               * Request body metadata
-               */
-              resource?: Schema$GoogleDatastoreAdminV1beta1ImportEntitiesRequest;
-                                          }
+                      
+                       /**
+              * Request body metadata
+              */
+            requestBody?: Schema$GoogleDatastoreAdminV1beta1ImportEntitiesRequest;
+          
+                  }
           
     
   

--- a/src/apis/datastore/v1beta3.ts
+++ b/src/apis/datastore/v1beta3.ts
@@ -1554,10 +1554,11 @@ export namespace datastore_v1beta3 {
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AllocateIdsRequest;
+    requestBody?: Schema$AllocateIdsRequest;
   }
   export interface Params$Resource$Projects$Begintransaction {
     /**
@@ -1569,10 +1570,11 @@ export namespace datastore_v1beta3 {
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BeginTransactionRequest;
+    requestBody?: Schema$BeginTransactionRequest;
   }
   export interface Params$Resource$Projects$Commit {
     /**
@@ -1584,10 +1586,11 @@ export namespace datastore_v1beta3 {
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommitRequest;
+    requestBody?: Schema$CommitRequest;
   }
   export interface Params$Resource$Projects$Lookup {
     /**
@@ -1599,10 +1602,11 @@ export namespace datastore_v1beta3 {
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LookupRequest;
+    requestBody?: Schema$LookupRequest;
   }
   export interface Params$Resource$Projects$Reserveids {
     /**
@@ -1614,10 +1618,11 @@ export namespace datastore_v1beta3 {
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReserveIdsRequest;
+    requestBody?: Schema$ReserveIdsRequest;
   }
   export interface Params$Resource$Projects$Rollback {
     /**
@@ -1629,10 +1634,11 @@ export namespace datastore_v1beta3 {
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackRequest;
+    requestBody?: Schema$RollbackRequest;
   }
   export interface Params$Resource$Projects$Runquery {
     /**
@@ -1644,9 +1650,10 @@ export namespace datastore_v1beta3 {
      * The ID of the project against which to make the request.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunQueryRequest;
+    requestBody?: Schema$RunQueryRequest;
   }
 }

--- a/src/apis/deploymentmanager/alpha.ts
+++ b/src/apis/deploymentmanager/alpha.ts
@@ -1919,10 +1919,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompositeType;
+    requestBody?: Schema$CompositeType;
   }
   export interface Params$Resource$Compositetypes$List {
     /**
@@ -1992,10 +1993,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompositeType;
+    requestBody?: Schema$CompositeType;
   }
   export interface Params$Resource$Compositetypes$Update {
     /**
@@ -2011,10 +2013,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompositeType;
+    requestBody?: Schema$CompositeType;
   }
 
 
@@ -2830,10 +2833,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeploymentsCancelPreviewRequest;
+    requestBody?: Schema$DeploymentsCancelPreviewRequest;
   }
   export interface Params$Resource$Deployments$Delete {
     /**
@@ -2908,10 +2912,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
   export interface Params$Resource$Deployments$List {
     /**
@@ -3002,10 +3007,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
   export interface Params$Resource$Deployments$Setiampolicy {
     /**
@@ -3021,10 +3027,11 @@ export namespace deploymentmanager_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Deployments$Stop {
     /**
@@ -3040,10 +3047,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeploymentsStopRequest;
+    requestBody?: Schema$DeploymentsStopRequest;
   }
   export interface Params$Resource$Deployments$Testiampermissions {
     /**
@@ -3059,10 +3067,11 @@ export namespace deploymentmanager_alpha {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Deployments$Update {
     /**
@@ -3099,10 +3108,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
 
 
@@ -4430,10 +4440,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TypeProvider;
+    requestBody?: Schema$TypeProvider;
   }
   export interface Params$Resource$Typeproviders$List {
     /**
@@ -4561,10 +4572,11 @@ export namespace deploymentmanager_alpha {
      * The name of the type provider for this request.
      */
     typeProvider?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TypeProvider;
+    requestBody?: Schema$TypeProvider;
   }
   export interface Params$Resource$Typeproviders$Update {
     /**
@@ -4580,10 +4592,11 @@ export namespace deploymentmanager_alpha {
      * The name of the type provider for this request.
      */
     typeProvider?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TypeProvider;
+    requestBody?: Schema$TypeProvider;
   }
 
 
@@ -5046,10 +5059,11 @@ export namespace deploymentmanager_alpha {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Type;
+    requestBody?: Schema$Type;
   }
   export interface Params$Resource$Types$List {
     /**
@@ -5119,10 +5133,11 @@ export namespace deploymentmanager_alpha {
      * The name of the type for this request.
      */
     type?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Type;
+    requestBody?: Schema$Type;
   }
   export interface Params$Resource$Types$Update {
     /**
@@ -5138,9 +5153,10 @@ export namespace deploymentmanager_alpha {
      * The name of the type for this request.
      */
     type?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Type;
+    requestBody?: Schema$Type;
   }
 }

--- a/src/apis/deploymentmanager/v2.ts
+++ b/src/apis/deploymentmanager/v2.ts
@@ -2393,10 +2393,11 @@ export namespace deploymentmanager_v2 {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeploymentsCancelPreviewRequest;
+    requestBody?: Schema$DeploymentsCancelPreviewRequest;
   }
   export interface Params$Resource$Deployments$Delete {
     /**
@@ -2471,10 +2472,11 @@ export namespace deploymentmanager_v2 {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
   export interface Params$Resource$Deployments$List {
     /**
@@ -2565,10 +2567,11 @@ export namespace deploymentmanager_v2 {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
   export interface Params$Resource$Deployments$Setiampolicy {
     /**
@@ -2584,10 +2587,11 @@ export namespace deploymentmanager_v2 {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Deployments$Stop {
     /**
@@ -2603,10 +2607,11 @@ export namespace deploymentmanager_v2 {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeploymentsStopRequest;
+    requestBody?: Schema$DeploymentsStopRequest;
   }
   export interface Params$Resource$Deployments$Testiampermissions {
     /**
@@ -2622,10 +2627,11 @@ export namespace deploymentmanager_v2 {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Deployments$Update {
     /**
@@ -2662,10 +2668,11 @@ export namespace deploymentmanager_v2 {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
 
 

--- a/src/apis/deploymentmanager/v2beta.ts
+++ b/src/apis/deploymentmanager/v2beta.ts
@@ -1851,10 +1851,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompositeType;
+    requestBody?: Schema$CompositeType;
   }
   export interface Params$Resource$Compositetypes$List {
     /**
@@ -1924,10 +1925,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompositeType;
+    requestBody?: Schema$CompositeType;
   }
   export interface Params$Resource$Compositetypes$Update {
     /**
@@ -1943,10 +1945,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompositeType;
+    requestBody?: Schema$CompositeType;
   }
 
 
@@ -2762,10 +2765,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeploymentsCancelPreviewRequest;
+    requestBody?: Schema$DeploymentsCancelPreviewRequest;
   }
   export interface Params$Resource$Deployments$Delete {
     /**
@@ -2840,10 +2844,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
   export interface Params$Resource$Deployments$List {
     /**
@@ -2934,10 +2939,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
   export interface Params$Resource$Deployments$Setiampolicy {
     /**
@@ -2953,10 +2959,11 @@ export namespace deploymentmanager_v2beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Deployments$Stop {
     /**
@@ -2972,10 +2979,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeploymentsStopRequest;
+    requestBody?: Schema$DeploymentsStopRequest;
   }
   export interface Params$Resource$Deployments$Testiampermissions {
     /**
@@ -2991,10 +2999,11 @@ export namespace deploymentmanager_v2beta {
      * Name of the resource for this request.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestPermissionsRequest;
+    requestBody?: Schema$TestPermissionsRequest;
   }
   export interface Params$Resource$Deployments$Update {
     /**
@@ -3031,10 +3040,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Deployment;
+    requestBody?: Schema$Deployment;
   }
 
 
@@ -4362,10 +4372,11 @@ export namespace deploymentmanager_v2beta {
      * The project ID for this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TypeProvider;
+    requestBody?: Schema$TypeProvider;
   }
   export interface Params$Resource$Typeproviders$List {
     /**
@@ -4493,10 +4504,11 @@ export namespace deploymentmanager_v2beta {
      * The name of the type provider for this request.
      */
     typeProvider?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TypeProvider;
+    requestBody?: Schema$TypeProvider;
   }
   export interface Params$Resource$Typeproviders$Update {
     /**
@@ -4512,10 +4524,11 @@ export namespace deploymentmanager_v2beta {
      * The name of the type provider for this request.
      */
     typeProvider?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TypeProvider;
+    requestBody?: Schema$TypeProvider;
   }
 
 

--- a/src/apis/dfareporting/v2.8.ts
+++ b/src/apis/dfareporting/v2.8.ts
@@ -8766,10 +8766,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
   export interface Params$Resource$Accounts$Update {
     /**
@@ -8781,10 +8782,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
 
@@ -9461,10 +9463,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountUserProfile;
+    requestBody?: Schema$AccountUserProfile;
   }
   export interface Params$Resource$Accountuserprofiles$List {
     /**
@@ -9533,10 +9536,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountUserProfile;
+    requestBody?: Schema$AccountUserProfile;
   }
   export interface Params$Resource$Accountuserprofiles$Update {
     /**
@@ -9548,10 +9552,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountUserProfile;
+    requestBody?: Schema$AccountUserProfile;
   }
 
 
@@ -10215,10 +10220,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Ad;
+    requestBody?: Schema$Ad;
   }
   export interface Params$Resource$Ads$List {
     /**
@@ -10350,10 +10356,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Ad;
+    requestBody?: Schema$Ad;
   }
   export interface Params$Resource$Ads$Update {
     /**
@@ -10365,10 +10372,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Ad;
+    requestBody?: Schema$Ad;
   }
 
 
@@ -11177,10 +11185,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdvertiserGroup;
+    requestBody?: Schema$AdvertiserGroup;
   }
   export interface Params$Resource$Advertisergroups$List {
     /**
@@ -11237,10 +11246,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdvertiserGroup;
+    requestBody?: Schema$AdvertiserGroup;
   }
   export interface Params$Resource$Advertisergroups$Update {
     /**
@@ -11252,10 +11262,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdvertiserGroup;
+    requestBody?: Schema$AdvertiserGroup;
   }
 
 
@@ -11925,10 +11936,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Advertiser;
+    requestBody?: Schema$Advertiser;
   }
   export interface Params$Resource$Advertisers$List {
     /**
@@ -12010,10 +12022,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Advertiser;
+    requestBody?: Schema$Advertiser;
   }
   export interface Params$Resource$Advertisers$Update {
     /**
@@ -12025,10 +12038,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Advertiser;
+    requestBody?: Schema$Advertiser;
   }
 
 
@@ -12479,10 +12493,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CampaignCreativeAssociation;
+    requestBody?: Schema$CampaignCreativeAssociation;
   }
   export interface Params$Resource$Campaigncreativeassociations$List {
     /**
@@ -13188,10 +13203,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Campaign;
+    requestBody?: Schema$Campaign;
   }
   export interface Params$Resource$Campaigns$List {
     /**
@@ -13278,10 +13294,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Campaign;
+    requestBody?: Schema$Campaign;
   }
   export interface Params$Resource$Campaigns$Update {
     /**
@@ -13293,10 +13310,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Campaign;
+    requestBody?: Schema$Campaign;
   }
 
 
@@ -14885,10 +14903,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContentCategory;
+    requestBody?: Schema$ContentCategory;
   }
   export interface Params$Resource$Contentcategories$List {
     /**
@@ -14945,10 +14964,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContentCategory;
+    requestBody?: Schema$ContentCategory;
   }
   export interface Params$Resource$Contentcategories$Update {
     /**
@@ -14960,10 +14980,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContentCategory;
+    requestBody?: Schema$ContentCategory;
   }
 
 
@@ -15249,10 +15270,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ConversionsBatchInsertRequest;
+    requestBody?: Schema$ConversionsBatchInsertRequest;
   }
   export interface Params$Resource$Conversions$Batchupdate {
     /**
@@ -15264,10 +15286,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ConversionsBatchUpdateRequest;
+    requestBody?: Schema$ConversionsBatchUpdateRequest;
   }
 
 
@@ -15708,14 +15731,16 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeAssetMetadata;
+    requestBody?: Schema$CreativeAssetMetadata;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -15724,7 +15749,7 @@ export namespace dfareporting_v2_8 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -16532,10 +16557,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeField;
+    requestBody?: Schema$CreativeField;
   }
   export interface Params$Resource$Creativefields$List {
     /**
@@ -16596,10 +16622,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeField;
+    requestBody?: Schema$CreativeField;
   }
   export interface Params$Resource$Creativefields$Update {
     /**
@@ -16611,10 +16638,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeField;
+    requestBody?: Schema$CreativeField;
   }
 
 
@@ -17455,10 +17483,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeFieldValue;
+    requestBody?: Schema$CreativeFieldValue;
   }
   export interface Params$Resource$Creativefieldvalues$List {
     /**
@@ -17518,10 +17547,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeFieldValue;
+    requestBody?: Schema$CreativeFieldValue;
   }
   export interface Params$Resource$Creativefieldvalues$Update {
     /**
@@ -17537,10 +17567,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeFieldValue;
+    requestBody?: Schema$CreativeFieldValue;
   }
 
 
@@ -18217,10 +18248,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeGroup;
+    requestBody?: Schema$CreativeGroup;
   }
   export interface Params$Resource$Creativegroups$List {
     /**
@@ -18285,10 +18317,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeGroup;
+    requestBody?: Schema$CreativeGroup;
   }
   export interface Params$Resource$Creativegroups$Update {
     /**
@@ -18300,10 +18333,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeGroup;
+    requestBody?: Schema$CreativeGroup;
   }
 
 
@@ -18966,10 +19000,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Creatives$List {
     /**
@@ -19068,10 +19103,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Creatives$Update {
     /**
@@ -19083,10 +19119,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
 
 
@@ -19257,10 +19294,11 @@ export namespace dfareporting_v2_8 {
      * The DFA user profile ID.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DimensionValueRequest;
+    requestBody?: Schema$DimensionValueRequest;
   }
 
 
@@ -20031,10 +20069,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DirectorySite;
+    requestBody?: Schema$DirectorySite;
   }
   export interface Params$Resource$Directorysites$List {
     /**
@@ -20539,10 +20578,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DynamicTargetingKey;
+    requestBody?: Schema$DynamicTargetingKey;
   }
   export interface Params$Resource$Dynamictargetingkeys$List {
     /**
@@ -21342,10 +21382,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EventTag;
+    requestBody?: Schema$EventTag;
   }
   export interface Params$Resource$Eventtags$List {
     /**
@@ -21432,10 +21473,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EventTag;
+    requestBody?: Schema$EventTag;
   }
   export interface Params$Resource$Eventtags$Update {
     /**
@@ -21447,10 +21489,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EventTag;
+    requestBody?: Schema$EventTag;
   }
 
 
@@ -22711,10 +22754,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivity;
+    requestBody?: Schema$FloodlightActivity;
   }
   export interface Params$Resource$Floodlightactivities$List {
     /**
@@ -22810,10 +22854,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivity;
+    requestBody?: Schema$FloodlightActivity;
   }
   export interface Params$Resource$Floodlightactivities$Update {
     /**
@@ -22825,10 +22870,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivity;
+    requestBody?: Schema$FloodlightActivity;
   }
 
 
@@ -23512,10 +23558,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivityGroup;
+    requestBody?: Schema$FloodlightActivityGroup;
   }
   export interface Params$Resource$Floodlightactivitygroups$List {
     /**
@@ -23592,10 +23639,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivityGroup;
+    requestBody?: Schema$FloodlightActivityGroup;
   }
   export interface Params$Resource$Floodlightactivitygroups$Update {
     /**
@@ -23607,10 +23655,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivityGroup;
+    requestBody?: Schema$FloodlightActivityGroup;
   }
 
 
@@ -24166,10 +24215,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightConfiguration;
+    requestBody?: Schema$FloodlightConfiguration;
   }
   export interface Params$Resource$Floodlightconfigurations$Update {
     /**
@@ -24181,10 +24231,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightConfiguration;
+    requestBody?: Schema$FloodlightConfiguration;
   }
 
 
@@ -25353,10 +25404,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LandingPage;
+    requestBody?: Schema$LandingPage;
   }
   export interface Params$Resource$Landingpages$List {
     /**
@@ -25391,10 +25443,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LandingPage;
+    requestBody?: Schema$LandingPage;
   }
   export interface Params$Resource$Landingpages$Update {
     /**
@@ -25410,10 +25463,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LandingPage;
+    requestBody?: Schema$LandingPage;
   }
 
 
@@ -27922,10 +27976,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementGroup;
+    requestBody?: Schema$PlacementGroup;
   }
   export interface Params$Resource$Placementgroups$List {
     /**
@@ -28049,10 +28104,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementGroup;
+    requestBody?: Schema$PlacementGroup;
   }
   export interface Params$Resource$Placementgroups$Update {
     /**
@@ -28064,10 +28120,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementGroup;
+    requestBody?: Schema$PlacementGroup;
   }
 
 
@@ -28896,10 +28953,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Placement;
+    requestBody?: Schema$Placement;
   }
   export interface Params$Resource$Placements$List {
     /**
@@ -29032,10 +29090,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Placement;
+    requestBody?: Schema$Placement;
   }
   export interface Params$Resource$Placements$Update {
     /**
@@ -29047,10 +29106,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Placement;
+    requestBody?: Schema$Placement;
   }
 
 
@@ -29855,10 +29915,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementStrategy;
+    requestBody?: Schema$PlacementStrategy;
   }
   export interface Params$Resource$Placementstrategies$List {
     /**
@@ -29916,10 +29977,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementStrategy;
+    requestBody?: Schema$PlacementStrategy;
   }
   export interface Params$Resource$Placementstrategies$Update {
     /**
@@ -29931,10 +29993,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementStrategy;
+    requestBody?: Schema$PlacementStrategy;
   }
 
 
@@ -31625,10 +31688,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingList;
+    requestBody?: Schema$RemarketingList;
   }
   export interface Params$Resource$Remarketinglists$List {
     /**
@@ -31693,10 +31757,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingList;
+    requestBody?: Schema$RemarketingList;
   }
   export interface Params$Resource$Remarketinglists$Update {
     /**
@@ -31708,10 +31773,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingList;
+    requestBody?: Schema$RemarketingList;
   }
 
 
@@ -32123,10 +32189,11 @@ export namespace dfareporting_v2_8 {
      * Remarketing list ID.
      */
     remarketingListId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingListShare;
+    requestBody?: Schema$RemarketingListShare;
   }
   export interface Params$Resource$Remarketinglistshares$Update {
     /**
@@ -32138,10 +32205,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingListShare;
+    requestBody?: Schema$RemarketingListShare;
   }
 
 
@@ -33046,10 +33114,11 @@ export namespace dfareporting_v2_8 {
      * The DFA user profile ID.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
   export interface Params$Resource$Reports$List {
     /**
@@ -33096,10 +33165,11 @@ export namespace dfareporting_v2_8 {
      * The ID of the report.
      */
     reportId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
   export interface Params$Resource$Reports$Run {
     /**
@@ -33134,10 +33204,11 @@ export namespace dfareporting_v2_8 {
      * The ID of the report.
      */
     reportId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
 
   export class Resource$Reports$Compatiblefields {
@@ -33284,10 +33355,11 @@ export namespace dfareporting_v2_8 {
      * The DFA user profile ID.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
 
 
@@ -34272,10 +34344,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Site;
+    requestBody?: Schema$Site;
   }
   export interface Params$Resource$Sites$List {
     /**
@@ -34369,10 +34442,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Site;
+    requestBody?: Schema$Site;
   }
   export interface Params$Resource$Sites$Update {
     /**
@@ -34384,10 +34458,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Site;
+    requestBody?: Schema$Site;
   }
 
 
@@ -34778,10 +34853,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Size;
+    requestBody?: Schema$Size;
   }
   export interface Params$Resource$Sizes$List {
     /**
@@ -35472,10 +35548,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subaccount;
+    requestBody?: Schema$Subaccount;
   }
   export interface Params$Resource$Subaccounts$List {
     /**
@@ -35532,10 +35609,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subaccount;
+    requestBody?: Schema$Subaccount;
   }
   export interface Params$Resource$Subaccounts$Update {
     /**
@@ -35547,10 +35625,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subaccount;
+    requestBody?: Schema$Subaccount;
   }
 
 
@@ -36566,10 +36645,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetingTemplate;
+    requestBody?: Schema$TargetingTemplate;
   }
   export interface Params$Resource$Targetingtemplates$List {
     /**
@@ -36630,10 +36710,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetingTemplate;
+    requestBody?: Schema$TargetingTemplate;
   }
   export interface Params$Resource$Targetingtemplates$Update {
     /**
@@ -36645,10 +36726,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetingTemplate;
+    requestBody?: Schema$TargetingTemplate;
   }
 
 
@@ -38254,10 +38336,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserRole;
+    requestBody?: Schema$UserRole;
   }
   export interface Params$Resource$Userroles$List {
     /**
@@ -38323,10 +38406,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserRole;
+    requestBody?: Schema$UserRole;
   }
   export interface Params$Resource$Userroles$Update {
     /**
@@ -38338,10 +38422,11 @@ export namespace dfareporting_v2_8 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserRole;
+    requestBody?: Schema$UserRole;
   }
 
 

--- a/src/apis/dfareporting/v3.0.ts
+++ b/src/apis/dfareporting/v3.0.ts
@@ -8352,10 +8352,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
   export interface Params$Resource$Accounts$Update {
     /**
@@ -8367,10 +8368,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
 
@@ -8777,10 +8779,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountUserProfile;
+    requestBody?: Schema$AccountUserProfile;
   }
   export interface Params$Resource$Accountuserprofiles$List {
     /**
@@ -8849,10 +8852,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountUserProfile;
+    requestBody?: Schema$AccountUserProfile;
   }
   export interface Params$Resource$Accountuserprofiles$Update {
     /**
@@ -8864,10 +8868,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AccountUserProfile;
+    requestBody?: Schema$AccountUserProfile;
   }
 
 
@@ -9256,10 +9261,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Ad;
+    requestBody?: Schema$Ad;
   }
   export interface Params$Resource$Ads$List {
     /**
@@ -9391,10 +9397,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Ad;
+    requestBody?: Schema$Ad;
   }
   export interface Params$Resource$Ads$Update {
     /**
@@ -9406,10 +9413,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Ad;
+    requestBody?: Schema$Ad;
   }
 
 
@@ -9894,10 +9902,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdvertiserGroup;
+    requestBody?: Schema$AdvertiserGroup;
   }
   export interface Params$Resource$Advertisergroups$List {
     /**
@@ -9954,10 +9963,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdvertiserGroup;
+    requestBody?: Schema$AdvertiserGroup;
   }
   export interface Params$Resource$Advertisergroups$Update {
     /**
@@ -9969,10 +9979,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AdvertiserGroup;
+    requestBody?: Schema$AdvertiserGroup;
   }
 
 
@@ -10380,10 +10391,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LandingPage;
+    requestBody?: Schema$LandingPage;
   }
   export interface Params$Resource$Advertiserlandingpages$List {
     /**
@@ -10453,10 +10465,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LandingPage;
+    requestBody?: Schema$LandingPage;
   }
   export interface Params$Resource$Advertiserlandingpages$Update {
     /**
@@ -10468,10 +10481,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LandingPage;
+    requestBody?: Schema$LandingPage;
   }
 
 
@@ -10865,10 +10879,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Advertiser;
+    requestBody?: Schema$Advertiser;
   }
   export interface Params$Resource$Advertisers$List {
     /**
@@ -10950,10 +10965,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Advertiser;
+    requestBody?: Schema$Advertiser;
   }
   export interface Params$Resource$Advertisers$Update {
     /**
@@ -10965,10 +10981,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Advertiser;
+    requestBody?: Schema$Advertiser;
   }
 
 
@@ -11251,10 +11268,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CampaignCreativeAssociation;
+    requestBody?: Schema$CampaignCreativeAssociation;
   }
   export interface Params$Resource$Campaigncreativeassociations$List {
     /**
@@ -11666,10 +11684,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Campaign;
+    requestBody?: Schema$Campaign;
   }
   export interface Params$Resource$Campaigns$List {
     /**
@@ -11756,10 +11775,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Campaign;
+    requestBody?: Schema$Campaign;
   }
   export interface Params$Resource$Campaigns$Update {
     /**
@@ -11771,10 +11791,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Campaign;
+    requestBody?: Schema$Campaign;
   }
 
 
@@ -12783,10 +12804,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContentCategory;
+    requestBody?: Schema$ContentCategory;
   }
   export interface Params$Resource$Contentcategories$List {
     /**
@@ -12843,10 +12865,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContentCategory;
+    requestBody?: Schema$ContentCategory;
   }
   export interface Params$Resource$Contentcategories$Update {
     /**
@@ -12858,10 +12881,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContentCategory;
+    requestBody?: Schema$ContentCategory;
   }
 
 
@@ -13043,10 +13067,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ConversionsBatchInsertRequest;
+    requestBody?: Schema$ConversionsBatchInsertRequest;
   }
   export interface Params$Resource$Conversions$Batchupdate {
     /**
@@ -13058,10 +13083,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ConversionsBatchUpdateRequest;
+    requestBody?: Schema$ConversionsBatchUpdateRequest;
   }
 
 
@@ -13341,14 +13367,16 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeAssetMetadata;
+    requestBody?: Schema$CreativeAssetMetadata;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -13357,7 +13385,7 @@ export namespace dfareporting_v3_0 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -13841,10 +13869,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeField;
+    requestBody?: Schema$CreativeField;
   }
   export interface Params$Resource$Creativefields$List {
     /**
@@ -13905,10 +13934,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeField;
+    requestBody?: Schema$CreativeField;
   }
   export interface Params$Resource$Creativefields$Update {
     /**
@@ -13920,10 +13950,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeField;
+    requestBody?: Schema$CreativeField;
   }
 
 
@@ -14428,10 +14459,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeFieldValue;
+    requestBody?: Schema$CreativeFieldValue;
   }
   export interface Params$Resource$Creativefieldvalues$List {
     /**
@@ -14491,10 +14523,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeFieldValue;
+    requestBody?: Schema$CreativeFieldValue;
   }
   export interface Params$Resource$Creativefieldvalues$Update {
     /**
@@ -14510,10 +14543,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeFieldValue;
+    requestBody?: Schema$CreativeFieldValue;
   }
 
 
@@ -14914,10 +14948,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeGroup;
+    requestBody?: Schema$CreativeGroup;
   }
   export interface Params$Resource$Creativegroups$List {
     /**
@@ -14982,10 +15017,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeGroup;
+    requestBody?: Schema$CreativeGroup;
   }
   export interface Params$Resource$Creativegroups$Update {
     /**
@@ -14997,10 +15033,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreativeGroup;
+    requestBody?: Schema$CreativeGroup;
   }
 
 
@@ -15388,10 +15425,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Creatives$List {
     /**
@@ -15490,10 +15528,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
   export interface Params$Resource$Creatives$Update {
     /**
@@ -15505,10 +15544,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Creative;
+    requestBody?: Schema$Creative;
   }
 
 
@@ -15614,10 +15654,11 @@ export namespace dfareporting_v3_0 {
      * The DFA user profile ID.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DimensionValueRequest;
+    requestBody?: Schema$DimensionValueRequest;
   }
 
 
@@ -16112,10 +16153,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DirectorySite;
+    requestBody?: Schema$DirectorySite;
   }
   export interface Params$Resource$Directorysites$List {
     /**
@@ -16468,10 +16510,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DynamicTargetingKey;
+    requestBody?: Schema$DynamicTargetingKey;
   }
   export interface Params$Resource$Dynamictargetingkeys$List {
     /**
@@ -16961,10 +17004,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EventTag;
+    requestBody?: Schema$EventTag;
   }
   export interface Params$Resource$Eventtags$List {
     /**
@@ -17051,10 +17095,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EventTag;
+    requestBody?: Schema$EventTag;
   }
   export interface Params$Resource$Eventtags$Update {
     /**
@@ -17066,10 +17111,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EventTag;
+    requestBody?: Schema$EventTag;
   }
 
 
@@ -17852,10 +17898,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivity;
+    requestBody?: Schema$FloodlightActivity;
   }
   export interface Params$Resource$Floodlightactivities$List {
     /**
@@ -17951,10 +17998,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivity;
+    requestBody?: Schema$FloodlightActivity;
   }
   export interface Params$Resource$Floodlightactivities$Update {
     /**
@@ -17966,10 +18014,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivity;
+    requestBody?: Schema$FloodlightActivity;
   }
 
 
@@ -18384,10 +18433,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivityGroup;
+    requestBody?: Schema$FloodlightActivityGroup;
   }
   export interface Params$Resource$Floodlightactivitygroups$List {
     /**
@@ -18464,10 +18514,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivityGroup;
+    requestBody?: Schema$FloodlightActivityGroup;
   }
   export interface Params$Resource$Floodlightactivitygroups$Update {
     /**
@@ -18479,10 +18530,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightActivityGroup;
+    requestBody?: Schema$FloodlightActivityGroup;
   }
 
 
@@ -18836,10 +18888,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightConfiguration;
+    requestBody?: Schema$FloodlightConfiguration;
   }
   export interface Params$Resource$Floodlightconfigurations$Update {
     /**
@@ -18851,10 +18904,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FloodlightConfiguration;
+    requestBody?: Schema$FloodlightConfiguration;
   }
 
 
@@ -20696,10 +20750,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementGroup;
+    requestBody?: Schema$PlacementGroup;
   }
   export interface Params$Resource$Placementgroups$List {
     /**
@@ -20823,10 +20878,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementGroup;
+    requestBody?: Schema$PlacementGroup;
   }
   export interface Params$Resource$Placementgroups$Update {
     /**
@@ -20838,10 +20894,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementGroup;
+    requestBody?: Schema$PlacementGroup;
   }
 
 
@@ -21346,10 +21403,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Placement;
+    requestBody?: Schema$Placement;
   }
   export interface Params$Resource$Placements$List {
     /**
@@ -21482,10 +21540,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Placement;
+    requestBody?: Schema$Placement;
   }
   export interface Params$Resource$Placements$Update {
     /**
@@ -21497,10 +21556,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Placement;
+    requestBody?: Schema$Placement;
   }
 
 
@@ -21987,10 +22047,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementStrategy;
+    requestBody?: Schema$PlacementStrategy;
   }
   export interface Params$Resource$Placementstrategies$List {
     /**
@@ -22048,10 +22109,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementStrategy;
+    requestBody?: Schema$PlacementStrategy;
   }
   export interface Params$Resource$Placementstrategies$Update {
     /**
@@ -22063,10 +22125,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlacementStrategy;
+    requestBody?: Schema$PlacementStrategy;
   }
 
 
@@ -23120,10 +23183,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingList;
+    requestBody?: Schema$RemarketingList;
   }
   export interface Params$Resource$Remarketinglists$List {
     /**
@@ -23188,10 +23252,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingList;
+    requestBody?: Schema$RemarketingList;
   }
   export interface Params$Resource$Remarketinglists$Update {
     /**
@@ -23203,10 +23268,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingList;
+    requestBody?: Schema$RemarketingList;
   }
 
 
@@ -23462,10 +23528,11 @@ export namespace dfareporting_v3_0 {
      * Remarketing list ID.
      */
     remarketingListId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingListShare;
+    requestBody?: Schema$RemarketingListShare;
   }
   export interface Params$Resource$Remarketinglistshares$Update {
     /**
@@ -23477,10 +23544,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemarketingListShare;
+    requestBody?: Schema$RemarketingListShare;
   }
 
 
@@ -24008,10 +24076,11 @@ export namespace dfareporting_v3_0 {
      * The DFA user profile ID.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
   export interface Params$Resource$Reports$List {
     /**
@@ -24058,10 +24127,11 @@ export namespace dfareporting_v3_0 {
      * The ID of the report.
      */
     reportId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
   export interface Params$Resource$Reports$Run {
     /**
@@ -24096,10 +24166,11 @@ export namespace dfareporting_v3_0 {
      * The ID of the report.
      */
     reportId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
 
   export class Resource$Reports$Compatiblefields {
@@ -24196,10 +24267,11 @@ export namespace dfareporting_v3_0 {
      * The DFA user profile ID.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Report;
+    requestBody?: Schema$Report;
   }
 
 
@@ -24787,10 +24859,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Site;
+    requestBody?: Schema$Site;
   }
   export interface Params$Resource$Sites$List {
     /**
@@ -24884,10 +24957,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Site;
+    requestBody?: Schema$Site;
   }
   export interface Params$Resource$Sites$Update {
     /**
@@ -24899,10 +24973,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Site;
+    requestBody?: Schema$Site;
   }
 
 
@@ -25142,10 +25217,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Size;
+    requestBody?: Schema$Size;
   }
   export interface Params$Resource$Sizes$List {
     /**
@@ -25560,10 +25636,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subaccount;
+    requestBody?: Schema$Subaccount;
   }
   export interface Params$Resource$Subaccounts$List {
     /**
@@ -25620,10 +25697,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subaccount;
+    requestBody?: Schema$Subaccount;
   }
   export interface Params$Resource$Subaccounts$Update {
     /**
@@ -25635,10 +25713,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subaccount;
+    requestBody?: Schema$Subaccount;
   }
 
 
@@ -26269,10 +26348,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetingTemplate;
+    requestBody?: Schema$TargetingTemplate;
   }
   export interface Params$Resource$Targetingtemplates$List {
     /**
@@ -26333,10 +26413,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetingTemplate;
+    requestBody?: Schema$TargetingTemplate;
   }
   export interface Params$Resource$Targetingtemplates$Update {
     /**
@@ -26348,10 +26429,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TargetingTemplate;
+    requestBody?: Schema$TargetingTemplate;
   }
 
 
@@ -27347,10 +27429,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserRole;
+    requestBody?: Schema$UserRole;
   }
   export interface Params$Resource$Userroles$List {
     /**
@@ -27416,10 +27499,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserRole;
+    requestBody?: Schema$UserRole;
   }
   export interface Params$Resource$Userroles$Update {
     /**
@@ -27431,10 +27515,11 @@ export namespace dfareporting_v3_0 {
      * User profile ID associated with this request.
      */
     profileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserRole;
+    requestBody?: Schema$UserRole;
   }
 
 

--- a/src/apis/dialogflow/v2.ts
+++ b/src/apis/dialogflow/v2.ts
@@ -1066,11 +1066,10 @@ export namespace dialogflow_v2 {
      * The Speech recognition confidence between 0.0 and 1.0. A higher number
      * indicates an estimated greater likelihood that the recognized words are
      * correct. The default of 0.0 is a sentinel value indicating that
-     * confidence was not set.  You should not rely on this field as it
-     * isn&#39;t guaranteed to be accurate, or even set. In particular this
-     * field isn&#39;t set in Webhook calls and for StreamingDetectIntent since
-     * the streaming endpoint has separate confidence estimates per portion of
-     * the audio in StreamingRecognitionResult.
+     * confidence was not set.  This field is not guaranteed to be accurate or
+     * set. In particular this field isn&#39;t set for StreamingDetectIntent
+     * since the streaming endpoint has separate confidence estimates per
+     * portion of the audio in StreamingRecognitionResult.
      */
     speechRecognitionConfidence?: number;
     /**
@@ -2130,11 +2129,10 @@ export namespace dialogflow_v2 {
      * The Speech recognition confidence between 0.0 and 1.0. A higher number
      * indicates an estimated greater likelihood that the recognized words are
      * correct. The default of 0.0 is a sentinel value indicating that
-     * confidence was not set.  You should not rely on this field as it
-     * isn&#39;t guaranteed to be accurate, or even set. In particular this
-     * field isn&#39;t set in Webhook calls and for StreamingDetectIntent since
-     * the streaming endpoint has separate confidence estimates per portion of
-     * the audio in StreamingRecognitionResult.
+     * confidence was not set.  This field is not guaranteed to be accurate or
+     * set. In particular this field isn&#39;t set for StreamingDetectIntent
+     * since the streaming endpoint has separate confidence estimates per
+     * portion of the audio in StreamingRecognitionResult.
      */
     speechRecognitionConfidence?: number;
     /**
@@ -2893,10 +2891,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2ExportAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2ExportAgentRequest;
   }
   export interface Params$Resource$Projects$Agent$Import {
     /**
@@ -2909,10 +2908,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2ImportAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2ImportAgentRequest;
   }
   export interface Params$Resource$Projects$Agent$Restore {
     /**
@@ -2925,10 +2925,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2RestoreAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2RestoreAgentRequest;
   }
   export interface Params$Resource$Projects$Agent$Search {
     /**
@@ -2963,10 +2964,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2TrainAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2TrainAgentRequest;
   }
 
   export class Resource$Projects$Agent$Entitytypes {
@@ -3528,10 +3530,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2BatchDeleteEntityTypesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2BatchDeleteEntityTypesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Batchupdate {
     /**
@@ -3544,10 +3547,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2BatchUpdateEntityTypesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2BatchUpdateEntityTypesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Create {
     /**
@@ -3567,10 +3571,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2EntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2EntityType;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Delete {
     /**
@@ -3655,10 +3660,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2EntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2EntityType;
   }
 
   export class Resource$Projects$Agent$Entitytypes$Entities {
@@ -3924,10 +3930,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2BatchCreateEntitiesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2BatchCreateEntitiesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Entities$Batchdelete {
     /**
@@ -3940,10 +3947,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2BatchDeleteEntitiesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2BatchDeleteEntitiesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Entities$Batchupdate {
     /**
@@ -3956,10 +3964,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2BatchUpdateEntitiesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2BatchUpdateEntitiesRequest;
   }
 
 
@@ -4510,10 +4519,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2BatchDeleteIntentsRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2BatchDeleteIntentsRequest;
   }
   export interface Params$Resource$Projects$Agent$Intents$Batchupdate {
     /**
@@ -4526,10 +4536,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2BatchUpdateIntentsRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2BatchUpdateIntentsRequest;
   }
   export interface Params$Resource$Projects$Agent$Intents$Create {
     /**
@@ -4554,10 +4565,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2Intent;
+    requestBody?: Schema$GoogleCloudDialogflowV2Intent;
   }
   export interface Params$Resource$Projects$Agent$Intents$Delete {
     /**
@@ -4657,10 +4669,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2Intent;
+    requestBody?: Schema$GoogleCloudDialogflowV2Intent;
   }
 
 
@@ -4855,10 +4868,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * session ID must not exceed 36 bytes.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2DetectIntentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2DetectIntentRequest;
   }
 
   export class Resource$Projects$Agent$Sessions$Contexts {
@@ -5253,10 +5267,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * ID>/agent/sessions/<Session ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2Context;
+    requestBody?: Schema$GoogleCloudDialogflowV2Context;
   }
   export interface Params$Resource$Projects$Agent$Sessions$Contexts$Delete {
     /**
@@ -5320,10 +5335,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2Context;
+    requestBody?: Schema$GoogleCloudDialogflowV2Context;
   }
 
 
@@ -5731,10 +5747,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent/sessions/<Session ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2SessionEntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2SessionEntityType;
   }
   export interface Params$Resource$Projects$Agent$Sessions$Entitytypes$Delete {
     /**
@@ -5799,10 +5816,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2SessionEntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2SessionEntityType;
   }
 
 

--- a/src/apis/dialogflow/v2beta1.ts
+++ b/src/apis/dialogflow/v2beta1.ts
@@ -1305,11 +1305,10 @@ export namespace dialogflow_v2beta1 {
      * The Speech recognition confidence between 0.0 and 1.0. A higher number
      * indicates an estimated greater likelihood that the recognized words are
      * correct. The default of 0.0 is a sentinel value indicating that
-     * confidence was not set.  You should not rely on this field as it
-     * isn&#39;t guaranteed to be accurate, or even set. In particular this
-     * field isn&#39;t set in Webhook calls and for StreamingDetectIntent since
-     * the streaming endpoint has separate confidence estimates per portion of
-     * the audio in StreamingRecognitionResult.
+     * confidence was not set.  This field is not guaranteed to be accurate or
+     * set. In particular this field isn&#39;t set for StreamingDetectIntent
+     * since the streaming endpoint has separate confidence estimates per
+     * portion of the audio in StreamingRecognitionResult.
      */
     speechRecognitionConfidence?: number;
     /**
@@ -2218,11 +2217,10 @@ export namespace dialogflow_v2beta1 {
      * The Speech recognition confidence between 0.0 and 1.0. A higher number
      * indicates an estimated greater likelihood that the recognized words are
      * correct. The default of 0.0 is a sentinel value indicating that
-     * confidence was not set.  You should not rely on this field as it
-     * isn&#39;t guaranteed to be accurate, or even set. In particular this
-     * field isn&#39;t set in Webhook calls and for StreamingDetectIntent since
-     * the streaming endpoint has separate confidence estimates per portion of
-     * the audio in StreamingRecognitionResult.
+     * confidence was not set.  This field is not guaranteed to be accurate or
+     * set. In particular this field isn&#39;t set for StreamingDetectIntent
+     * since the streaming endpoint has separate confidence estimates per
+     * portion of the audio in StreamingRecognitionResult.
      */
     speechRecognitionConfidence?: number;
     /**
@@ -2908,10 +2906,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1ExportAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1ExportAgentRequest;
   }
   export interface Params$Resource$Projects$Agent$Import {
     /**
@@ -2924,10 +2923,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1ImportAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1ImportAgentRequest;
   }
   export interface Params$Resource$Projects$Agent$Restore {
     /**
@@ -2940,10 +2940,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1RestoreAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1RestoreAgentRequest;
   }
   export interface Params$Resource$Projects$Agent$Search {
     /**
@@ -2978,10 +2979,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1TrainAgentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1TrainAgentRequest;
   }
 
   export class Resource$Projects$Agent$Entitytypes {
@@ -3538,10 +3540,12 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1BatchDeleteEntityTypesRequest;
+    requestBody?:
+        Schema$GoogleCloudDialogflowV2beta1BatchDeleteEntityTypesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Batchupdate {
     /**
@@ -3554,10 +3558,12 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Format: `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1BatchUpdateEntityTypesRequest;
+    requestBody?:
+        Schema$GoogleCloudDialogflowV2beta1BatchUpdateEntityTypesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Create {
     /**
@@ -3577,10 +3583,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1EntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1EntityType;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Delete {
     /**
@@ -3665,10 +3672,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1EntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1EntityType;
   }
 
   export class Resource$Projects$Agent$Entitytypes$Entities {
@@ -3934,10 +3942,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1BatchCreateEntitiesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1BatchCreateEntitiesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Entities$Batchdelete {
     /**
@@ -3950,10 +3959,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1BatchDeleteEntitiesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1BatchDeleteEntitiesRequest;
   }
   export interface Params$Resource$Projects$Agent$Entitytypes$Entities$Batchupdate {
     /**
@@ -3966,10 +3976,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1BatchUpdateEntitiesRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1BatchUpdateEntitiesRequest;
   }
 
 
@@ -4224,10 +4235,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * of the <Session ID> and <User ID> must not exceed 36 characters.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1DetectIntentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1DetectIntentRequest;
   }
 
   export class Resource$Projects$Agent$Environments$Users$Sessions$Contexts {
@@ -4665,10 +4677,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * user.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1Context;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1Context;
   }
   export interface Params$Resource$Projects$Agent$Environments$Users$Sessions$Contexts$Delete {
     /**
@@ -4752,10 +4765,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1Context;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1Context;
   }
 
 
@@ -5194,10 +5208,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * specified, we assume default '-' user.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
   }
   export interface Params$Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes$Delete {
     /**
@@ -5282,10 +5297,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
   }
 
 
@@ -5849,10 +5865,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1BatchDeleteIntentsRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1BatchDeleteIntentsRequest;
   }
   export interface Params$Resource$Projects$Agent$Intents$Batchupdate {
     /**
@@ -5865,10 +5882,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * `projects/<Project ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1BatchUpdateIntentsRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1BatchUpdateIntentsRequest;
   }
   export interface Params$Resource$Projects$Agent$Intents$Create {
     /**
@@ -5893,10 +5911,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * ID>/agent`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1Intent;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1Intent;
   }
   export interface Params$Resource$Projects$Agent$Intents$Delete {
     /**
@@ -5996,10 +6015,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1Intent;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1Intent;
   }
 
 
@@ -6207,10 +6227,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * of the <Session ID> and <User ID> must not exceed 36 characters.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1DetectIntentRequest;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1DetectIntentRequest;
   }
 
   export class Resource$Projects$Agent$Sessions$Contexts {
@@ -6623,10 +6644,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * user.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1Context;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1Context;
   }
   export interface Params$Resource$Projects$Agent$Sessions$Contexts$Delete {
     /**
@@ -6710,10 +6732,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1Context;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1Context;
   }
 
 
@@ -7130,10 +7153,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * specified, we assume default '-' user.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
   }
   export interface Params$Resource$Projects$Agent$Sessions$Entitytypes$Delete {
     /**
@@ -7218,10 +7242,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
      * Optional. The mask to control which fields get updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
+    requestBody?: Schema$GoogleCloudDialogflowV2beta1SessionEntityType;
   }
 
 

--- a/src/apis/dlp/v2.ts
+++ b/src/apis/dlp/v2.ts
@@ -3173,10 +3173,11 @@ export namespace dlp_v2 {
      * organizations/my-org-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2CreateDeidentifyTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2CreateDeidentifyTemplateRequest;
   }
   export interface Params$Resource$Organizations$Deidentifytemplates$Delete {
     /**
@@ -3238,10 +3239,11 @@ export namespace dlp_v2 {
      * projects/project-id/deidentifyTemplates/432452342.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest;
   }
 
 
@@ -3645,10 +3647,11 @@ export namespace dlp_v2 {
      * organizations/my-org-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2CreateInspectTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2CreateInspectTemplateRequest;
   }
   export interface Params$Resource$Organizations$Inspecttemplates$Delete {
     /**
@@ -3710,10 +3713,11 @@ export namespace dlp_v2 {
      * projects/project-id/inspectTemplates/432452342.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2UpdateInspectTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2UpdateInspectTemplateRequest;
   }
 
 
@@ -4001,10 +4005,11 @@ export namespace dlp_v2 {
      * The parent resource name, for example projects/my-project-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2DeidentifyContentRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2DeidentifyContentRequest;
   }
   export interface Params$Resource$Projects$Content$Inspect {
     /**
@@ -4016,10 +4021,11 @@ export namespace dlp_v2 {
      * The parent resource name, for example projects/my-project-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2InspectContentRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2InspectContentRequest;
   }
   export interface Params$Resource$Projects$Content$Reidentify {
     /**
@@ -4031,10 +4037,11 @@ export namespace dlp_v2 {
      * The parent resource name.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2ReidentifyContentRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2ReidentifyContentRequest;
   }
 
 
@@ -4440,10 +4447,11 @@ export namespace dlp_v2 {
      * organizations/my-org-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2CreateDeidentifyTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2CreateDeidentifyTemplateRequest;
   }
   export interface Params$Resource$Projects$Deidentifytemplates$Delete {
     /**
@@ -4505,10 +4513,11 @@ export namespace dlp_v2 {
      * projects/project-id/deidentifyTemplates/432452342.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest;
   }
 
 
@@ -4889,10 +4898,11 @@ export namespace dlp_v2 {
      * The name of the DlpJob resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2CancelDlpJobRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2CancelDlpJobRequest;
   }
   export interface Params$Resource$Projects$Dlpjobs$Create {
     /**
@@ -4904,10 +4914,11 @@ export namespace dlp_v2 {
      * The parent resource name, for example projects/my-project-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2CreateDlpJobRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2CreateDlpJobRequest;
   }
   export interface Params$Resource$Projects$Dlpjobs$Delete {
     /**
@@ -5077,10 +5088,11 @@ export namespace dlp_v2 {
      * The parent resource name, for example projects/my-project-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2RedactImageRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2RedactImageRequest;
   }
 
 
@@ -5482,10 +5494,11 @@ export namespace dlp_v2 {
      * organizations/my-org-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2CreateInspectTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2CreateInspectTemplateRequest;
   }
   export interface Params$Resource$Projects$Inspecttemplates$Delete {
     /**
@@ -5547,10 +5560,11 @@ export namespace dlp_v2 {
      * projects/project-id/inspectTemplates/432452342.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2UpdateInspectTemplateRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2UpdateInspectTemplateRequest;
   }
 
 
@@ -5939,10 +5953,11 @@ export namespace dlp_v2 {
      * The parent resource name, for example projects/my-project-id.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2CreateJobTriggerRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2CreateJobTriggerRequest;
   }
   export interface Params$Resource$Projects$Jobtriggers$Delete {
     /**
@@ -6011,9 +6026,10 @@ export namespace dlp_v2 {
      * `projects/dlp-test-project/jobTriggers/53234423`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GooglePrivacyDlpV2UpdateJobTriggerRequest;
+    requestBody?: Schema$GooglePrivacyDlpV2UpdateJobTriggerRequest;
   }
 }

--- a/src/apis/dns/v1.ts
+++ b/src/apis/dns/v1.ts
@@ -1037,10 +1037,11 @@ export namespace dns_v1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Change;
+    requestBody?: Schema$Change;
   }
   export interface Params$Resource$Changes$Get {
     /**
@@ -2217,10 +2218,11 @@ export namespace dns_v1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
   export interface Params$Resource$Managedzones$Delete {
     /**
@@ -2312,10 +2314,11 @@ export namespace dns_v1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
   export interface Params$Resource$Managedzones$Update {
     /**
@@ -2338,10 +2341,11 @@ export namespace dns_v1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
 
 

--- a/src/apis/dns/v1beta2.ts
+++ b/src/apis/dns/v1beta2.ts
@@ -845,10 +845,11 @@ export namespace dns_v1beta2 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Change;
+    requestBody?: Schema$Change;
   }
   export interface Params$Resource$Changes$Get {
     /**
@@ -1794,10 +1795,11 @@ export namespace dns_v1beta2 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
   export interface Params$Resource$Managedzones$Delete {
     /**
@@ -1889,10 +1891,11 @@ export namespace dns_v1beta2 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
   export interface Params$Resource$Managedzones$Update {
     /**
@@ -1915,10 +1918,11 @@ export namespace dns_v1beta2 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
 
 

--- a/src/apis/dns/v2beta1.ts
+++ b/src/apis/dns/v2beta1.ts
@@ -1037,10 +1037,11 @@ export namespace dns_v2beta1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Change;
+    requestBody?: Schema$Change;
   }
   export interface Params$Resource$Changes$Get {
     /**
@@ -2609,10 +2610,11 @@ export namespace dns_v2beta1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
   export interface Params$Resource$Managedzones$Delete {
     /**
@@ -2704,10 +2706,11 @@ export namespace dns_v2beta1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
   export interface Params$Resource$Managedzones$Update {
     /**
@@ -2730,10 +2733,11 @@ export namespace dns_v2beta1 {
      * Identifies the project addressed by this request.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedZone;
+    requestBody?: Schema$ManagedZone;
   }
 
 

--- a/src/apis/doubleclickbidmanager/v1.ts
+++ b/src/apis/doubleclickbidmanager/v1.ts
@@ -688,12 +688,24 @@ export namespace doubleclickbidmanager_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$DownloadLineItemsRequest;
   }
   export interface Params$Resource$Lineitems$Uploadlineitems {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$UploadLineItemsRequest;
   }
 
 
@@ -1042,6 +1054,12 @@ export namespace doubleclickbidmanager_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Query;
   }
   export interface Params$Resource$Queries$Deletequery {
     /**
@@ -1081,10 +1099,11 @@ export namespace doubleclickbidmanager_v1 {
      * Query ID to run.
      */
     queryId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunQueryRequest;
+    requestBody?: Schema$RunQueryRequest;
   }
 
 
@@ -1264,5 +1283,11 @@ export namespace doubleclickbidmanager_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$DownloadRequest;
   }
 }

--- a/src/apis/doubleclicksearch/v2.ts
+++ b/src/apis/doubleclicksearch/v2.ts
@@ -1006,6 +1006,12 @@ export namespace doubleclicksearch_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ConversionList;
   }
   export interface Params$Resource$Conversion$Patch {
     /**
@@ -1043,22 +1049,35 @@ export namespace doubleclicksearch_v2 {
      * The 0-based starting index for retrieving conversions results.
      */
     startRow?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ConversionList;
+    requestBody?: Schema$ConversionList;
   }
   export interface Params$Resource$Conversion$Update {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ConversionList;
   }
   export interface Params$Resource$Conversion$Updateavailability {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$UpdateAvailabilityRequest;
   }
 
 
@@ -1335,6 +1354,12 @@ export namespace doubleclicksearch_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ReportRequest;
   }
   export interface Params$Resource$Reports$Get {
     /**
@@ -1367,6 +1392,12 @@ export namespace doubleclicksearch_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ReportRequest;
   }
 
 

--- a/src/apis/drive/v2.ts
+++ b/src/apis/drive/v2.ts
@@ -2297,10 +2297,11 @@ export namespace drive_v2 {
      * Drive ID and change ID as an identifier.
      */
     teamDriveId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -2384,6 +2385,12 @@ export namespace drive_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Channel;
   }
 
 
@@ -2706,10 +2713,11 @@ export namespace drive_v2 {
      * Whether the requesting application supports Team Drives.
      */
     supportsTeamDrives?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChildReference;
+    requestBody?: Schema$ChildReference;
   }
   export interface Params$Resource$Children$List {
     /**
@@ -3196,10 +3204,11 @@ export namespace drive_v2 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
   export interface Params$Resource$Comments$List {
     /**
@@ -3247,10 +3256,11 @@ export namespace drive_v2 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
   export interface Params$Resource$Comments$Update {
     /**
@@ -3266,10 +3276,11 @@ export namespace drive_v2 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
 
 
@@ -4313,10 +4324,11 @@ export namespace drive_v2 {
      * source is not a native Google Doc and convert=false.
      */
     visibility?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$File;
+    requestBody?: Schema$File;
   }
   export interface Params$Resource$Files$Delete {
     /**
@@ -4449,14 +4461,16 @@ export namespace drive_v2 {
      * convert=false.
      */
     visibility?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$File;
+    requestBody?: Schema$File;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -4465,7 +4479,7 @@ export namespace drive_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Files$List {
@@ -4613,10 +4627,11 @@ export namespace drive_v2 {
      * Whether to use the content as indexable text.
      */
     useContentAsIndexableText?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$File;
+    requestBody?: Schema$File;
   }
   export interface Params$Resource$Files$Touch {
     /**
@@ -4742,14 +4757,16 @@ export namespace drive_v2 {
      * Whether to use the content as indexable text.
      */
     useContentAsIndexableText?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$File;
+    requestBody?: Schema$File;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -4758,7 +4775,7 @@ export namespace drive_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Files$Watch {
@@ -4794,10 +4811,11 @@ export namespace drive_v2 {
      * updateViewedDate=true and an empty request body.
      */
     updateViewedDate?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -5116,10 +5134,11 @@ export namespace drive_v2 {
      * Whether the requesting application supports Team Drives.
      */
     supportsTeamDrives?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ParentReference;
+    requestBody?: Schema$ParentReference;
   }
   export interface Params$Resource$Parents$List {
     /**
@@ -5726,10 +5745,11 @@ export namespace drive_v2 {
      * if they are an administrator of the domain to which the item belongs.
      */
     useDomainAdminAccess?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Permission;
+    requestBody?: Schema$Permission;
   }
   export interface Params$Resource$Permissions$List {
     /**
@@ -5796,10 +5816,11 @@ export namespace drive_v2 {
      * if they are an administrator of the domain to which the item belongs.
      */
     useDomainAdminAccess?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Permission;
+    requestBody?: Schema$Permission;
   }
   export interface Params$Resource$Permissions$Update {
     /**
@@ -5834,10 +5855,11 @@ export namespace drive_v2 {
      * if they are an administrator of the domain to which the item belongs.
      */
     useDomainAdminAccess?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Permission;
+    requestBody?: Schema$Permission;
   }
 
 
@@ -6300,10 +6322,11 @@ export namespace drive_v2 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Property;
+    requestBody?: Schema$Property;
   }
   export interface Params$Resource$Properties$List {
     /**
@@ -6335,10 +6358,11 @@ export namespace drive_v2 {
      * (Default: PRIVATE)
      */
     visibility?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Property;
+    requestBody?: Schema$Property;
   }
   export interface Params$Resource$Properties$Update {
     /**
@@ -6359,10 +6383,11 @@ export namespace drive_v2 {
      * (Default: PRIVATE)
      */
     visibility?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Property;
+    requestBody?: Schema$Property;
   }
 
 
@@ -6545,10 +6570,12 @@ export namespace drive_v2 {
      * The ID of the file that the Realtime API data model is associated with.
      */
     fileId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -6557,7 +6584,7 @@ export namespace drive_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -7042,10 +7069,11 @@ export namespace drive_v2 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommentReply;
+    requestBody?: Schema$CommentReply;
   }
   export interface Params$Resource$Replies$List {
     /**
@@ -7096,10 +7124,11 @@ export namespace drive_v2 {
      * The ID of the reply.
      */
     replyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommentReply;
+    requestBody?: Schema$CommentReply;
   }
   export interface Params$Resource$Replies$Update {
     /**
@@ -7119,10 +7148,11 @@ export namespace drive_v2 {
      * The ID of the reply.
      */
     replyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommentReply;
+    requestBody?: Schema$CommentReply;
   }
 
 
@@ -7527,10 +7557,11 @@ export namespace drive_v2 {
      * The ID for the revision.
      */
     revisionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Revision;
+    requestBody?: Schema$Revision;
   }
   export interface Params$Resource$Revisions$Update {
     /**
@@ -7546,10 +7577,11 @@ export namespace drive_v2 {
      * The ID for the revision.
      */
     revisionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Revision;
+    requestBody?: Schema$Revision;
   }
 
 
@@ -7938,10 +7970,11 @@ export namespace drive_v2 {
      * exists a 409 error will be returned.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TeamDrive;
+    requestBody?: Schema$TeamDrive;
   }
   export interface Params$Resource$Teamdrives$List {
     /**
@@ -7978,9 +8011,10 @@ export namespace drive_v2 {
      * The ID of the Team Drive
      */
     teamDriveId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TeamDrive;
+    requestBody?: Schema$TeamDrive;
   }
 }

--- a/src/apis/drive/v3.ts
+++ b/src/apis/drive/v3.ts
@@ -1444,10 +1444,11 @@ export namespace drive_v3 {
      * Drive ID and change ID as an identifier.
      */
     teamDriveId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -1531,6 +1532,12 @@ export namespace drive_v3 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Channel;
   }
 
 
@@ -1883,10 +1890,11 @@ export namespace drive_v3 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
   export interface Params$Resource$Comments$Delete {
     /**
@@ -1967,10 +1975,11 @@ export namespace drive_v3 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
 
 
@@ -2702,10 +2711,11 @@ export namespace drive_v3 {
      * Whether the requesting application supports Team Drives.
      */
     supportsTeamDrives?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$File;
+    requestBody?: Schema$File;
   }
   export interface Params$Resource$Files$Create {
     /**
@@ -2737,14 +2747,16 @@ export namespace drive_v3 {
      * Whether to use the uploaded content as indexable text.
      */
     useContentAsIndexableText?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$File;
+    requestBody?: Schema$File;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2753,7 +2765,7 @@ export namespace drive_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Files$Delete {
@@ -2926,14 +2938,16 @@ export namespace drive_v3 {
      * Whether to use the uploaded content as indexable text.
      */
     useContentAsIndexableText?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$File;
+    requestBody?: Schema$File;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2942,7 +2956,7 @@ export namespace drive_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Files$Watch {
@@ -2964,10 +2978,11 @@ export namespace drive_v3 {
      * Whether the requesting application supports Team Drives.
      */
     supportsTeamDrives?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -3370,10 +3385,11 @@ export namespace drive_v3 {
      * if they are an administrator of the domain to which the item belongs.
      */
     useDomainAdminAccess?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Permission;
+    requestBody?: Schema$Permission;
   }
   export interface Params$Resource$Permissions$Delete {
     /**
@@ -3491,10 +3507,11 @@ export namespace drive_v3 {
      * if they are an administrator of the domain to which the item belongs.
      */
     useDomainAdminAccess?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Permission;
+    requestBody?: Schema$Permission;
   }
 
 
@@ -3863,10 +3880,11 @@ export namespace drive_v3 {
      * The ID of the file.
      */
     fileId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Reply;
+    requestBody?: Schema$Reply;
   }
   export interface Params$Resource$Replies$Delete {
     /**
@@ -3958,10 +3976,11 @@ export namespace drive_v3 {
      * The ID of the reply.
      */
     replyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Reply;
+    requestBody?: Schema$Reply;
   }
 
 
@@ -4307,10 +4326,11 @@ export namespace drive_v3 {
      * The ID of the revision.
      */
     revisionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Revision;
+    requestBody?: Schema$Revision;
   }
 
 
@@ -4670,10 +4690,11 @@ export namespace drive_v3 {
      * exists a 409 error will be returned.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TeamDrive;
+    requestBody?: Schema$TeamDrive;
   }
   export interface Params$Resource$Teamdrives$Delete {
     /**
@@ -4739,9 +4760,10 @@ export namespace drive_v3 {
      * The ID of the Team Drive
      */
     teamDriveId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TeamDrive;
+    requestBody?: Schema$TeamDrive;
   }
 }

--- a/src/apis/firebasedynamiclinks/v1.ts
+++ b/src/apis/firebasedynamiclinks/v1.ts
@@ -723,10 +723,11 @@ export namespace firebasedynamiclinks_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateManagedShortLinkRequest;
+    requestBody?: Schema$CreateManagedShortLinkRequest;
   }
 
 
@@ -826,10 +827,11 @@ export namespace firebasedynamiclinks_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateShortDynamicLinkRequest;
+    requestBody?: Schema$CreateShortDynamicLinkRequest;
   }
 
 
@@ -1016,9 +1018,10 @@ export namespace firebasedynamiclinks_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetIosPostInstallAttributionRequest;
+    requestBody?: Schema$GetIosPostInstallAttributionRequest;
   }
 }

--- a/src/apis/firebaserules/v1.ts
+++ b/src/apis/firebaserules/v1.ts
@@ -553,10 +553,11 @@ export namespace firebaserules_v1 {
      * `projects/{project_id}/rulesets/{ruleset_id}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TestRulesetRequest;
+    requestBody?: Schema$TestRulesetRequest;
   }
 
   export class Resource$Projects$Releases {
@@ -1012,10 +1013,11 @@ export namespace firebaserules_v1 {
      * `projects/{project_id}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Release;
+    requestBody?: Schema$Release;
   }
   export interface Params$Resource$Projects$Releases$Delete {
     /**
@@ -1113,10 +1115,11 @@ export namespace firebaserules_v1 {
      * `projects/{project_id}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateReleaseRequest;
+    requestBody?: Schema$UpdateReleaseRequest;
   }
 
 
@@ -1418,10 +1421,11 @@ export namespace firebaserules_v1 {
      * `projects/{project_id}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Ruleset;
+    requestBody?: Schema$Ruleset;
   }
   export interface Params$Resource$Projects$Rulesets$Delete {
     /**

--- a/src/apis/firestore/v1beta1.ts
+++ b/src/apis/firestore/v1beta1.ts
@@ -2118,10 +2118,11 @@ export namespace firestore_v1beta1 {
      * `projects/{project_id}/databases/{database_id}`.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchGetDocumentsRequest;
+    requestBody?: Schema$BatchGetDocumentsRequest;
   }
   export interface Params$Resource$Projects$Databases$Documents$Begintransaction {
     /**
@@ -2134,10 +2135,11 @@ export namespace firestore_v1beta1 {
      * `projects/{project_id}/databases/{database_id}`.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BeginTransactionRequest;
+    requestBody?: Schema$BeginTransactionRequest;
   }
   export interface Params$Resource$Projects$Databases$Documents$Commit {
     /**
@@ -2150,10 +2152,11 @@ export namespace firestore_v1beta1 {
      * `projects/{project_id}/databases/{database_id}`.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommitRequest;
+    requestBody?: Schema$CommitRequest;
   }
   export interface Params$Resource$Projects$Databases$Documents$Createdocument {
     /**
@@ -2182,10 +2185,11 @@ export namespace firestore_v1beta1 {
      * `projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}`
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Document;
+    requestBody?: Schema$Document;
   }
   export interface Params$Resource$Projects$Databases$Documents$Delete {
     /**
@@ -2303,10 +2307,11 @@ export namespace firestore_v1beta1 {
      * `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ListCollectionIdsRequest;
+    requestBody?: Schema$ListCollectionIdsRequest;
   }
   export interface Params$Resource$Projects$Databases$Documents$Listen {
     /**
@@ -2319,10 +2324,11 @@ export namespace firestore_v1beta1 {
      * `projects/{project_id}/databases/{database_id}`.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ListenRequest;
+    requestBody?: Schema$ListenRequest;
   }
   export interface Params$Resource$Projects$Databases$Documents$Patch {
     /**
@@ -2355,10 +2361,11 @@ export namespace firestore_v1beta1 {
      * syntax reference.
      */
     'updateMask.fieldPaths'?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Document;
+    requestBody?: Schema$Document;
   }
   export interface Params$Resource$Projects$Databases$Documents$Rollback {
     /**
@@ -2371,10 +2378,11 @@ export namespace firestore_v1beta1 {
      * `projects/{project_id}/databases/{database_id}`.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackRequest;
+    requestBody?: Schema$RollbackRequest;
   }
   export interface Params$Resource$Projects$Databases$Documents$Runquery {
     /**
@@ -2390,10 +2398,11 @@ export namespace firestore_v1beta1 {
      * `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunQueryRequest;
+    requestBody?: Schema$RunQueryRequest;
   }
   export interface Params$Resource$Projects$Databases$Documents$Write {
     /**
@@ -2407,10 +2416,11 @@ export namespace firestore_v1beta1 {
      * the first message.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WriteRequest;
+    requestBody?: Schema$WriteRequest;
   }
 
 
@@ -2709,10 +2719,11 @@ export namespace firestore_v1beta1 {
      * `projects/{project_id}/databases/{database_id}`
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Index;
+    requestBody?: Schema$Index;
   }
   export interface Params$Resource$Projects$Databases$Indexes$Delete {
     /**

--- a/src/apis/fitness/v1.ts
+++ b/src/apis/fitness/v1.ts
@@ -730,10 +730,11 @@ export namespace fitness_v1 {
      * authenticated user. Only me is supported at this time.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AggregateRequest;
+    requestBody?: Schema$AggregateRequest;
   }
 
 
@@ -1193,10 +1194,11 @@ export namespace fitness_v1 {
      * authenticated user. Only me is supported at this time.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DataSource;
+    requestBody?: Schema$DataSource;
   }
   export interface Params$Resource$Users$Datasources$Delete {
     /**
@@ -1262,10 +1264,11 @@ export namespace fitness_v1 {
      * authenticated user. Only me is supported at this time.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DataSource;
+    requestBody?: Schema$DataSource;
   }
   export interface Params$Resource$Users$Datasources$Update {
     /**
@@ -1282,10 +1285,11 @@ export namespace fitness_v1 {
      * authenticated user. Only me is supported at this time.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DataSource;
+    requestBody?: Schema$DataSource;
   }
 
   export class Resource$Users$Datasources$Datapointchanges {
@@ -1741,10 +1745,11 @@ export namespace fitness_v1 {
      * authenticated user. Only me is supported at this time.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Dataset;
+    requestBody?: Schema$Dataset;
   }
 
 
@@ -2041,9 +2046,10 @@ export namespace fitness_v1 {
      * authenticated user. Only me is supported at this time.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Session;
+    requestBody?: Schema$Session;
   }
 }

--- a/src/apis/fusiontables/v1.ts
+++ b/src/apis/fusiontables/v1.ts
@@ -1046,10 +1046,11 @@ export namespace fusiontables_v1 {
      * Table for which a new column is being added.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Column;
+    requestBody?: Schema$Column;
   }
   export interface Params$Resource$Column$List {
     /**
@@ -1084,10 +1085,11 @@ export namespace fusiontables_v1 {
      * Table for which the column is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Column;
+    requestBody?: Schema$Column;
   }
   export interface Params$Resource$Column$Update {
     /**
@@ -1103,10 +1105,11 @@ export namespace fusiontables_v1 {
      * Table for which the column is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Column;
+    requestBody?: Schema$Column;
   }
 
 
@@ -1746,10 +1749,11 @@ export namespace fusiontables_v1 {
      * Table for which a new style is being added
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StyleSetting;
+    requestBody?: Schema$StyleSetting;
   }
   export interface Params$Resource$Style$List {
     /**
@@ -1784,10 +1788,11 @@ export namespace fusiontables_v1 {
      * Table whose style is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StyleSetting;
+    requestBody?: Schema$StyleSetting;
   }
   export interface Params$Resource$Style$Update {
     /**
@@ -1803,10 +1808,11 @@ export namespace fusiontables_v1 {
      * Table whose style is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StyleSetting;
+    requestBody?: Schema$StyleSetting;
   }
 
 
@@ -2503,10 +2509,12 @@ export namespace fusiontables_v1 {
      * The table into which new rows are being imported.
      */
     tableId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2515,7 +2523,7 @@ export namespace fusiontables_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Table$Importtable {
@@ -2538,10 +2546,12 @@ export namespace fusiontables_v1 {
      * The name to be assigned to the new table.
      */
     name?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2550,7 +2560,7 @@ export namespace fusiontables_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Table$Insert {
@@ -2558,6 +2568,12 @@ export namespace fusiontables_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Table;
   }
   export interface Params$Resource$Table$List {
     /**
@@ -2590,10 +2606,11 @@ export namespace fusiontables_v1 {
      * ID of the table that is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Table;
+    requestBody?: Schema$Table;
   }
   export interface Params$Resource$Table$Update {
     /**
@@ -2611,10 +2628,11 @@ export namespace fusiontables_v1 {
      * ID of the table that is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Table;
+    requestBody?: Schema$Table;
   }
 
 
@@ -3326,10 +3344,11 @@ export namespace fusiontables_v1 {
      * Table for which a new template is being created
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Template;
+    requestBody?: Schema$Template;
   }
   export interface Params$Resource$Template$List {
     /**
@@ -3364,10 +3383,11 @@ export namespace fusiontables_v1 {
      * Identifier for the template that is being updated
      */
     templateId?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Template;
+    requestBody?: Schema$Template;
   }
   export interface Params$Resource$Template$Update {
     /**
@@ -3383,9 +3403,10 @@ export namespace fusiontables_v1 {
      * Identifier for the template that is being updated
      */
     templateId?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Template;
+    requestBody?: Schema$Template;
   }
 }

--- a/src/apis/fusiontables/v2.ts
+++ b/src/apis/fusiontables/v2.ts
@@ -1104,10 +1104,11 @@ export namespace fusiontables_v2 {
      * Table for which a new column is being added.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Column;
+    requestBody?: Schema$Column;
   }
   export interface Params$Resource$Column$List {
     /**
@@ -1142,10 +1143,11 @@ export namespace fusiontables_v2 {
      * Table for which the column is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Column;
+    requestBody?: Schema$Column;
   }
   export interface Params$Resource$Column$Update {
     /**
@@ -1161,10 +1163,11 @@ export namespace fusiontables_v2 {
      * Table for which the column is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Column;
+    requestBody?: Schema$Column;
   }
 
 
@@ -1806,10 +1809,11 @@ export namespace fusiontables_v2 {
      * Table for which a new style is being added
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StyleSetting;
+    requestBody?: Schema$StyleSetting;
   }
   export interface Params$Resource$Style$List {
     /**
@@ -1844,10 +1848,11 @@ export namespace fusiontables_v2 {
      * Table whose style is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StyleSetting;
+    requestBody?: Schema$StyleSetting;
   }
   export interface Params$Resource$Style$Update {
     /**
@@ -1863,10 +1868,11 @@ export namespace fusiontables_v2 {
      * Table whose style is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StyleSetting;
+    requestBody?: Schema$StyleSetting;
   }
 
 
@@ -2704,10 +2710,12 @@ export namespace fusiontables_v2 {
      * The table into which new rows are being imported.
      */
     tableId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2716,7 +2724,7 @@ export namespace fusiontables_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Table$Importtable {
@@ -2739,10 +2747,12 @@ export namespace fusiontables_v2 {
      * The name to be assigned to the new table.
      */
     name?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2751,7 +2761,7 @@ export namespace fusiontables_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Table$Insert {
@@ -2759,6 +2769,12 @@ export namespace fusiontables_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Table;
   }
   export interface Params$Resource$Table$List {
     /**
@@ -2791,10 +2807,11 @@ export namespace fusiontables_v2 {
      * ID of the table that is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Table;
+    requestBody?: Schema$Table;
   }
   export interface Params$Resource$Table$Refetchsheet {
     /**
@@ -2846,10 +2863,12 @@ export namespace fusiontables_v2 {
      * Table whose rows will be replaced.
      */
     tableId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2858,7 +2877,7 @@ export namespace fusiontables_v2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Table$Update {
@@ -2877,10 +2896,11 @@ export namespace fusiontables_v2 {
      * ID of the table that is being updated.
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Table;
+    requestBody?: Schema$Table;
   }
 
 
@@ -3593,10 +3613,11 @@ export namespace fusiontables_v2 {
      * Table for which a new template is being created
      */
     tableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Template;
+    requestBody?: Schema$Template;
   }
   export interface Params$Resource$Template$List {
     /**
@@ -3631,10 +3652,11 @@ export namespace fusiontables_v2 {
      * Identifier for the template that is being updated
      */
     templateId?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Template;
+    requestBody?: Schema$Template;
   }
   export interface Params$Resource$Template$Update {
     /**
@@ -3650,9 +3672,10 @@ export namespace fusiontables_v2 {
      * Identifier for the template that is being updated
      */
     templateId?: number;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Template;
+    requestBody?: Schema$Template;
   }
 }

--- a/src/apis/games/v1.ts
+++ b/src/apis/games/v1.ts
@@ -3604,6 +3604,12 @@ export namespace games_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$AchievementUpdateMultipleRequest;
   }
 
 
@@ -4137,10 +4143,11 @@ export namespace games_v1 {
      * The preferred language to use for strings returned by this method.
      */
     language?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EventRecordRequest;
+    requestBody?: Schema$EventRecordRequest;
   }
 
 
@@ -4850,12 +4857,24 @@ export namespace games_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PushTokenId;
   }
   export interface Params$Resource$Pushtokens$Update {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PushToken;
   }
 
 
@@ -5798,10 +5817,11 @@ export namespace games_v1 {
      * The preferred language to use for strings returned by this method.
      */
     language?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RoomCreateRequest;
+    requestBody?: Schema$RoomCreateRequest;
   }
   export interface Params$Resource$Rooms$Decline {
     /**
@@ -5858,10 +5878,11 @@ export namespace games_v1 {
      * The ID of the room.
      */
     roomId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RoomJoinRequest;
+    requestBody?: Schema$RoomJoinRequest;
   }
   export interface Params$Resource$Rooms$Leave {
     /**
@@ -5877,10 +5898,11 @@ export namespace games_v1 {
      * The ID of the room.
      */
     roomId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RoomLeaveRequest;
+    requestBody?: Schema$RoomLeaveRequest;
   }
   export interface Params$Resource$Rooms$List {
     /**
@@ -5917,10 +5939,11 @@ export namespace games_v1 {
      * The ID of the room.
      */
     roomId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RoomP2PStatuses;
+    requestBody?: Schema$RoomP2PStatuses;
   }
 
 
@@ -6465,10 +6488,11 @@ export namespace games_v1 {
      * The preferred language to use for strings returned by this method.
      */
     language?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlayerScoreSubmissionList;
+    requestBody?: Schema$PlayerScoreSubmissionList;
   }
 
 
@@ -7590,10 +7614,11 @@ export namespace games_v1 {
      * The preferred language to use for strings returned by this method.
      */
     language?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TurnBasedMatchCreateRequest;
+    requestBody?: Schema$TurnBasedMatchCreateRequest;
   }
   export interface Params$Resource$Turnbasedmatches$Decline {
     /**
@@ -7635,10 +7660,11 @@ export namespace games_v1 {
      * The ID of the match.
      */
     matchId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TurnBasedMatchResults;
+    requestBody?: Schema$TurnBasedMatchResults;
   }
   export interface Params$Resource$Turnbasedmatches$Get {
     /**
@@ -7820,9 +7846,10 @@ export namespace games_v1 {
      * The ID of the match.
      */
     matchId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TurnBasedMatchTurn;
+    requestBody?: Schema$TurnBasedMatchTurn;
   }
 }

--- a/src/apis/gamesConfiguration/v1configuration.ts
+++ b/src/apis/gamesConfiguration/v1configuration.ts
@@ -845,10 +845,11 @@ export namespace gamesConfiguration_v1configuration {
      * The application ID from the Google Play developer console.
      */
     applicationId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AchievementConfiguration;
+    requestBody?: Schema$AchievementConfiguration;
   }
   export interface Params$Resource$Achievementconfigurations$List {
     /**
@@ -881,10 +882,11 @@ export namespace gamesConfiguration_v1configuration {
      * The ID of the achievement used by this method.
      */
     achievementId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AchievementConfiguration;
+    requestBody?: Schema$AchievementConfiguration;
   }
   export interface Params$Resource$Achievementconfigurations$Update {
     /**
@@ -896,10 +898,11 @@ export namespace gamesConfiguration_v1configuration {
      * The ID of the achievement used by this method.
      */
     achievementId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AchievementConfiguration;
+    requestBody?: Schema$AchievementConfiguration;
   }
 
 
@@ -1006,10 +1009,12 @@ export namespace gamesConfiguration_v1configuration {
      * The ID of the resource used by this method.
      */
     resourceId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -1018,7 +1023,7 @@ export namespace gamesConfiguration_v1configuration {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -1498,10 +1503,11 @@ export namespace gamesConfiguration_v1configuration {
      * The application ID from the Google Play developer console.
      */
     applicationId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LeaderboardConfiguration;
+    requestBody?: Schema$LeaderboardConfiguration;
   }
   export interface Params$Resource$Leaderboardconfigurations$List {
     /**
@@ -1534,10 +1540,11 @@ export namespace gamesConfiguration_v1configuration {
      * The ID of the leaderboard.
      */
     leaderboardId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LeaderboardConfiguration;
+    requestBody?: Schema$LeaderboardConfiguration;
   }
   export interface Params$Resource$Leaderboardconfigurations$Update {
     /**
@@ -1549,9 +1556,10 @@ export namespace gamesConfiguration_v1configuration {
      * The ID of the leaderboard.
      */
     leaderboardId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LeaderboardConfiguration;
+    requestBody?: Schema$LeaderboardConfiguration;
   }
 }

--- a/src/apis/gamesManagement/v1management.ts
+++ b/src/apis/gamesManagement/v1management.ts
@@ -785,6 +785,12 @@ export namespace gamesManagement_v1management {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$AchievementResetMultipleForAllRequest;
   }
 
 
@@ -1281,6 +1287,12 @@ export namespace gamesManagement_v1management {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$EventsResetMultipleForAllRequest;
   }
 
 
@@ -1848,6 +1860,12 @@ export namespace gamesManagement_v1management {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$QuestsResetMultipleForAllRequest;
   }
 
 
@@ -2404,6 +2422,12 @@ export namespace gamesManagement_v1management {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ScoresResetMultipleForAllRequest;
   }
 
 

--- a/src/apis/genomics/v1.ts
+++ b/src/apis/genomics/v1.ts
@@ -3059,10 +3059,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchCreateAnnotationsRequest;
+    requestBody?: Schema$BatchCreateAnnotationsRequest;
   }
   export interface Params$Resource$Annotations$Create {
     /**
@@ -3070,10 +3071,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Annotation;
+    requestBody?: Schema$Annotation;
   }
   export interface Params$Resource$Annotations$Delete {
     /**
@@ -3103,10 +3105,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchAnnotationsRequest;
+    requestBody?: Schema$SearchAnnotationsRequest;
   }
   export interface Params$Resource$Annotations$Update {
     /**
@@ -3124,10 +3127,11 @@ export namespace genomics_v1 {
      * will be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Annotation;
+    requestBody?: Schema$Annotation;
   }
 
 
@@ -3788,10 +3792,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnnotationSet;
+    requestBody?: Schema$AnnotationSet;
   }
   export interface Params$Resource$Annotationsets$Delete {
     /**
@@ -3821,10 +3826,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchAnnotationSetsRequest;
+    requestBody?: Schema$SearchAnnotationSetsRequest;
   }
   export interface Params$Resource$Annotationsets$Update {
     /**
@@ -3842,10 +3848,11 @@ export namespace genomics_v1 {
      * updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnnotationSet;
+    requestBody?: Schema$AnnotationSet;
   }
 
 
@@ -4471,10 +4478,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CallSet;
+    requestBody?: Schema$CallSet;
   }
   export interface Params$Resource$Callsets$Delete {
     /**
@@ -4514,10 +4522,11 @@ export namespace genomics_v1 {
      * unspecified, all mutable fields will be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CallSet;
+    requestBody?: Schema$CallSet;
   }
   export interface Params$Resource$Callsets$Search {
     /**
@@ -4525,10 +4534,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchCallSetsRequest;
+    requestBody?: Schema$SearchCallSetsRequest;
   }
 
 
@@ -5673,10 +5683,11 @@ export namespace genomics_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Dataset;
+    requestBody?: Schema$Dataset;
   }
   export interface Params$Resource$Datasets$Delete {
     /**
@@ -5711,10 +5722,11 @@ export namespace genomics_v1 {
      * `datasets/<dataset ID>`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Datasets$List {
     /**
@@ -5754,10 +5766,11 @@ export namespace genomics_v1 {
      * unspecified, all mutable fields will be updated.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Dataset;
+    requestBody?: Schema$Dataset;
   }
   export interface Params$Resource$Datasets$Setiampolicy {
     /**
@@ -5770,10 +5783,11 @@ export namespace genomics_v1 {
      * `datasets/<dataset ID>`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Datasets$Testiampermissions {
     /**
@@ -5786,10 +5800,11 @@ export namespace genomics_v1 {
      * `datasets/<dataset ID>`.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Datasets$Undelete {
     /**
@@ -5801,10 +5816,11 @@ export namespace genomics_v1 {
      * The ID of the dataset to be undeleted.
      */
     datasetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteDatasetRequest;
+    requestBody?: Schema$UndeleteDatasetRequest;
   }
 
 
@@ -6205,10 +6221,11 @@ export namespace genomics_v1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Get {
     /**
@@ -7031,10 +7048,11 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
      * READ access to this read group set.
      */
     readGroupSetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ExportReadGroupSetRequest;
+    requestBody?: Schema$ExportReadGroupSetRequest;
   }
   export interface Params$Resource$Readgroupsets$Get {
     /**
@@ -7053,10 +7071,11 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ImportReadGroupSetsRequest;
+    requestBody?: Schema$ImportReadGroupSetsRequest;
   }
   export interface Params$Resource$Readgroupsets$Patch {
     /**
@@ -7075,10 +7094,11 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
      * specifying all mutable fields.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReadGroupSet;
+    requestBody?: Schema$ReadGroupSet;
   }
   export interface Params$Resource$Readgroupsets$Search {
     /**
@@ -7086,10 +7106,11 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchReadGroupSetsRequest;
+    requestBody?: Schema$SearchReadGroupSetsRequest;
   }
 
   export class Resource$Readgroupsets$Coveragebuckets {
@@ -7472,10 +7493,11 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchReadsRequest;
+    requestBody?: Schema$SearchReadsRequest;
   }
 
 
@@ -7763,10 +7785,11 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchReferencesRequest;
+    requestBody?: Schema$SearchReferencesRequest;
   }
 
   export class Resource$References$Bases {
@@ -8242,10 +8265,11 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchReferenceSetsRequest;
+    requestBody?: Schema$SearchReferenceSetsRequest;
   }
 
 
@@ -9083,10 +9107,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variant;
+    requestBody?: Schema$Variant;
   }
   export interface Params$Resource$Variants$Delete {
     /**
@@ -9116,10 +9141,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ImportVariantsRequest;
+    requestBody?: Schema$ImportVariantsRequest;
   }
   export interface Params$Resource$Variants$Merge {
     /**
@@ -9127,10 +9153,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$MergeVariantsRequest;
+    requestBody?: Schema$MergeVariantsRequest;
   }
   export interface Params$Resource$Variants$Patch {
     /**
@@ -9148,10 +9175,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      * The ID of the variant to be updated.
      */
     variantId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variant;
+    requestBody?: Schema$Variant;
   }
   export interface Params$Resource$Variants$Search {
     /**
@@ -9159,10 +9187,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchVariantsRequest;
+    requestBody?: Schema$SearchVariantsRequest;
   }
 
 
@@ -9936,10 +9965,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VariantSet;
+    requestBody?: Schema$VariantSet;
   }
   export interface Params$Resource$Variantsets$Delete {
     /**
@@ -9963,10 +9993,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      * should be exported. The caller must have READ access to this variant set.
      */
     variantSetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ExportVariantSetRequest;
+    requestBody?: Schema$ExportVariantSetRequest;
   }
   export interface Params$Resource$Variantsets$Get {
     /**
@@ -9995,10 +10026,11 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      * The ID of the variant to be updated (must already exist).
      */
     variantSetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VariantSet;
+    requestBody?: Schema$VariantSet;
   }
   export interface Params$Resource$Variantsets$Search {
     /**
@@ -10006,9 +10038,10 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchVariantSetsRequest;
+    requestBody?: Schema$SearchVariantSetsRequest;
   }
 }

--- a/src/apis/genomics/v1alpha2.ts
+++ b/src/apis/genomics/v1alpha2.ts
@@ -1305,10 +1305,11 @@ export namespace genomics_v1alpha2 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Get {
     /**
@@ -2229,10 +2230,11 @@ export namespace genomics_v1alpha2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Pipeline;
+    requestBody?: Schema$Pipeline;
   }
   export interface Params$Resource$Pipelines$Delete {
     /**
@@ -2306,10 +2308,11 @@ export namespace genomics_v1alpha2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunPipelineRequest;
+    requestBody?: Schema$RunPipelineRequest;
   }
   export interface Params$Resource$Pipelines$Setoperationstatus {
     /**
@@ -2317,9 +2320,10 @@ export namespace genomics_v1alpha2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SetOperationStatusRequest;
+    requestBody?: Schema$SetOperationStatusRequest;
   }
 }

--- a/src/apis/genomics/v2alpha1.ts
+++ b/src/apis/genomics/v2alpha1.ts
@@ -936,10 +936,11 @@ export namespace genomics_v2alpha1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunPipelineRequest;
+    requestBody?: Schema$RunPipelineRequest;
   }
 
 
@@ -1187,10 +1188,11 @@ export namespace genomics_v2alpha1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Projects$Operations$Get {
     /**
@@ -1336,9 +1338,10 @@ export namespace genomics_v2alpha1 {
      * The worker id, assigned when it was created.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CheckInRequest;
+    requestBody?: Schema$CheckInRequest;
   }
 }

--- a/src/apis/gmail/v1.ts
+++ b/src/apis/gmail/v1.ts
@@ -1156,10 +1156,11 @@ export namespace gmail_v1 {
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WatchRequest;
+    requestBody?: Schema$WatchRequest;
   }
 
   export class Resource$Users$Drafts {
@@ -1602,14 +1603,16 @@ export namespace gmail_v1 {
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Draft;
+    requestBody?: Schema$Draft;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -1618,7 +1621,7 @@ export namespace gmail_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Users$Drafts$Delete {
@@ -1698,14 +1701,16 @@ export namespace gmail_v1 {
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Draft;
+    requestBody?: Schema$Draft;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -1714,7 +1719,7 @@ export namespace gmail_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Users$Drafts$Update {
@@ -1732,14 +1737,16 @@ export namespace gmail_v1 {
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Draft;
+    requestBody?: Schema$Draft;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -1748,7 +1755,7 @@ export namespace gmail_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -2301,10 +2308,11 @@ export namespace gmail_v1 {
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Label;
+    requestBody?: Schema$Label;
   }
   export interface Params$Resource$Users$Labels$Delete {
     /**
@@ -2365,10 +2373,11 @@ export namespace gmail_v1 {
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Label;
+    requestBody?: Schema$Label;
   }
   export interface Params$Resource$Users$Labels$Update {
     /**
@@ -2385,10 +2394,11 @@ export namespace gmail_v1 {
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Label;
+    requestBody?: Schema$Label;
   }
 
 
@@ -3146,10 +3156,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchDeleteMessagesRequest;
+    requestBody?: Schema$BatchDeleteMessagesRequest;
   }
   export interface Params$Resource$Users$Messages$Batchmodify {
     /**
@@ -3162,10 +3173,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchModifyMessagesRequest;
+    requestBody?: Schema$BatchModifyMessagesRequest;
   }
   export interface Params$Resource$Users$Messages$Delete {
     /**
@@ -3237,14 +3249,16 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Message;
+    requestBody?: Schema$Message;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -3253,7 +3267,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Users$Messages$Insert {
@@ -3276,14 +3290,16 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Message;
+    requestBody?: Schema$Message;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -3292,7 +3308,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Users$Messages$List {
@@ -3347,10 +3363,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyMessageRequest;
+    requestBody?: Schema$ModifyMessageRequest;
   }
   export interface Params$Resource$Users$Messages$Send {
     /**
@@ -3363,14 +3380,16 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Message;
+    requestBody?: Schema$Message;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -3379,7 +3398,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Users$Messages$Trash {
@@ -4143,10 +4162,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AutoForwarding;
+    requestBody?: Schema$AutoForwarding;
   }
   export interface Params$Resource$Users$Settings$Updateimap {
     /**
@@ -4159,10 +4179,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ImapSettings;
+    requestBody?: Schema$ImapSettings;
   }
   export interface Params$Resource$Users$Settings$Updatepop {
     /**
@@ -4175,10 +4196,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PopSettings;
+    requestBody?: Schema$PopSettings;
   }
   export interface Params$Resource$Users$Settings$Updatevacation {
     /**
@@ -4191,10 +4213,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VacationSettings;
+    requestBody?: Schema$VacationSettings;
   }
 
   export class Resource$Users$Settings$Filters {
@@ -4483,10 +4506,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Filter;
+    requestBody?: Schema$Filter;
   }
   export interface Params$Resource$Users$Settings$Filters$Delete {
     /**
@@ -4851,10 +4875,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ForwardingAddress;
+    requestBody?: Schema$ForwardingAddress;
   }
   export interface Params$Resource$Users$Settings$Forwardingaddresses$Delete {
     /**
@@ -5421,10 +5446,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendAs;
+    requestBody?: Schema$SendAs;
   }
   export interface Params$Resource$Users$Settings$Sendas$Delete {
     /**
@@ -5485,10 +5511,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendAs;
+    requestBody?: Schema$SendAs;
   }
   export interface Params$Resource$Users$Settings$Sendas$Update {
     /**
@@ -5505,10 +5532,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendAs;
+    requestBody?: Schema$SendAs;
   }
   export interface Params$Resource$Users$Settings$Sendas$Verify {
     /**
@@ -5950,10 +5978,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SmimeInfo;
+    requestBody?: Schema$SmimeInfo;
   }
   export interface Params$Resource$Users$Settings$Sendas$Smimeinfo$List {
     /**
@@ -6505,10 +6534,11 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
      * the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyThreadRequest;
+    requestBody?: Schema$ModifyThreadRequest;
   }
   export interface Params$Resource$Users$Threads$Trash {
     /**

--- a/src/apis/groupsmigration/v1.ts
+++ b/src/apis/groupsmigration/v1.ts
@@ -174,10 +174,12 @@ export namespace groupsmigration_v1 {
      * The group ID
      */
     groupId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -186,7 +188,7 @@ export namespace groupsmigration_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 }

--- a/src/apis/groupssettings/v1.ts
+++ b/src/apis/groupssettings/v1.ts
@@ -441,10 +441,11 @@ export namespace groupssettings_v1 {
      * The resource ID
      */
     groupUniqueId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Groups;
+    requestBody?: Schema$Groups;
   }
   export interface Params$Resource$Groups$Update {
     /**
@@ -456,9 +457,10 @@ export namespace groupssettings_v1 {
      * The resource ID
      */
     groupUniqueId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Groups;
+    requestBody?: Schema$Groups;
   }
 }

--- a/src/apis/iam/v1.ts
+++ b/src/apis/iam/v1.ts
@@ -803,10 +803,11 @@ export namespace iam_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$QueryAuditableServicesRequest;
+    requestBody?: Schema$QueryAuditableServicesRequest;
   }
 
 
@@ -1252,10 +1253,11 @@ export namespace iam_v1 {
      * `organizations/{ORGANIZATION_ID}` `projects/{PROJECT_ID}`
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateRoleRequest;
+    requestBody?: Schema$CreateRoleRequest;
   }
   export interface Params$Resource$Organizations$Roles$Delete {
     /**
@@ -1332,10 +1334,11 @@ export namespace iam_v1 {
      * A mask describing which fields in the Role have changed.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Role;
+    requestBody?: Schema$Role;
   }
   export interface Params$Resource$Organizations$Roles$Undelete {
     /**
@@ -1349,10 +1352,11 @@ export namespace iam_v1 {
      * `projects/{PROJECT_ID}/roles/{ROLE_NAME}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteRoleRequest;
+    requestBody?: Schema$UndeleteRoleRequest;
   }
 
 
@@ -1455,10 +1459,11 @@ export namespace iam_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$QueryTestablePermissionsRequest;
+    requestBody?: Schema$QueryTestablePermissionsRequest;
   }
 
 
@@ -1905,10 +1910,11 @@ export namespace iam_v1 {
      * `organizations/{ORGANIZATION_ID}` `projects/{PROJECT_ID}`
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateRoleRequest;
+    requestBody?: Schema$CreateRoleRequest;
   }
   export interface Params$Resource$Projects$Roles$Delete {
     /**
@@ -1985,10 +1991,11 @@ export namespace iam_v1 {
      * A mask describing which fields in the Role have changed.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Role;
+    requestBody?: Schema$Role;
   }
   export interface Params$Resource$Projects$Roles$Undelete {
     /**
@@ -2002,10 +2009,11 @@ export namespace iam_v1 {
      * `projects/{PROJECT_ID}/roles/{ROLE_NAME}`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteRoleRequest;
+    requestBody?: Schema$UndeleteRoleRequest;
   }
 
 
@@ -2724,10 +2732,11 @@ export namespace iam_v1 {
      * accounts, such as `projects/my-project-123`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateServiceAccountRequest;
+    requestBody?: Schema$CreateServiceAccountRequest;
   }
   export interface Params$Resource$Projects$Serviceaccounts$Delete {
     /**
@@ -2805,10 +2814,11 @@ export namespace iam_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Serviceaccounts$Signblob {
     /**
@@ -2824,10 +2834,11 @@ export namespace iam_v1 {
      * service account.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SignBlobRequest;
+    requestBody?: Schema$SignBlobRequest;
   }
   export interface Params$Resource$Projects$Serviceaccounts$Signjwt {
     /**
@@ -2843,10 +2854,11 @@ export namespace iam_v1 {
      * service account.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SignJwtRequest;
+    requestBody?: Schema$SignJwtRequest;
   }
   export interface Params$Resource$Projects$Serviceaccounts$Testiampermissions {
     /**
@@ -2859,10 +2871,11 @@ export namespace iam_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Serviceaccounts$Update {
     /**
@@ -2879,10 +2892,11 @@ export namespace iam_v1 {
      * the format `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ServiceAccount;
+    requestBody?: Schema$ServiceAccount;
   }
 
   export class Resource$Projects$Serviceaccounts$Keys {
@@ -3180,10 +3194,11 @@ export namespace iam_v1 {
      * service account.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateServiceAccountKeyRequest;
+    requestBody?: Schema$CreateServiceAccountKeyRequest;
   }
   export interface Params$Resource$Projects$Serviceaccounts$Keys$Delete {
     /**
@@ -3508,9 +3523,10 @@ export namespace iam_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$QueryGrantableRolesRequest;
+    requestBody?: Schema$QueryGrantableRolesRequest;
   }
 }

--- a/src/apis/identitytoolkit/v3.ts
+++ b/src/apis/identitytoolkit/v3.ts
@@ -2999,36 +2999,72 @@ export namespace identitytoolkit_v3 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyCreateAuthUriRequest;
   }
   export interface Params$Resource$Relyingparty$Deleteaccount {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyDeleteAccountRequest;
   }
   export interface Params$Resource$Relyingparty$Downloadaccount {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyDownloadAccountRequest;
   }
   export interface Params$Resource$Relyingparty$Emaillinksignin {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyEmailLinkSigninRequest;
   }
   export interface Params$Resource$Relyingparty$Getaccountinfo {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyGetAccountInfoRequest;
   }
   export interface Params$Resource$Relyingparty$Getoobconfirmationcode {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Relyingparty;
   }
   export interface Params$Resource$Relyingparty$Getprojectconfig {
     /**
@@ -3062,65 +3098,131 @@ export namespace identitytoolkit_v3 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyResetPasswordRequest;
   }
   export interface Params$Resource$Relyingparty$Sendverificationcode {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartySendVerificationCodeRequest;
   }
   export interface Params$Resource$Relyingparty$Setaccountinfo {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartySetAccountInfoRequest;
   }
   export interface Params$Resource$Relyingparty$Setprojectconfig {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartySetProjectConfigRequest;
   }
   export interface Params$Resource$Relyingparty$Signoutuser {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartySignOutUserRequest;
   }
   export interface Params$Resource$Relyingparty$Signupnewuser {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartySignupNewUserRequest;
   }
   export interface Params$Resource$Relyingparty$Uploadaccount {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyUploadAccountRequest;
   }
   export interface Params$Resource$Relyingparty$Verifyassertion {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyVerifyAssertionRequest;
   }
   export interface Params$Resource$Relyingparty$Verifycustomtoken {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyVerifyCustomTokenRequest;
   }
   export interface Params$Resource$Relyingparty$Verifypassword {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyVerifyPasswordRequest;
   }
   export interface Params$Resource$Relyingparty$Verifyphonenumber {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$IdentitytoolkitRelyingpartyVerifyPhoneNumberRequest;
   }
 }

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -153,6 +153,7 @@ import {proximitybeacon_v1beta1} from './proximitybeacon/v1beta1';
 import {pubsub_v1} from './pubsub/v1';
 import {pubsub_v1beta1a} from './pubsub/v1beta1a';
 import {pubsub_v1beta2} from './pubsub/v1beta2';
+import {redis_v1beta1} from './redis/v1beta1';
 import {replicapool_v1beta1} from './replicapool/v1beta1';
 import {replicapool_v1beta2} from './replicapool/v1beta2';
 import {replicapoolupdater_v1beta1} from './replicapoolupdater/v1beta1';
@@ -529,6 +530,9 @@ export const APIS: APIList = {
     'v1': pubsub_v1.Pubsub,
     'v1beta1a': pubsub_v1beta1a.Pubsub,
     'v1beta2': pubsub_v1beta2.Pubsub,
+  },
+  redis: {
+    'v1beta1': redis_v1beta1.Redis,
   },
   replicapool: {
     'v1beta1': replicapool_v1beta1.Replicapool,
@@ -1451,6 +1455,12 @@ export class GeneratedAPIs {
       versionOrOptions: 'v1'|pubsub_v1.Options|'v1beta1a'|
       pubsub_v1beta1a.Options|'v1beta2'|pubsub_v1beta2.Options) {
     return this.getAPI<T>('pubsub', versionOrOptions);
+  }
+  redis(version: 'v1beta1'): redis_v1beta1.Redis;
+  redis(options: redis_v1beta1.Options): redis_v1beta1.Redis;
+  redis<T = redis_v1beta1.Redis>(versionOrOptions: 'v1beta1'|
+                                 redis_v1beta1.Options) {
+    return this.getAPI<T>('redis', versionOrOptions);
   }
   replicapool(version: 'v1beta1'): replicapool_v1beta1.Replicapool;
   replicapool(options: replicapool_v1beta1.Options):

--- a/src/apis/language/v1.ts
+++ b/src/apis/language/v1.ts
@@ -1037,10 +1037,11 @@ export namespace language_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeEntitiesRequest;
+    requestBody?: Schema$AnalyzeEntitiesRequest;
   }
   export interface Params$Resource$Documents$Analyzeentitysentiment {
     /**
@@ -1048,10 +1049,11 @@ export namespace language_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeEntitySentimentRequest;
+    requestBody?: Schema$AnalyzeEntitySentimentRequest;
   }
   export interface Params$Resource$Documents$Analyzesentiment {
     /**
@@ -1059,10 +1061,11 @@ export namespace language_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeSentimentRequest;
+    requestBody?: Schema$AnalyzeSentimentRequest;
   }
   export interface Params$Resource$Documents$Analyzesyntax {
     /**
@@ -1070,10 +1073,11 @@ export namespace language_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeSyntaxRequest;
+    requestBody?: Schema$AnalyzeSyntaxRequest;
   }
   export interface Params$Resource$Documents$Annotatetext {
     /**
@@ -1081,10 +1085,11 @@ export namespace language_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnnotateTextRequest;
+    requestBody?: Schema$AnnotateTextRequest;
   }
   export interface Params$Resource$Documents$Classifytext {
     /**
@@ -1092,9 +1097,10 @@ export namespace language_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ClassifyTextRequest;
+    requestBody?: Schema$ClassifyTextRequest;
   }
 }

--- a/src/apis/language/v1beta1.ts
+++ b/src/apis/language/v1beta1.ts
@@ -809,10 +809,11 @@ export namespace language_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeEntitiesRequest;
+    requestBody?: Schema$AnalyzeEntitiesRequest;
   }
   export interface Params$Resource$Documents$Analyzesentiment {
     /**
@@ -820,10 +821,11 @@ export namespace language_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeSentimentRequest;
+    requestBody?: Schema$AnalyzeSentimentRequest;
   }
   export interface Params$Resource$Documents$Analyzesyntax {
     /**
@@ -831,10 +833,11 @@ export namespace language_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeSyntaxRequest;
+    requestBody?: Schema$AnalyzeSyntaxRequest;
   }
   export interface Params$Resource$Documents$Annotatetext {
     /**
@@ -842,9 +845,10 @@ export namespace language_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnnotateTextRequest;
+    requestBody?: Schema$AnnotateTextRequest;
   }
 }

--- a/src/apis/language/v1beta2.ts
+++ b/src/apis/language/v1beta2.ts
@@ -1037,10 +1037,11 @@ export namespace language_v1beta2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeEntitiesRequest;
+    requestBody?: Schema$AnalyzeEntitiesRequest;
   }
   export interface Params$Resource$Documents$Analyzeentitysentiment {
     /**
@@ -1048,10 +1049,11 @@ export namespace language_v1beta2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeEntitySentimentRequest;
+    requestBody?: Schema$AnalyzeEntitySentimentRequest;
   }
   export interface Params$Resource$Documents$Analyzesentiment {
     /**
@@ -1059,10 +1061,11 @@ export namespace language_v1beta2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeSentimentRequest;
+    requestBody?: Schema$AnalyzeSentimentRequest;
   }
   export interface Params$Resource$Documents$Analyzesyntax {
     /**
@@ -1070,10 +1073,11 @@ export namespace language_v1beta2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnalyzeSyntaxRequest;
+    requestBody?: Schema$AnalyzeSyntaxRequest;
   }
   export interface Params$Resource$Documents$Annotatetext {
     /**
@@ -1081,10 +1085,11 @@ export namespace language_v1beta2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AnnotateTextRequest;
+    requestBody?: Schema$AnnotateTextRequest;
   }
   export interface Params$Resource$Documents$Classifytext {
     /**
@@ -1092,9 +1097,10 @@ export namespace language_v1beta2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ClassifyTextRequest;
+    requestBody?: Schema$ClassifyTextRequest;
   }
 }

--- a/src/apis/licensing/v1.ts
+++ b/src/apis/licensing/v1.ts
@@ -699,10 +699,11 @@ export namespace licensing_v1 {
      * Name for sku
      */
     skuId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LicenseAssignmentInsert;
+    requestBody?: Schema$LicenseAssignmentInsert;
   }
   export interface Params$Resource$Licenseassignments$Listforproduct {
     /**
@@ -778,10 +779,11 @@ export namespace licensing_v1 {
      * email id or unique Id of the user
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LicenseAssignment;
+    requestBody?: Schema$LicenseAssignment;
   }
   export interface Params$Resource$Licenseassignments$Update {
     /**
@@ -801,9 +803,10 @@ export namespace licensing_v1 {
      * email id or unique Id of the user
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LicenseAssignment;
+    requestBody?: Schema$LicenseAssignment;
   }
 }

--- a/src/apis/logging/v2.ts
+++ b/src/apis/logging/v2.ts
@@ -1649,10 +1649,11 @@ export namespace logging_v2 {
      * "projects/my-logging-project", "organizations/123456789".
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
   export interface Params$Resource$Billingaccounts$Exclusions$Delete {
     /**
@@ -1736,10 +1737,11 @@ export namespace logging_v2 {
      * update_mask of "filter,description".
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
 
 
@@ -2385,10 +2387,11 @@ export namespace logging_v2 {
      * writer_identity in LogSink.
      */
     uniqueWriterIdentity?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Billingaccounts$Sinks$Delete {
     /**
@@ -2489,10 +2492,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Billingaccounts$Sinks$Update {
     /**
@@ -2534,10 +2538,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
 
 
@@ -2697,10 +2702,11 @@ export namespace logging_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ListLogEntriesRequest;
+    requestBody?: Schema$ListLogEntriesRequest;
   }
   export interface Params$Resource$Entries$Write {
     /**
@@ -2708,10 +2714,11 @@ export namespace logging_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WriteLogEntriesRequest;
+    requestBody?: Schema$WriteLogEntriesRequest;
   }
 
 
@@ -3068,10 +3075,11 @@ export namespace logging_v2 {
      * "projects/my-logging-project", "organizations/123456789".
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
   export interface Params$Resource$Exclusions$Delete {
     /**
@@ -3155,10 +3163,11 @@ export namespace logging_v2 {
      * update_mask of "filter,description".
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
 
 
@@ -3541,10 +3550,11 @@ export namespace logging_v2 {
      * "projects/my-logging-project", "organizations/123456789".
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
   export interface Params$Resource$Folders$Exclusions$Delete {
     /**
@@ -3628,10 +3638,11 @@ export namespace logging_v2 {
      * update_mask of "filter,description".
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
 
 
@@ -4275,10 +4286,11 @@ export namespace logging_v2 {
      * writer_identity in LogSink.
      */
     uniqueWriterIdentity?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Folders$Sinks$Delete {
     /**
@@ -4379,10 +4391,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Folders$Sinks$Update {
     /**
@@ -4424,10 +4437,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
 
 
@@ -5113,10 +5127,11 @@ export namespace logging_v2 {
      * "projects/my-logging-project", "organizations/123456789".
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
   export interface Params$Resource$Organizations$Exclusions$Delete {
     /**
@@ -5200,10 +5215,11 @@ export namespace logging_v2 {
      * update_mask of "filter,description".
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
 
 
@@ -5849,10 +5865,11 @@ export namespace logging_v2 {
      * writer_identity in LogSink.
      */
     uniqueWriterIdentity?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Organizations$Sinks$Delete {
     /**
@@ -5953,10 +5970,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Organizations$Sinks$Update {
     /**
@@ -5998,10 +6016,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
 
 
@@ -6387,10 +6406,11 @@ export namespace logging_v2 {
      * "projects/my-logging-project", "organizations/123456789".
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
   export interface Params$Resource$Projects$Exclusions$Delete {
     /**
@@ -6474,10 +6494,11 @@ export namespace logging_v2 {
      * update_mask of "filter,description".
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogExclusion;
+    requestBody?: Schema$LogExclusion;
   }
 
 
@@ -7033,10 +7054,11 @@ export namespace logging_v2 {
      * "projects/[PROJECT_ID]" The new metric must be provided in the request.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogMetric;
+    requestBody?: Schema$LogMetric;
   }
   export interface Params$Resource$Projects$Metrics$Delete {
     /**
@@ -7101,10 +7123,11 @@ export namespace logging_v2 {
      * metric is created.
      */
     metricName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogMetric;
+    requestBody?: Schema$LogMetric;
   }
 
 
@@ -7554,10 +7577,11 @@ export namespace logging_v2 {
      * writer_identity in LogSink.
      */
     uniqueWriterIdentity?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Projects$Sinks$Delete {
     /**
@@ -7658,10 +7682,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Projects$Sinks$Update {
     /**
@@ -7703,10 +7728,11 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
 
 
@@ -8078,10 +8104,11 @@ export namespace logging_v2 {
      * writer_identity in LogSink.
      */
     uniqueWriterIdentity?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Sinks$Delete {
     /**
@@ -8182,9 +8209,10 @@ export namespace logging_v2 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
 }

--- a/src/apis/logging/v2beta1.ts
+++ b/src/apis/logging/v2beta1.ts
@@ -1832,10 +1832,11 @@ export namespace logging_v2beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ListLogEntriesRequest;
+    requestBody?: Schema$ListLogEntriesRequest;
   }
   export interface Params$Resource$Entries$Write {
     /**
@@ -1843,10 +1844,11 @@ export namespace logging_v2beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WriteLogEntriesRequest;
+    requestBody?: Schema$WriteLogEntriesRequest;
   }
 
 
@@ -3370,10 +3372,11 @@ export namespace logging_v2beta1 {
      * "projects/[PROJECT_ID]" The new metric must be provided in the request.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogMetric;
+    requestBody?: Schema$LogMetric;
   }
   export interface Params$Resource$Projects$Metrics$Delete {
     /**
@@ -3438,10 +3441,11 @@ export namespace logging_v2beta1 {
      * metric is created.
      */
     metricName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogMetric;
+    requestBody?: Schema$LogMetric;
   }
 
 
@@ -4140,10 +4144,11 @@ export namespace logging_v2beta1 {
      * writer_identity in LogSink.
      */
     uniqueWriterIdentity?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
   export interface Params$Resource$Projects$Sinks$Delete {
     /**
@@ -4244,9 +4249,10 @@ export namespace logging_v2beta1 {
      * updateMask=filter.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogSink;
+    requestBody?: Schema$LogSink;
   }
 }

--- a/src/apis/manufacturers/v1.ts
+++ b/src/apis/manufacturers/v1.ts
@@ -908,9 +908,10 @@ export namespace manufacturers_v1 {
      * of the Manufacturer Center account.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Attributes;
+    requestBody?: Schema$Attributes;
   }
 }

--- a/src/apis/mirror/v1.ts
+++ b/src/apis/mirror/v1.ts
@@ -820,10 +820,11 @@ export namespace mirror_v1 {
      * The ID for the user.
      */
     userToken?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
 
@@ -1249,6 +1250,12 @@ export namespace mirror_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Contact;
   }
   export interface Params$Resource$Contacts$List {
     /**
@@ -1266,10 +1273,11 @@ export namespace mirror_v1 {
      * The ID of the contact.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Contact;
+    requestBody?: Schema$Contact;
   }
   export interface Params$Resource$Contacts$Update {
     /**
@@ -1281,10 +1289,11 @@ export namespace mirror_v1 {
      * The ID of the contact.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Contact;
+    requestBody?: Schema$Contact;
   }
 
 
@@ -1832,6 +1841,12 @@ export namespace mirror_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Subscription;
   }
   export interface Params$Resource$Subscriptions$List {
     /**
@@ -1849,10 +1864,11 @@ export namespace mirror_v1 {
      * The ID of the subscription.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subscription;
+    requestBody?: Schema$Subscription;
   }
 
 
@@ -2302,6 +2318,27 @@ export namespace mirror_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$TimelineItem;
+
+    /**
+     * Media metadata
+     */
+    media?: {
+      /**
+       * Media mime-type
+       */
+      mediaType?: string;
+
+      /**
+       * Media body contents
+       */
+      body?: any;
+    };
   }
   export interface Params$Resource$Timeline$List {
     /**
@@ -2348,10 +2385,11 @@ export namespace mirror_v1 {
      * The ID of the timeline item.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TimelineItem;
+    requestBody?: Schema$TimelineItem;
   }
   export interface Params$Resource$Timeline$Update {
     /**
@@ -2363,14 +2401,16 @@ export namespace mirror_v1 {
      * The ID of the timeline item.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TimelineItem;
+    requestBody?: Schema$TimelineItem;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2379,7 +2419,7 @@ export namespace mirror_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -2708,10 +2748,12 @@ export namespace mirror_v1 {
      * The ID of the timeline item the attachment belongs to.
      */
     itemId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2720,7 +2762,7 @@ export namespace mirror_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Timeline$Attachments$List {

--- a/src/apis/ml/v1.ts
+++ b/src/apis/ml/v1.ts
@@ -1330,10 +1330,11 @@ export namespace ml_v1 {
      * requires the `predict` permission on the specified resource.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__PredictRequest;
+    requestBody?: Schema$GoogleCloudMlV1__PredictRequest;
   }
 
   export class Resource$Projects$Jobs {
@@ -1858,10 +1859,11 @@ export namespace ml_v1 {
      * Required. The name of the job to cancel.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__CancelJobRequest;
+    requestBody?: Schema$GoogleCloudMlV1__CancelJobRequest;
   }
   export interface Params$Resource$Projects$Jobs$Create {
     /**
@@ -1873,10 +1875,11 @@ export namespace ml_v1 {
      * Required. The project name.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__Job;
+    requestBody?: Schema$GoogleCloudMlV1__Job;
   }
   export interface Params$Resource$Projects$Jobs$Get {
     /**
@@ -1947,10 +1950,11 @@ export namespace ml_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__SetIamPolicyRequest;
+    requestBody?: Schema$GoogleIamV1__SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Jobs$Testiampermissions {
     /**
@@ -1963,10 +1967,11 @@ export namespace ml_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__TestIamPermissionsRequest;
+    requestBody?: Schema$GoogleIamV1__TestIamPermissionsRequest;
   }
 
 
@@ -2778,10 +2783,11 @@ export namespace ml_v1 {
      * Required. The project name.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__Model;
+    requestBody?: Schema$GoogleCloudMlV1__Model;
   }
   export interface Params$Resource$Projects$Models$Delete {
     /**
@@ -2866,10 +2872,11 @@ export namespace ml_v1 {
      * `default_version.name`.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__Model;
+    requestBody?: Schema$GoogleCloudMlV1__Model;
   }
   export interface Params$Resource$Projects$Models$Setiampolicy {
     /**
@@ -2882,10 +2889,11 @@ export namespace ml_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__SetIamPolicyRequest;
+    requestBody?: Schema$GoogleIamV1__SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Models$Testiampermissions {
     /**
@@ -2898,10 +2906,11 @@ export namespace ml_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__TestIamPermissionsRequest;
+    requestBody?: Schema$GoogleIamV1__TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Models$Versions {
@@ -3387,10 +3396,11 @@ export namespace ml_v1 {
      * Required. The name of the model.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__Version;
+    requestBody?: Schema$GoogleCloudMlV1__Version;
   }
   export interface Params$Resource$Projects$Models$Versions$Delete {
     /**
@@ -3463,10 +3473,11 @@ export namespace ml_v1 {
      * Currently the only supported update mask is`description`.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__Version;
+    requestBody?: Schema$GoogleCloudMlV1__Version;
   }
   export interface Params$Resource$Projects$Models$Versions$Setdefault {
     /**
@@ -3480,10 +3491,11 @@ export namespace ml_v1 {
      * [projects.models.versions.list](/ml-engine/reference/rest/v1/projects.models.versions/list).
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudMlV1__SetDefaultVersionRequest;
+    requestBody?: Schema$GoogleCloudMlV1__SetDefaultVersionRequest;
   }
 
 

--- a/src/apis/monitoring/v3.ts
+++ b/src/apis/monitoring/v3.ts
@@ -2221,10 +2221,11 @@ export namespace monitoring_v3 {
      * the container.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AlertPolicy;
+    requestBody?: Schema$AlertPolicy;
   }
   export interface Params$Resource$Projects$Alertpolicies$Delete {
     /**
@@ -2322,10 +2323,11 @@ export namespace monitoring_v3 {
      * created.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AlertPolicy;
+    requestBody?: Schema$AlertPolicy;
   }
 
 
@@ -2477,10 +2479,11 @@ export namespace monitoring_v3 {
      * "projects/PROJECT_ID_OR_NUMBER".
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateCollectdTimeSeriesRequest;
+    requestBody?: Schema$CreateCollectdTimeSeriesRequest;
   }
 
 
@@ -3094,10 +3097,11 @@ export namespace monitoring_v3 {
      * If true, validate this request but do not create the group.
      */
     validateOnly?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
   export interface Params$Resource$Projects$Groups$Delete {
     /**
@@ -3184,10 +3188,11 @@ export namespace monitoring_v3 {
      * If true, validate this request but do not update the existing group.
      */
     validateOnly?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
 
   export class Resource$Projects$Groups$Members {
@@ -3862,10 +3867,11 @@ export namespace monitoring_v3 {
      * "projects/{project_id_or_number}".
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$MetricDescriptor;
+    requestBody?: Schema$MetricDescriptor;
   }
   export interface Params$Resource$Projects$Metricdescriptors$Delete {
     /**
@@ -5068,10 +5074,11 @@ export namespace monitoring_v3 {
      * the channel.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NotificationChannel;
+    requestBody?: Schema$NotificationChannel;
   }
   export interface Params$Resource$Projects$Notificationchannels$Delete {
     /**
@@ -5116,10 +5123,11 @@ export namespace monitoring_v3 {
      * specified channel is not verified, the request will fail.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetNotificationChannelVerificationCodeRequest;
+    requestBody?: Schema$GetNotificationChannelVerificationCodeRequest;
   }
   export interface Params$Resource$Projects$Notificationchannels$List {
     /**
@@ -5176,10 +5184,11 @@ export namespace monitoring_v3 {
      * The fields to update.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$NotificationChannel;
+    requestBody?: Schema$NotificationChannel;
   }
   export interface Params$Resource$Projects$Notificationchannels$Sendverificationcode {
     /**
@@ -5191,10 +5200,11 @@ export namespace monitoring_v3 {
      * The notification channel to which to send a verification code.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SendNotificationChannelVerificationCodeRequest;
+    requestBody?: Schema$SendNotificationChannelVerificationCodeRequest;
   }
   export interface Params$Resource$Projects$Notificationchannels$Verify {
     /**
@@ -5206,10 +5216,11 @@ export namespace monitoring_v3 {
      * The notification channel to verify.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VerifyNotificationChannelRequest;
+    requestBody?: Schema$VerifyNotificationChannelRequest;
   }
 
 
@@ -5486,10 +5497,11 @@ export namespace monitoring_v3 {
      * "projects/{project_id_or_number}".
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateTimeSeriesRequest;
+    requestBody?: Schema$CreateTimeSeriesRequest;
   }
   export interface Params$Resource$Projects$Timeseries$List {
     /**
@@ -5961,10 +5973,11 @@ export namespace monitoring_v3 {
      * projects/[PROJECT_ID].
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UptimeCheckConfig;
+    requestBody?: Schema$UptimeCheckConfig;
   }
   export interface Params$Resource$Projects$Uptimecheckconfigs$Delete {
     /**
@@ -6036,10 +6049,11 @@ export namespace monitoring_v3 {
      * with the new configuration.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UptimeCheckConfig;
+    requestBody?: Schema$UptimeCheckConfig;
   }
 
 

--- a/src/apis/oslogin/v1.ts
+++ b/src/apis/oslogin/v1.ts
@@ -357,10 +357,11 @@ export namespace oslogin_v1 {
      * The project ID of the Google Cloud Platform project.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SshPublicKey;
+    requestBody?: Schema$SshPublicKey;
   }
 
   export class Resource$Users$Projects {
@@ -705,9 +706,10 @@ export namespace oslogin_v1 {
      * Mask to control which fields get updated. Updates all if not present.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SshPublicKey;
+    requestBody?: Schema$SshPublicKey;
   }
 }

--- a/src/apis/oslogin/v1alpha.ts
+++ b/src/apis/oslogin/v1alpha.ts
@@ -357,10 +357,11 @@ export namespace oslogin_v1alpha {
      * The project ID of the Google Cloud Platform project.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SshPublicKey;
+    requestBody?: Schema$SshPublicKey;
   }
 
   export class Resource$Users$Projects {
@@ -710,9 +711,10 @@ export namespace oslogin_v1alpha {
      * Mask to control which fields get updated. Updates all if not present.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SshPublicKey;
+    requestBody?: Schema$SshPublicKey;
   }
 }

--- a/src/apis/oslogin/v1beta.ts
+++ b/src/apis/oslogin/v1beta.ts
@@ -357,10 +357,11 @@ export namespace oslogin_v1beta {
      * The project ID of the Google Cloud Platform project.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SshPublicKey;
+    requestBody?: Schema$SshPublicKey;
   }
 
   export class Resource$Users$Projects {
@@ -705,9 +706,10 @@ export namespace oslogin_v1beta {
      * Mask to control which fields get updated. Updates all if not present.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SshPublicKey;
+    requestBody?: Schema$SshPublicKey;
   }
 }

--- a/src/apis/partners/v2.ts
+++ b/src/apis/partners/v2.ts
@@ -1623,10 +1623,11 @@ export namespace partners_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogMessageRequest;
+    requestBody?: Schema$LogMessageRequest;
   }
 
 
@@ -2099,10 +2100,11 @@ export namespace partners_v2 {
      * The ID of the company to contact.
      */
     companyId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateLeadRequest;
+    requestBody?: Schema$CreateLeadRequest;
   }
 
 
@@ -2605,10 +2607,11 @@ export namespace partners_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LogUserEventRequest;
+    requestBody?: Schema$LogUserEventRequest;
   }
 
 
@@ -2961,10 +2964,11 @@ export namespace partners_v2 {
      * authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CompanyRelation;
+    requestBody?: Schema$CompanyRelation;
   }
   export interface Params$Resource$Users$Deletecompanyrelation {
     /**
@@ -3093,10 +3097,11 @@ export namespace partners_v2 {
      * Logged-in user ID to impersonate instead of the user's ID.
      */
     'requestMetadata.userOverrides.userId'?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserProfile;
+    requestBody?: Schema$UserProfile;
   }
 
 
@@ -3538,10 +3543,11 @@ export namespace partners_v2 {
      * least 1 value in FieldMask's paths.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Company;
+    requestBody?: Schema$Company;
   }
   export interface Params$Resource$V2$Updateleads {
     /**
@@ -3586,9 +3592,10 @@ export namespace partners_v2 {
      * `adwords_customer_id` are currently supported.
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Lead;
+    requestBody?: Schema$Lead;
   }
 }

--- a/src/apis/people/v1.ts
+++ b/src/apis/people/v1.ts
@@ -1739,10 +1739,11 @@ export namespace people_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateContactGroupRequest;
+    requestBody?: Schema$CreateContactGroupRequest;
   }
   export interface Params$Resource$Contactgroups$Delete {
     /**
@@ -1807,10 +1808,11 @@ export namespace people_v1 {
      * string, in the form of `contactGroups/`<var>contact_group_id</var>.
      */
     resourceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateContactGroupRequest;
+    requestBody?: Schema$UpdateContactGroupRequest;
   }
 
   export class Resource$Contactgroups$Members {
@@ -1915,10 +1917,11 @@ export namespace people_v1 {
      * The resource name of the contact group to modify.
      */
     resourceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyContactGroupMembersRequest;
+    requestBody?: Schema$ModifyContactGroupMembersRequest;
   }
 
 
@@ -2294,10 +2297,11 @@ export namespace people_v1 {
      * The resource name of the owning person resource.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Person;
+    requestBody?: Schema$Person;
   }
   export interface Params$Resource$People$Deletecontact {
     /**
@@ -2398,10 +2402,11 @@ export namespace people_v1 {
      * phoneNumbers * relations * residences * urls
      */
     updatePersonFields?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Person;
+    requestBody?: Schema$Person;
   }
 
   export class Resource$People$Connections {

--- a/src/apis/playcustomapp/v1.ts
+++ b/src/apis/playcustomapp/v1.ts
@@ -194,14 +194,16 @@ export namespace playcustomapp_v1 {
      * Developer account ID.
      */
     account?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CustomApp;
+    requestBody?: Schema$CustomApp;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -210,7 +212,7 @@ export namespace playcustomapp_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 }

--- a/src/apis/plusDomains/v1.ts
+++ b/src/apis/plusDomains/v1.ts
@@ -1000,10 +1000,11 @@ export namespace plusDomains_v1 {
      * be "me", to indicate the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Activity;
+    requestBody?: Schema$Activity;
   }
   export interface Params$Resource$Activities$List {
     /**
@@ -1716,10 +1717,11 @@ export namespace plusDomains_v1 {
      * be used to indicate the authenticated user.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Circle;
+    requestBody?: Schema$Circle;
   }
   export interface Params$Resource$Circles$List {
     /**
@@ -1755,10 +1757,11 @@ export namespace plusDomains_v1 {
      * The ID of the circle to update.
      */
     circleId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Circle;
+    requestBody?: Schema$Circle;
   }
   export interface Params$Resource$Circles$Remove {
     /**
@@ -1800,10 +1803,11 @@ export namespace plusDomains_v1 {
      * The ID of the circle to update.
      */
     circleId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Circle;
+    requestBody?: Schema$Circle;
   }
 
 
@@ -2036,10 +2040,11 @@ export namespace plusDomains_v1 {
      * The ID of the activity to reply to.
      */
     activityId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
   export interface Params$Resource$Comments$List {
     /**
@@ -2172,14 +2177,16 @@ export namespace plusDomains_v1 {
      * The ID of the user to create the activity on behalf of.
      */
     userId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Media;
+    requestBody?: Schema$Media;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2188,7 +2195,7 @@ export namespace plusDomains_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 

--- a/src/apis/proximitybeacon/v1beta1.ts
+++ b/src/apis/proximitybeacon/v1beta1.ts
@@ -672,10 +672,11 @@ export namespace proximitybeacon_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetInfoForObservedBeaconsRequest;
+    requestBody?: Schema$GetInfoForObservedBeaconsRequest;
   }
 
 
@@ -1477,10 +1478,11 @@ export namespace proximitybeacon_v1beta1 {
      * Optional.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Beacon;
+    requestBody?: Schema$Beacon;
   }
   export interface Params$Resource$Beacons$Update {
     /**
@@ -1503,10 +1505,11 @@ export namespace proximitybeacon_v1beta1 {
      * must match the project that owns the beacon. Optional.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Beacon;
+    requestBody?: Schema$Beacon;
   }
 
   export class Resource$Beacons$Attachments {
@@ -1894,10 +1897,11 @@ export namespace proximitybeacon_v1beta1 {
      * Optional.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BeaconAttachment;
+    requestBody?: Schema$BeaconAttachment;
   }
   export interface Params$Resource$Beacons$Attachments$Delete {
     /**
@@ -2260,10 +2264,11 @@ export namespace proximitybeacon_v1beta1 {
      * must match the project that owns the beacon. Optional.
      */
     projectId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Namespace;
+    requestBody?: Schema$Namespace;
   }
 
 

--- a/src/apis/pubsub/v1.ts
+++ b/src/apis/pubsub/v1.ts
@@ -90,13 +90,12 @@ export namespace pubsub_v1 {
      * without a Google account.  * `allAuthenticatedUsers`: A special
      * identifier that represents anyone    who is authenticated with a Google
      * account or a service account.  * `user:{emailid}`: An email address that
-     * represents a specific Google    account. For example, `alice@gmail.com`
-     * or `joe@example.com`.   * `serviceAccount:{emailid}`: An email address
-     * that represents a service    account. For example,
-     * `my-other-app@appspot.gserviceaccount.com`.  * `group:{emailid}`: An
-     * email address that represents a Google group.    For example,
-     * `admins@example.com`.   * `domain:{domain}`: A Google Apps domain name
-     * that represents all the    users of that domain. For example,
+     * represents a specific Google    account. For example, `alice@gmail.com` .
+     * * `serviceAccount:{emailid}`: An email address that represents a service
+     * account. For example, `my-other-app@appspot.gserviceaccount.com`.  *
+     * `group:{emailid}`: An email address that represents a Google group. For
+     * example, `admins@example.com`.   * `domain:{domain}`: A Google Apps
+     * domain name that represents all the    users of that domain. For example,
      * `google.com` or `example.com`.
      */
     members?: string[];
@@ -1363,10 +1362,11 @@ export namespace pubsub_v1 {
      * `projects/{project}/snapshots/{snap}`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateSnapshotRequest;
+    requestBody?: Schema$CreateSnapshotRequest;
   }
   export interface Params$Resource$Projects$Snapshots$Delete {
     /**
@@ -1436,10 +1436,11 @@ export namespace pubsub_v1 {
      * The name of the snapshot.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateSnapshotRequest;
+    requestBody?: Schema$UpdateSnapshotRequest;
   }
   export interface Params$Resource$Projects$Snapshots$Setiampolicy {
     /**
@@ -1452,10 +1453,11 @@ export namespace pubsub_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Snapshots$Testiampermissions {
     /**
@@ -1468,10 +1470,11 @@ export namespace pubsub_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -3055,10 +3058,11 @@ export namespace pubsub_v1 {
      * `projects/{project}/subscriptions/{sub}`.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AcknowledgeRequest;
+    requestBody?: Schema$AcknowledgeRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Create {
     /**
@@ -3075,10 +3079,11 @@ export namespace pubsub_v1 {
      * characters in length, and it must not start with `"goog"`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subscription;
+    requestBody?: Schema$Subscription;
   }
   export interface Params$Resource$Projects$Subscriptions$Delete {
     /**
@@ -3149,10 +3154,11 @@ export namespace pubsub_v1 {
      * `projects/{project}/subscriptions/{sub}`.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyAckDeadlineRequest;
+    requestBody?: Schema$ModifyAckDeadlineRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Modifypushconfig {
     /**
@@ -3165,10 +3171,11 @@ export namespace pubsub_v1 {
      * `projects/{project}/subscriptions/{sub}`.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyPushConfigRequest;
+    requestBody?: Schema$ModifyPushConfigRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Patch {
     /**
@@ -3185,10 +3192,11 @@ export namespace pubsub_v1 {
      * characters in length, and it must not start with `"goog"`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateSubscriptionRequest;
+    requestBody?: Schema$UpdateSubscriptionRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Pull {
     /**
@@ -3201,10 +3209,11 @@ export namespace pubsub_v1 {
      * `projects/{project}/subscriptions/{sub}`.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PullRequest;
+    requestBody?: Schema$PullRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Seek {
     /**
@@ -3216,10 +3225,11 @@ export namespace pubsub_v1 {
      * The subscription to affect.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SeekRequest;
+    requestBody?: Schema$SeekRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Setiampolicy {
     /**
@@ -3232,10 +3242,11 @@ export namespace pubsub_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Testiampermissions {
     /**
@@ -3248,10 +3259,11 @@ export namespace pubsub_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -4310,10 +4322,11 @@ export namespace pubsub_v1 {
      * and it must not start with `"goog"`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Topic;
+    requestBody?: Schema$Topic;
   }
   export interface Params$Resource$Projects$Topics$Delete {
     /**
@@ -4384,10 +4397,11 @@ export namespace pubsub_v1 {
      * `projects/{project}/topics/{topic}`.
      */
     topic?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PublishRequest;
+    requestBody?: Schema$PublishRequest;
   }
   export interface Params$Resource$Projects$Topics$Setiampolicy {
     /**
@@ -4400,10 +4414,11 @@ export namespace pubsub_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Topics$Testiampermissions {
     /**
@@ -4416,10 +4431,11 @@ export namespace pubsub_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Topics$Snapshots {

--- a/src/apis/pubsub/v1beta1a.ts
+++ b/src/apis/pubsub/v1beta1a.ts
@@ -1044,10 +1044,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AcknowledgeRequest;
+    requestBody?: Schema$AcknowledgeRequest;
   }
   export interface Params$Resource$Subscriptions$Create {
     /**
@@ -1055,10 +1056,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subscription;
+    requestBody?: Schema$Subscription;
   }
   export interface Params$Resource$Subscriptions$Delete {
     /**
@@ -1108,10 +1110,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyAckDeadlineRequest;
+    requestBody?: Schema$ModifyAckDeadlineRequest;
   }
   export interface Params$Resource$Subscriptions$Modifypushconfig {
     /**
@@ -1119,10 +1122,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyPushConfigRequest;
+    requestBody?: Schema$ModifyPushConfigRequest;
   }
   export interface Params$Resource$Subscriptions$Pull {
     /**
@@ -1130,10 +1134,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PullRequest;
+    requestBody?: Schema$PullRequest;
   }
   export interface Params$Resource$Subscriptions$Pullbatch {
     /**
@@ -1141,10 +1146,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PullBatchRequest;
+    requestBody?: Schema$PullBatchRequest;
   }
 
 
@@ -1560,10 +1566,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Topic;
+    requestBody?: Schema$Topic;
   }
   export interface Params$Resource$Topics$Delete {
     /**
@@ -1613,10 +1620,11 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PublishRequest;
+    requestBody?: Schema$PublishRequest;
   }
   export interface Params$Resource$Topics$Publishbatch {
     /**
@@ -1624,9 +1632,10 @@ export namespace pubsub_v1beta1a {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PublishBatchRequest;
+    requestBody?: Schema$PublishBatchRequest;
   }
 }

--- a/src/apis/pubsub/v1beta2.ts
+++ b/src/apis/pubsub/v1beta2.ts
@@ -90,13 +90,12 @@ export namespace pubsub_v1beta2 {
      * without a Google account.  * `allAuthenticatedUsers`: A special
      * identifier that represents anyone    who is authenticated with a Google
      * account or a service account.  * `user:{emailid}`: An email address that
-     * represents a specific Google    account. For example, `alice@gmail.com`
-     * or `joe@example.com`.   * `serviceAccount:{emailid}`: An email address
-     * that represents a service    account. For example,
-     * `my-other-app@appspot.gserviceaccount.com`.  * `group:{emailid}`: An
-     * email address that represents a Google group.    For example,
-     * `admins@example.com`.   * `domain:{domain}`: A Google Apps domain name
-     * that represents all the    users of that domain. For example,
+     * represents a specific Google    account. For example, `alice@gmail.com` .
+     * * `serviceAccount:{emailid}`: An email address that represents a service
+     * account. For example, `my-other-app@appspot.gserviceaccount.com`.  *
+     * `group:{emailid}`: An email address that represents a Google group. For
+     * example, `admins@example.com`.   * `domain:{domain}`: A Google Apps
+     * domain name that represents all the    users of that domain. For example,
      * `google.com` or `example.com`.
      */
     members?: string[];
@@ -1267,10 +1266,11 @@ export namespace pubsub_v1beta2 {
      * The subscription whose message is being acknowledged.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AcknowledgeRequest;
+    requestBody?: Schema$AcknowledgeRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Create {
     /**
@@ -1287,10 +1287,11 @@ export namespace pubsub_v1beta2 {
      * characters in length, and it must not start with `"goog"`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subscription;
+    requestBody?: Schema$Subscription;
   }
   export interface Params$Resource$Projects$Subscriptions$Delete {
     /**
@@ -1357,10 +1358,11 @@ export namespace pubsub_v1beta2 {
      * The name of the subscription.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyAckDeadlineRequest;
+    requestBody?: Schema$ModifyAckDeadlineRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Modifypushconfig {
     /**
@@ -1372,10 +1374,11 @@ export namespace pubsub_v1beta2 {
      * The name of the subscription.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ModifyPushConfigRequest;
+    requestBody?: Schema$ModifyPushConfigRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Pull {
     /**
@@ -1387,10 +1390,11 @@ export namespace pubsub_v1beta2 {
      * The subscription from which messages should be pulled.
      */
     subscription?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PullRequest;
+    requestBody?: Schema$PullRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Setiampolicy {
     /**
@@ -1403,10 +1407,11 @@ export namespace pubsub_v1beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Subscriptions$Testiampermissions {
     /**
@@ -1419,10 +1424,11 @@ export namespace pubsub_v1beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -2007,10 +2013,11 @@ export namespace pubsub_v1beta2 {
      * and it must not start with `"goog"`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Topic;
+    requestBody?: Schema$Topic;
   }
   export interface Params$Resource$Projects$Topics$Delete {
     /**
@@ -2077,10 +2084,11 @@ export namespace pubsub_v1beta2 {
      * The messages in the request will be published on this topic.
      */
     topic?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PublishRequest;
+    requestBody?: Schema$PublishRequest;
   }
   export interface Params$Resource$Projects$Topics$Setiampolicy {
     /**
@@ -2093,10 +2101,11 @@ export namespace pubsub_v1beta2 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Topics$Testiampermissions {
     /**
@@ -2109,10 +2118,11 @@ export namespace pubsub_v1beta2 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Topics$Subscriptions {

--- a/src/apis/redis/v1beta1.ts
+++ b/src/apis/redis/v1beta1.ts
@@ -1,0 +1,1331 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AxiosPromise} from 'axios';
+import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
+
+import {GoogleApis} from '../..';
+import {BodyResponseCallback, GlobalOptions, MethodOptions} from '../../lib/api';
+import {createAPIRequest} from '../../lib/apirequest';
+
+// TODO: We will eventually get the `any` in here cleared out, but in the
+// interim we want to turn on no-implicit-any.
+
+// tslint:disable: no-any
+// tslint:disable: class-name
+// tslint:disable: variable-name
+// tslint:disable: jsdoc-format
+// tslint:disable: no-namespace
+
+export namespace redis_v1beta1 {
+  export interface Options extends GlobalOptions { version: 'v1beta1'; }
+
+  /**
+   * Cloud Memorystore for Redis API
+   *
+   * The Google Cloud Memorystore for Redis API is used for creating and
+   * managing Redis instances on the Google Cloud Platform.
+   *
+   * @example
+   * const google = require('googleapis');
+   * const redis = google.redis('v1beta1');
+   *
+   * @namespace redis
+   * @type {Function}
+   * @version v1beta1
+   * @variation v1beta1
+   * @param {object=} options Options for Redis
+   */
+  export class Redis {
+    _options: GlobalOptions;
+    google: GoogleApis;
+    root = this;
+
+    projects: Resource$Projects;
+
+    constructor(options: GlobalOptions, google: GoogleApis) {
+      this._options = options || {};
+      this.google = google;
+      this.getRoot.bind(this);
+
+      this.projects = new Resource$Projects(this);
+    }
+
+    getRoot() {
+      return this.root;
+    }
+  }
+
+  /**
+   * Represents the metadata of the long-running operation.
+   */
+  export interface Schema$GoogleCloudCommonOperationMetadata {
+    /**
+     * [Output only] API version used to start the operation.
+     */
+    apiVersion?: string;
+    /**
+     * [Output only] Identifies whether the user has requested cancellation of
+     * the operation. Operations that have successfully been cancelled have
+     * Operation.error value with a google.rpc.Status.code of 1, corresponding
+     * to `Code.CANCELLED`.
+     */
+    cancelRequested?: boolean;
+    /**
+     * [Output only] The time the operation was created.
+     */
+    createTime?: string;
+    /**
+     * [Output only] The time the operation finished running.
+     */
+    endTime?: string;
+    /**
+     * [Output only] Human-readable status of the operation, if any.
+     */
+    statusDetail?: string;
+    /**
+     * [Output only] Server-defined resource path for the target of the
+     * operation.
+     */
+    target?: string;
+    /**
+     * [Output only] Name of the verb executed by the operation.
+     */
+    verb?: string;
+  }
+  /**
+   * This location metadata represents additional configuration options for a
+   * given location where a Redis instance may be created. All fields are output
+   * only. It is returned as content of the
+   * `google.cloud.location.Location.metadata` field.
+   */
+  export interface Schema$GoogleCloudRedisV1beta1LocationMetadata {
+    /**
+     * Output only. The set of available zones in the location. The map is keyed
+     * by the lowercase ID of each zone, as defined by GCE. These keys can be
+     * specified in `location_id` or `alternative_location_id` fields when
+     * creating a Redis instance.
+     */
+    availableZones?: any;
+  }
+  /**
+   * Defines specific information for a particular zone. Currently empty and
+   * reserved for future use only.
+   */
+  export interface Schema$GoogleCloudRedisV1beta1ZoneMetadata {}
+  /**
+   * A Google Cloud Redis instance.
+   */
+  export interface Schema$Instance {
+    /**
+     * Optional. Only applicable to STANDARD_HA tier which protects the instance
+     * against zonal failures by provisioning it across two zones. If provided,
+     * it must be a different zone from the one provided in [location_id].
+     */
+    alternativeLocationId?: string;
+    /**
+     * Optional. The full name of the Google Compute Engine
+     * [network](/compute/docs/networks-and-firewalls#networks) to which the
+     * instance is connected. If left unspecified, the `default` network will be
+     * used.
+     */
+    authorizedNetwork?: string;
+    /**
+     * Output only. The time the instance was created.
+     */
+    createTime?: string;
+    /**
+     * Output only. The current zone where the Redis endpoint is placed. In
+     * single zone deployments, this will always be the same as [location_id]
+     * provided by the user at creation time. In cross-zone instances (only
+     * applicable in STANDARD_HA tier), this can be either [location_id] or
+     * [alternative_location_id] and can change on a failover event.
+     */
+    currentLocationId?: string;
+    /**
+     * An arbitrary and optional user-provided name for the instance.
+     */
+    displayName?: string;
+    /**
+     * Output only. Hostname or IP address of the exposed Redis endpoint used by
+     * clients to connect to the service.
+     */
+    host?: string;
+    /**
+     * Resource labels to represent user provided metadata
+     */
+    labels?: any;
+    /**
+     * Optional. The zone where the instance will be provisioned. If not
+     * provided, the service will choose a zone for the instance. For
+     * STANDARD_HA tier, instances will be created across two zones for
+     * protection against zonal failures. if [alternative_location_id] is also
+     * provided, it must be different from [location_id].
+     */
+    locationId?: string;
+    /**
+     * Required. Redis memory size in GB, up to 200GB.
+     */
+    memorySizeGb?: number;
+    /**
+     * Required. Unique name of the resource in this scope including project and
+     * location using the form:
+     * `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+     * Note: Redis instances are managed and addressed at regional level so
+     * location_id here refers to a GCP region; however, users get to choose
+     * which specific zone (or collection of zones for cross-zone instances) an
+     * instance should be provisioned in. Refer to [location_id] and
+     * [alternative_location_id] fields for more details.
+     */
+    name?: string;
+    /**
+     * Output only. The port number of the exposed Redis endpoint.
+     */
+    port?: number;
+    /**
+     * Optional. Redis configuration parameters, according to
+     * http://redis.io/topics/config. Currently, the only supported parameters
+     * are:  * maxmemory-policy  * notify-keyspace-events
+     */
+    redisConfigs?: any;
+    /**
+     * Optional. The version of Redis software. If not provided, latest
+     * supported version will be used. Updating the version will perform an
+     * upgrade/downgrade to the new version. Currently, the supported values are
+     * `REDIS_3_2` for Redis 3.2.
+     */
+    redisVersion?: string;
+    /**
+     * Optional. The CIDR range of internal addresses that are reserved for this
+     * instance. If not provided, the service will choose an unused /29 block,
+     * for example, 10.0.0.0/29 or 192.168.0.0/29. Ranges must be unique and
+     * non-overlapping with existing subnets in a network.
+     */
+    reservedIpRange?: string;
+    /**
+     * Output only. The current state of this instance.
+     */
+    state?: string;
+    /**
+     * Output only. Additional information about the current status of this
+     * instance, if available.
+     */
+    statusMessage?: string;
+    /**
+     * Required. The service tier of the instance.
+     */
+    tier?: string;
+  }
+  /**
+   * Response for ListInstances.
+   */
+  export interface Schema$ListInstancesResponse {
+    /**
+     * A list of Redis instances in the project in the specified location, or
+     * across all locations.  If the `location_id` in the parent field of the
+     * request is &quot;-&quot;, all regions available to the project are
+     * queried, and the results aggregated. If in such an aggregated query a
+     * location is unavailable, a dummy Redis entry is included in the response
+     * with the &quot;name&quot; field set to a value of the form
+     * projects/{project_id}/locations/{location_id}/instances/- and the
+     * &quot;status&quot; field set to ERROR and &quot;status_message&quot;
+     * field set to &quot;location not available for ListInstances&quot;.
+     */
+    instances?: Schema$Instance[];
+    /**
+     * Token to retrieve the next page of results, or empty if there are no more
+     * results in the list.
+     */
+    nextPageToken?: string;
+  }
+  /**
+   * The response message for Locations.ListLocations.
+   */
+  export interface Schema$ListLocationsResponse {
+    /**
+     * A list of locations that matches the specified filter in the request.
+     */
+    locations?: Schema$Location[];
+    /**
+     * The standard List next-page token.
+     */
+    nextPageToken?: string;
+  }
+  /**
+   * The response message for Operations.ListOperations.
+   */
+  export interface Schema$ListOperationsResponse {
+    /**
+     * The standard List next-page token.
+     */
+    nextPageToken?: string;
+    /**
+     * A list of operations that matches the specified filter in the request.
+     */
+    operations?: Schema$Operation[];
+  }
+  /**
+   * A resource that represents Google Cloud Platform location.
+   */
+  export interface Schema$Location {
+    /**
+     * The friendly name for this location, typically a nearby city name. For
+     * example, &quot;Tokyo&quot;.
+     */
+    displayName?: string;
+    /**
+     * Cross-service attributes for the location. For example
+     * {&quot;cloud.googleapis.com/region&quot;: &quot;us-east1&quot;}
+     */
+    labels?: any;
+    /**
+     * The canonical id for this location. For example: `&quot;us-east1&quot;`.
+     */
+    locationId?: string;
+    /**
+     * Service-specific metadata. For example the available capacity at the
+     * given location.
+     */
+    metadata?: any;
+    /**
+     * Resource name for the location, which may vary between implementations.
+     * For example: `&quot;projects/example-project/locations/us-east1&quot;`
+     */
+    name?: string;
+  }
+  /**
+   * This location metadata represents additional configuration options for a
+   * given location where a Redis instance may be created. All fields are output
+   * only. It is returned as content of the
+   * `google.cloud.location.Location.metadata` field.
+   */
+  export interface Schema$LocationMetadata {
+    /**
+     * Output only. The set of available zones in the location. The map is keyed
+     * by the lowercase ID of each zone, as defined by GCE. These keys can be
+     * specified in `location_id` or `alternative_location_id` fields when
+     * creating a Redis instance.
+     */
+    availableZones?: any;
+  }
+  /**
+   * This resource represents a long-running operation that is the result of a
+   * network API call.
+   */
+  export interface Schema$Operation {
+    /**
+     * If the value is `false`, it means the operation is still in progress. If
+     * `true`, the operation is completed, and either `error` or `response` is
+     * available.
+     */
+    done?: boolean;
+    /**
+     * The error result of the operation in case of failure or cancellation.
+     */
+    error?: Schema$Status;
+    /**
+     * Service-specific metadata associated with the operation.  It typically
+     * contains progress information and common metadata such as create time.
+     * Some services might not provide such metadata.  Any method that returns a
+     * long-running operation should document the metadata type, if any.
+     */
+    metadata?: any;
+    /**
+     * The server-assigned name, which is only unique within the same service
+     * that originally returns it. If you use the default HTTP mapping, the
+     * `name` should have the format of `operations/some/unique/name`.
+     */
+    name?: string;
+    /**
+     * The normal response of the operation in case of success.  If the original
+     * method returns no data on success, such as `Delete`, the response is
+     * `google.protobuf.Empty`.  If the original method is standard
+     * `Get`/`Create`/`Update`, the response should be the resource.  For other
+     * methods, the response should have the type `XxxResponse`, where `Xxx` is
+     * the original method name.  For example, if the original method name is
+     * `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.
+     */
+    response?: any;
+  }
+  /**
+   * This operation metadata represents the state of operations that may have
+   * happened or are happening on the instance. All fields are output only. It
+   * is returned as content of the `google.longrunning.Operation.metadata`
+   * field. The `google.longrunning.Operation.name` field will be of the form
+   * `projects/{project_id}/locations/{location_id}/operations/{operation_id}`
+   * and the name for a `ListOperations` request will be of the form
+   * `projects/{project_id}/locations/{location_id}`  On a ListOperations
+   * request where {location_id} is &quot;-&quot;, all regions available to the
+   * {project_id} are queried and the results aggregated. If a location is not
+   * available, a dummy `google.longrunning.Operation` entry will be included in
+   * the `operations` field of the response, with the `name` field set to a
+   * value of the form
+   * `projects/{project_id}/locations/{location_id}/operations/-` and the `done`
+   * field will be set and the `result.error` field set with the `code` field
+   * set to `google.rpc.Code.DEADLINE_EXCEEDED` and the `message` field set to
+   * `location unavailable for ListOperations`. The Operation metadata` field
+   * will not be set for such a dummy operation.
+   */
+  export interface Schema$OperationMetadata {
+    /**
+     * Output only. The time the operation was created.
+     */
+    createTime?: string;
+    /**
+     * Output only. Detailed operation progress, if available.
+     */
+    detail?: string;
+    /**
+     * Output only. The time the operation was completed.
+     */
+    endTime?: string;
+    /**
+     * Output only. The operation type.
+     */
+    operationType?: string;
+    /**
+     * Output only. The time the operation was started.
+     */
+    startTime?: string;
+    /**
+     * Output only. The current state of the operation.
+     */
+    state?: string;
+    /**
+     * Output only. Server-defined resource path for the target of the
+     * operation.
+     */
+    target?: string;
+  }
+  /**
+   * The `Status` type defines a logical error model that is suitable for
+   * different programming environments, including REST APIs and RPC APIs. It is
+   * used by [gRPC](https://github.com/grpc). The error model is designed to be:
+   * - Simple to use and understand for most users - Flexible enough to meet
+   * unexpected needs  # Overview  The `Status` message contains three pieces of
+   * data: error code, error message, and error details. The error code should
+   * be an enum value of google.rpc.Code, but it may accept additional error
+   * codes if needed.  The error message should be a developer-facing English
+   * message that helps developers *understand* and *resolve* the error. If a
+   * localized user-facing error message is needed, put the localized message in
+   * the error details or localize it in the client. The optional error details
+   * may contain arbitrary information about the error. There is a predefined
+   * set of error detail types in the package `google.rpc` that can be used for
+   * common error conditions.  # Language mapping  The `Status` message is the
+   * logical representation of the error model, but it is not necessarily the
+   * actual wire format. When the `Status` message is exposed in different
+   * client libraries and different wire protocols, it can be mapped
+   * differently. For example, it will likely be mapped to some exceptions in
+   * Java, but more likely mapped to some error codes in C.  # Other uses  The
+   * error model and the `Status` message can be used in a variety of
+   * environments, either with or without APIs, to provide a consistent
+   * developer experience across different environments.  Example uses of this
+   * error model include:  - Partial errors. If a service needs to return
+   * partial errors to the client,     it may embed the `Status` in the normal
+   * response to indicate the partial     errors.  - Workflow errors. A typical
+   * workflow has multiple steps. Each step may     have a `Status` message for
+   * error reporting.  - Batch operations. If a client uses batch request and
+   * batch response, the     `Status` message should be used directly inside
+   * batch response, one for     each error sub-response.  - Asynchronous
+   * operations. If an API call embeds asynchronous operation     results in its
+   * response, the status of those operations should be     represented directly
+   * using the `Status` message.  - Logging. If some API errors are stored in
+   * logs, the message `Status` could     be used directly after any stripping
+   * needed for security/privacy reasons.
+   */
+  export interface Schema$Status {
+    /**
+     * The status code, which should be an enum value of google.rpc.Code.
+     */
+    code?: number;
+    /**
+     * A list of messages that carry the error details.  There is a common set
+     * of message types for APIs to use.
+     */
+    details?: any[];
+    /**
+     * A developer-facing error message, which should be in English. Any
+     * user-facing error message should be localized and sent in the
+     * google.rpc.Status.details field, or localized by the client.
+     */
+    message?: string;
+  }
+  /**
+   * Defines specific information for a particular zone. Currently empty and
+   * reserved for future use only.
+   */
+  export interface Schema$ZoneMetadata {}
+
+
+  export class Resource$Projects {
+    root: Redis;
+    locations: Resource$Projects$Locations;
+    constructor(root: Redis) {
+      this.root = root;
+      this.getRoot.bind(this);
+      this.locations = new Resource$Projects$Locations(root);
+    }
+
+    getRoot() {
+      return this.root;
+    }
+  }
+
+
+  export class Resource$Projects$Locations {
+    root: Redis;
+    instances: Resource$Projects$Locations$Instances;
+    operations: Resource$Projects$Locations$Operations;
+    constructor(root: Redis) {
+      this.root = root;
+      this.getRoot.bind(this);
+      this.instances = new Resource$Projects$Locations$Instances(root);
+      this.operations = new Resource$Projects$Locations$Operations(root);
+    }
+
+    getRoot() {
+      return this.root;
+    }
+
+
+    /**
+     * redis.projects.locations.get
+     * @desc Gets information about a location.
+     * @alias redis.projects.locations.get
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.name Resource name for the location.
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get(params?: Params$Resource$Projects$Locations$Get,
+        options?: MethodOptions): AxiosPromise<Schema$Location>;
+    get(params: Params$Resource$Projects$Locations$Get,
+        options: MethodOptions|BodyResponseCallback<Schema$Location>,
+        callback: BodyResponseCallback<Schema$Location>): void;
+    get(params: Params$Resource$Projects$Locations$Get,
+        callback: BodyResponseCallback<Schema$Location>): void;
+    get(callback: BodyResponseCallback<Schema$Location>): void;
+    get(paramsOrCallback?: Params$Resource$Projects$Locations$Get|
+        BodyResponseCallback<Schema$Location>,
+        optionsOrCallback?: MethodOptions|BodyResponseCallback<Schema$Location>,
+        callback?: BodyResponseCallback<Schema$Location>):
+        void|AxiosPromise<Schema$Location> {
+      let params =
+          (paramsOrCallback || {}) as Params$Resource$Projects$Locations$Get;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Get;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+name}').replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$Location>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$Location>(parameters);
+      }
+    }
+
+
+    /**
+     * redis.projects.locations.list
+     * @desc Lists information about the supported locations for this service.
+     * @alias redis.projects.locations.list
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string=} params.filter The standard list filter.
+     * @param {string} params.name The resource that owns the locations collection, if applicable.
+     * @param {integer=} params.pageSize The standard list page size.
+     * @param {string=} params.pageToken The standard list page token.
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    list(
+        params?: Params$Resource$Projects$Locations$List,
+        options?: MethodOptions): AxiosPromise<Schema$ListLocationsResponse>;
+    list(
+        params: Params$Resource$Projects$Locations$List,
+        options: MethodOptions|
+        BodyResponseCallback<Schema$ListLocationsResponse>,
+        callback: BodyResponseCallback<Schema$ListLocationsResponse>): void;
+    list(
+        params: Params$Resource$Projects$Locations$List,
+        callback: BodyResponseCallback<Schema$ListLocationsResponse>): void;
+    list(callback: BodyResponseCallback<Schema$ListLocationsResponse>): void;
+    list(
+        paramsOrCallback?: Params$Resource$Projects$Locations$List|
+        BodyResponseCallback<Schema$ListLocationsResponse>,
+        optionsOrCallback?: MethodOptions|
+        BodyResponseCallback<Schema$ListLocationsResponse>,
+        callback?: BodyResponseCallback<Schema$ListLocationsResponse>):
+        void|AxiosPromise<Schema$ListLocationsResponse> {
+      let params =
+          (paramsOrCallback || {}) as Params$Resource$Projects$Locations$List;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$List;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+name}/locations')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$ListLocationsResponse>(parameters);
+      }
+    }
+  }
+
+  export interface Params$Resource$Projects$Locations$Get {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * Resource name for the location.
+     */
+    name?: string;
+  }
+  export interface Params$Resource$Projects$Locations$List {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * The standard list filter.
+     */
+    filter?: string;
+    /**
+     * The resource that owns the locations collection, if applicable.
+     */
+    name?: string;
+    /**
+     * The standard list page size.
+     */
+    pageSize?: number;
+    /**
+     * The standard list page token.
+     */
+    pageToken?: string;
+  }
+
+  export class Resource$Projects$Locations$Instances {
+    root: Redis;
+    constructor(root: Redis) {
+      this.root = root;
+      this.getRoot.bind(this);
+    }
+
+    getRoot() {
+      return this.root;
+    }
+
+
+    /**
+     * redis.projects.locations.instances.create
+     * @desc Creates a Redis instance based on the specified tier and memory
+     * size.  By default, the instance is peered to the project's [default
+     * network](/compute/docs/networks-and-firewalls#networks).  The creation is
+     * executed asynchronously and callers may check the returned operation to
+     * track its progress. Once the operation is completed the Redis instance
+     * will be fully functional. Completed longrunning.Operation will contain
+     * the new instance object in the response field.  The returned operation is
+     * automatically deleted after a few hours, so there is no need to call
+     * DeleteOperation.
+     * @alias redis.projects.locations.instances.create
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string=} params.instanceId Required. The logical name of the Redis instance in the customer project with the following restrictions:  * Must contain only lowercase letters, numbers, and hyphens. * Must start with a letter. * Must be between 1-40 characters. * Must end with a number or a letter. * Must be unique within the customer project / location
+     * @param {string} params.parent Required. The resource name of the instance location using the form:     `projects/{project_id}/locations/{location_id}` where `location_id` refers to a GCP region
+     * @param {().Instance} params.resource Request body data
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    create(
+        params?: Params$Resource$Projects$Locations$Instances$Create,
+        options?: MethodOptions): AxiosPromise<Schema$Operation>;
+    create(
+        params: Params$Resource$Projects$Locations$Instances$Create,
+        options: MethodOptions|BodyResponseCallback<Schema$Operation>,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    create(
+        params: Params$Resource$Projects$Locations$Instances$Create,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    create(callback: BodyResponseCallback<Schema$Operation>): void;
+    create(
+        paramsOrCallback?: Params$Resource$Projects$Locations$Instances$Create|
+        BodyResponseCallback<Schema$Operation>,
+        optionsOrCallback?: MethodOptions|
+        BodyResponseCallback<Schema$Operation>,
+        callback?: BodyResponseCallback<Schema$Operation>):
+        void|AxiosPromise<Schema$Operation> {
+      let params = (paramsOrCallback || {}) as
+          Params$Resource$Projects$Locations$Instances$Create;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Instances$Create;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+parent}/instances')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'POST'
+            },
+            options),
+        params,
+        requiredParams: ['parent'],
+        pathParams: ['parent'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$Operation>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$Operation>(parameters);
+      }
+    }
+
+
+    /**
+     * redis.projects.locations.instances.delete
+     * @desc Deletes a specific Redis instance.  Instance stops serving and data
+     * is deleted.
+     * @alias redis.projects.locations.instances.delete
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.name Required. Redis instance resource name using the form:     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id` refers to a GCP region
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    delete(
+        params?: Params$Resource$Projects$Locations$Instances$Delete,
+        options?: MethodOptions): AxiosPromise<Schema$Operation>;
+    delete(
+        params: Params$Resource$Projects$Locations$Instances$Delete,
+        options: MethodOptions|BodyResponseCallback<Schema$Operation>,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    delete(
+        params: Params$Resource$Projects$Locations$Instances$Delete,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    delete(callback: BodyResponseCallback<Schema$Operation>): void;
+    delete(
+        paramsOrCallback?: Params$Resource$Projects$Locations$Instances$Delete|
+        BodyResponseCallback<Schema$Operation>,
+        optionsOrCallback?: MethodOptions|
+        BodyResponseCallback<Schema$Operation>,
+        callback?: BodyResponseCallback<Schema$Operation>):
+        void|AxiosPromise<Schema$Operation> {
+      let params = (paramsOrCallback || {}) as
+          Params$Resource$Projects$Locations$Instances$Delete;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Instances$Delete;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+name}').replace(/([^:]\/)\/+/g, '$1'),
+              method: 'DELETE'
+            },
+            options),
+        params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$Operation>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$Operation>(parameters);
+      }
+    }
+
+
+    /**
+     * redis.projects.locations.instances.get
+     * @desc Gets the details of a specific Redis instance.
+     * @alias redis.projects.locations.instances.get
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.name Required. Redis instance resource name using the form:     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id` refers to a GCP region
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get(params?: Params$Resource$Projects$Locations$Instances$Get,
+        options?: MethodOptions): AxiosPromise<Schema$Instance>;
+    get(params: Params$Resource$Projects$Locations$Instances$Get,
+        options: MethodOptions|BodyResponseCallback<Schema$Instance>,
+        callback: BodyResponseCallback<Schema$Instance>): void;
+    get(params: Params$Resource$Projects$Locations$Instances$Get,
+        callback: BodyResponseCallback<Schema$Instance>): void;
+    get(callback: BodyResponseCallback<Schema$Instance>): void;
+    get(paramsOrCallback?: Params$Resource$Projects$Locations$Instances$Get|
+        BodyResponseCallback<Schema$Instance>,
+        optionsOrCallback?: MethodOptions|BodyResponseCallback<Schema$Instance>,
+        callback?: BodyResponseCallback<Schema$Instance>):
+        void|AxiosPromise<Schema$Instance> {
+      let params = (paramsOrCallback || {}) as
+          Params$Resource$Projects$Locations$Instances$Get;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Instances$Get;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+name}').replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$Instance>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$Instance>(parameters);
+      }
+    }
+
+
+    /**
+     * redis.projects.locations.instances.list
+     * @desc Lists all Redis instances owned by a project in either the
+     * specified location (region) or all locations.  The location should have
+     * the following format: * `projects/{project_id}/locations/{location_id}`
+     * If `location_id` is specified as `-` (wildcard), then all regions
+     * available to the project are queried, and the results are aggregated.
+     * @alias redis.projects.locations.instances.list
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {integer=} params.pageSize The maximum number of items to return.  If not specified, a default value of 1000 will be used by the service. Regardless of the page_size value, the response may include a partial list and a caller should only rely on response's next_page_token to determine if there are more instances left to be queried.
+     * @param {string=} params.pageToken The next_page_token value returned from a previous List request, if any.
+     * @param {string} params.parent Required. The resource name of the instance location using the form:     `projects/{project_id}/locations/{location_id}` where `location_id` refers to a GCP region
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    list(
+        params?: Params$Resource$Projects$Locations$Instances$List,
+        options?: MethodOptions): AxiosPromise<Schema$ListInstancesResponse>;
+    list(
+        params: Params$Resource$Projects$Locations$Instances$List,
+        options: MethodOptions|
+        BodyResponseCallback<Schema$ListInstancesResponse>,
+        callback: BodyResponseCallback<Schema$ListInstancesResponse>): void;
+    list(
+        params: Params$Resource$Projects$Locations$Instances$List,
+        callback: BodyResponseCallback<Schema$ListInstancesResponse>): void;
+    list(callback: BodyResponseCallback<Schema$ListInstancesResponse>): void;
+    list(
+        paramsOrCallback?: Params$Resource$Projects$Locations$Instances$List|
+        BodyResponseCallback<Schema$ListInstancesResponse>,
+        optionsOrCallback?: MethodOptions|
+        BodyResponseCallback<Schema$ListInstancesResponse>,
+        callback?: BodyResponseCallback<Schema$ListInstancesResponse>):
+        void|AxiosPromise<Schema$ListInstancesResponse> {
+      let params = (paramsOrCallback || {}) as
+          Params$Resource$Projects$Locations$Instances$List;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Instances$List;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+parent}/instances')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['parent'],
+        pathParams: ['parent'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$ListInstancesResponse>(parameters);
+      }
+    }
+
+
+    /**
+     * redis.projects.locations.instances.patch
+     * @desc Updates the metadata and configuration of a specific Redis
+     * instance.  Completed longrunning.Operation will contain the new instance
+     * object in the response field. The returned operation is automatically
+     * deleted after a few hours, so there is no need to call DeleteOperation.
+     * @alias redis.projects.locations.instances.patch
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.name Required. Unique name of the resource in this scope including project and location using the form:     `projects/{project_id}/locations/{location_id}/instances/{instance_id}`  Note: Redis instances are managed and addressed at regional level so location_id here refers to a GCP region; however, users get to choose which specific zone (or collection of zones for cross-zone instances) an instance should be provisioned in. Refer to [location_id] and [alternative_location_id] fields for more details.
+     * @param {string=} params.updateMask Required. Mask of fields to update. At least one path must be supplied in this field. The elements of the repeated paths field may only include these fields from Instance: * `display_name` * `labels` * `redis_config` * `redis_version`
+     * @param {().Instance} params.resource Request body data
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    patch(
+        params?: Params$Resource$Projects$Locations$Instances$Patch,
+        options?: MethodOptions): AxiosPromise<Schema$Operation>;
+    patch(
+        params: Params$Resource$Projects$Locations$Instances$Patch,
+        options: MethodOptions|BodyResponseCallback<Schema$Operation>,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    patch(
+        params: Params$Resource$Projects$Locations$Instances$Patch,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    patch(callback: BodyResponseCallback<Schema$Operation>): void;
+    patch(
+        paramsOrCallback?: Params$Resource$Projects$Locations$Instances$Patch|
+        BodyResponseCallback<Schema$Operation>,
+        optionsOrCallback?: MethodOptions|
+        BodyResponseCallback<Schema$Operation>,
+        callback?: BodyResponseCallback<Schema$Operation>):
+        void|AxiosPromise<Schema$Operation> {
+      let params = (paramsOrCallback || {}) as
+          Params$Resource$Projects$Locations$Instances$Patch;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Instances$Patch;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+name}').replace(/([^:]\/)\/+/g, '$1'),
+              method: 'PATCH'
+            },
+            options),
+        params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$Operation>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$Operation>(parameters);
+      }
+    }
+  }
+
+  export interface Params$Resource$Projects$Locations$Instances$Create {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * Required. The logical name of the Redis instance in the customer project
+     * with the following restrictions:  * Must contain only lowercase letters,
+     * numbers, and hyphens. * Must start with a letter. * Must be between 1-40
+     * characters. * Must end with a number or a letter. * Must be unique within
+     * the customer project / location
+     */
+    instanceId?: string;
+    /**
+     * Required. The resource name of the instance location using the form:
+     * `projects/{project_id}/locations/{location_id}` where `location_id`
+     * refers to a GCP region
+     */
+    parent?: string;
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Instance;
+  }
+  export interface Params$Resource$Projects$Locations$Instances$Delete {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * Required. Redis instance resource name using the form:
+     * `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+     * where `location_id` refers to a GCP region
+     */
+    name?: string;
+  }
+  export interface Params$Resource$Projects$Locations$Instances$Get {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * Required. Redis instance resource name using the form:
+     * `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+     * where `location_id` refers to a GCP region
+     */
+    name?: string;
+  }
+  export interface Params$Resource$Projects$Locations$Instances$List {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * The maximum number of items to return.  If not specified, a default value
+     * of 1000 will be used by the service. Regardless of the page_size value,
+     * the response may include a partial list and a caller should only rely on
+     * response's next_page_token to determine if there are more instances left
+     * to be queried.
+     */
+    pageSize?: number;
+    /**
+     * The next_page_token value returned from a previous List request, if any.
+     */
+    pageToken?: string;
+    /**
+     * Required. The resource name of the instance location using the form:
+     * `projects/{project_id}/locations/{location_id}` where `location_id`
+     * refers to a GCP region
+     */
+    parent?: string;
+  }
+  export interface Params$Resource$Projects$Locations$Instances$Patch {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * Required. Unique name of the resource in this scope including project and
+     * location using the form:
+     * `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+     * Note: Redis instances are managed and addressed at regional level so
+     * location_id here refers to a GCP region; however, users get to choose
+     * which specific zone (or collection of zones for cross-zone instances) an
+     * instance should be provisioned in. Refer to [location_id] and
+     * [alternative_location_id] fields for more details.
+     */
+    name?: string;
+    /**
+     * Required. Mask of fields to update. At least one path must be supplied in
+     * this field. The elements of the repeated paths field may only include
+     * these fields from Instance: * `display_name` * `labels` * `redis_config`
+     * * `redis_version`
+     */
+    updateMask?: string;
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Instance;
+  }
+
+
+  export class Resource$Projects$Locations$Operations {
+    root: Redis;
+    constructor(root: Redis) {
+      this.root = root;
+      this.getRoot.bind(this);
+    }
+
+    getRoot() {
+      return this.root;
+    }
+
+
+    /**
+     * redis.projects.locations.operations.get
+     * @desc Gets the latest state of a long-running operation.  Clients can use
+     * this method to poll the operation result at intervals as recommended by
+     * the API service.
+     * @alias redis.projects.locations.operations.get
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string} params.name The name of the operation resource.
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    get(params?: Params$Resource$Projects$Locations$Operations$Get,
+        options?: MethodOptions): AxiosPromise<Schema$Operation>;
+    get(params: Params$Resource$Projects$Locations$Operations$Get,
+        options: MethodOptions|BodyResponseCallback<Schema$Operation>,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    get(params: Params$Resource$Projects$Locations$Operations$Get,
+        callback: BodyResponseCallback<Schema$Operation>): void;
+    get(callback: BodyResponseCallback<Schema$Operation>): void;
+    get(paramsOrCallback?: Params$Resource$Projects$Locations$Operations$Get|
+        BodyResponseCallback<Schema$Operation>,
+        optionsOrCallback?: MethodOptions|
+        BodyResponseCallback<Schema$Operation>,
+        callback?: BodyResponseCallback<Schema$Operation>):
+        void|AxiosPromise<Schema$Operation> {
+      let params = (paramsOrCallback || {}) as
+          Params$Resource$Projects$Locations$Operations$Get;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Operations$Get;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+name}').replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$Operation>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$Operation>(parameters);
+      }
+    }
+
+
+    /**
+     * redis.projects.locations.operations.list
+     * @desc Lists operations that match the specified filter in the request. If
+     * the server doesn't support this method, it returns `UNIMPLEMENTED`. NOTE:
+     * the `name` binding allows API services to override the binding to use
+     * different resource name schemes, such as `users/x/operations`. To
+     * override the binding, API services can add a binding such as
+     * `"/v1/{name=users/x}/operations"` to their service configuration. For
+     * backwards compatibility, the default name includes the operations
+     * collection id, however overriding users must ensure the name binding is
+     * the parent resource, without the operations collection id.
+     * @alias redis.projects.locations.operations.list
+     * @memberOf! ()
+     *
+     * @param {object} params Parameters for request
+     * @param {string=} params.filter The standard list filter.
+     * @param {string} params.name The name of the operation's parent resource.
+     * @param {integer=} params.pageSize The standard list page size.
+     * @param {string=} params.pageToken The standard list page token.
+     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param {callback} callback The callback that handles the response.
+     * @return {object} Request object
+     */
+    list(
+        params?: Params$Resource$Projects$Locations$Operations$List,
+        options?: MethodOptions): AxiosPromise<Schema$ListOperationsResponse>;
+    list(
+        params: Params$Resource$Projects$Locations$Operations$List,
+        options: MethodOptions|
+        BodyResponseCallback<Schema$ListOperationsResponse>,
+        callback: BodyResponseCallback<Schema$ListOperationsResponse>): void;
+    list(
+        params: Params$Resource$Projects$Locations$Operations$List,
+        callback: BodyResponseCallback<Schema$ListOperationsResponse>): void;
+    list(callback: BodyResponseCallback<Schema$ListOperationsResponse>): void;
+    list(
+        paramsOrCallback?: Params$Resource$Projects$Locations$Operations$List|
+        BodyResponseCallback<Schema$ListOperationsResponse>,
+        optionsOrCallback?: MethodOptions|
+        BodyResponseCallback<Schema$ListOperationsResponse>,
+        callback?: BodyResponseCallback<Schema$ListOperationsResponse>):
+        void|AxiosPromise<Schema$ListOperationsResponse> {
+      let params = (paramsOrCallback || {}) as
+          Params$Resource$Projects$Locations$Operations$List;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Projects$Locations$Operations$List;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://redis.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+            {
+              url: (rootUrl + '/v1beta1/{+name}/operations')
+                       .replace(/([^:]\/)\/+/g, '$1'),
+              method: 'GET'
+            },
+            options),
+        params,
+        requiredParams: ['name'],
+        pathParams: ['name'],
+        context: this.getRoot()
+      };
+      if (callback) {
+        createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
+      } else {
+        return createAPIRequest<Schema$ListOperationsResponse>(parameters);
+      }
+    }
+  }
+
+  export interface Params$Resource$Projects$Locations$Operations$Get {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * The name of the operation resource.
+     */
+    name?: string;
+  }
+  export interface Params$Resource$Projects$Locations$Operations$List {
+    /**
+     * Auth client or API Key for the request
+     */
+    auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+    /**
+     * The standard list filter.
+     */
+    filter?: string;
+    /**
+     * The name of the operation's parent resource.
+     */
+    name?: string;
+    /**
+     * The standard list page size.
+     */
+    pageSize?: number;
+    /**
+     * The standard list page token.
+     */
+    pageToken?: string;
+  }
+}

--- a/src/apis/replicapool/v1beta1.ts
+++ b/src/apis/replicapool/v1beta1.ts
@@ -1024,10 +1024,11 @@ export namespace replicapool_v1beta1 {
      * The zone for this replica pool.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PoolsDeleteRequest;
+    requestBody?: Schema$PoolsDeleteRequest;
   }
   export interface Params$Resource$Pools$Get {
     /**
@@ -1062,10 +1063,11 @@ export namespace replicapool_v1beta1 {
      * The zone for this replica pool.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Pool;
+    requestBody?: Schema$Pool;
   }
   export interface Params$Resource$Pools$List {
     /**
@@ -1135,10 +1137,11 @@ export namespace replicapool_v1beta1 {
      * The zone for this replica pool.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Template;
+    requestBody?: Schema$Template;
   }
 
 
@@ -1453,10 +1456,11 @@ export namespace replicapool_v1beta1 {
      * The zone where the replica lives.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReplicasDeleteRequest;
+    requestBody?: Schema$ReplicasDeleteRequest;
   }
   export interface Params$Resource$Replicas$Get {
     /**

--- a/src/apis/replicapool/v1beta2.ts
+++ b/src/apis/replicapool/v1beta2.ts
@@ -1135,10 +1135,11 @@ export namespace replicapool_v1beta2 {
      * The name of the zone in which the instance group manager resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersAbandonInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersAbandonInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Delete {
     /**
@@ -1177,10 +1178,11 @@ export namespace replicapool_v1beta2 {
      * The name of the zone in which the instance group manager resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersDeleteInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersDeleteInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Get {
     /**
@@ -1219,10 +1221,11 @@ export namespace replicapool_v1beta2 {
      * The name of the zone in which the instance group manager resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManager;
+    requestBody?: Schema$InstanceGroupManager;
   }
   export interface Params$Resource$Instancegroupmanagers$List {
     /**
@@ -1271,10 +1274,11 @@ export namespace replicapool_v1beta2 {
      * The name of the zone in which the instance group manager resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersRecreateInstancesRequest;
+    requestBody?: Schema$InstanceGroupManagersRecreateInstancesRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Resize {
     /**
@@ -1317,10 +1321,11 @@ export namespace replicapool_v1beta2 {
      * The name of the zone in which the instance group manager resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
+    requestBody?: Schema$InstanceGroupManagersSetInstanceTemplateRequest;
   }
   export interface Params$Resource$Instancegroupmanagers$Settargetpools {
     /**
@@ -1340,10 +1345,11 @@ export namespace replicapool_v1beta2 {
      * The name of the zone in which the instance group manager resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
+    requestBody?: Schema$InstanceGroupManagersSetTargetPoolsRequest;
   }
 
 

--- a/src/apis/replicapoolupdater/v1beta1.ts
+++ b/src/apis/replicapoolupdater/v1beta1.ts
@@ -975,10 +975,11 @@ export namespace replicapoolupdater_v1beta1 {
      * The name of the zone in which the update's target resides.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollingUpdate;
+    requestBody?: Schema$RollingUpdate;
   }
   export interface Params$Resource$Rollingupdates$List {
     /**

--- a/src/apis/reseller/v1.ts
+++ b/src/apis/reseller/v1.ts
@@ -741,10 +741,11 @@ export namespace reseller_v1 {
      * center.
      */
     customerAuthToken?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Customer;
+    requestBody?: Schema$Customer;
   }
   export interface Params$Resource$Customers$Patch {
     /**
@@ -759,10 +760,11 @@ export namespace reseller_v1 {
      * customerId is changed, the Google system automatically updates.
      */
     customerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Customer;
+    requestBody?: Schema$Customer;
   }
   export interface Params$Resource$Customers$Update {
     /**
@@ -777,10 +779,11 @@ export namespace reseller_v1 {
      * customerId is changed, the Google system automatically updates.
      */
     customerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Customer;
+    requestBody?: Schema$Customer;
   }
 
 
@@ -1803,10 +1806,11 @@ export namespace reseller_v1 {
      * the retrieve all reseller subscriptions method.
      */
     subscriptionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChangePlanRequest;
+    requestBody?: Schema$ChangePlanRequest;
   }
   export interface Params$Resource$Subscriptions$Changerenewalsettings {
     /**
@@ -1829,10 +1833,11 @@ export namespace reseller_v1 {
      * the retrieve all reseller subscriptions method.
      */
     subscriptionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RenewalSettings;
+    requestBody?: Schema$RenewalSettings;
   }
   export interface Params$Resource$Subscriptions$Changeseats {
     /**
@@ -1855,10 +1860,11 @@ export namespace reseller_v1 {
      * the retrieve all reseller subscriptions method.
      */
     subscriptionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Seats;
+    requestBody?: Schema$Seats;
   }
   export interface Params$Resource$Subscriptions$Delete {
     /**
@@ -1931,10 +1937,11 @@ export namespace reseller_v1 {
      * customerId is changed, the Google system automatically updates.
      */
     customerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subscription;
+    requestBody?: Schema$Subscription;
   }
   export interface Params$Resource$Subscriptions$List {
     /**

--- a/src/apis/resourceviews/v1beta1.ts
+++ b/src/apis/resourceviews/v1beta1.ts
@@ -772,10 +772,11 @@ export namespace resourceviews_v1beta1 {
      * The name of the resource view.
      */
     resourceViewName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionViewsAddResourcesRequest;
+    requestBody?: Schema$RegionViewsAddResourcesRequest;
   }
   export interface Params$Resource$Regionviews$Delete {
     /**
@@ -829,10 +830,11 @@ export namespace resourceviews_v1beta1 {
      * The region name of the resource view.
      */
     region?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceView;
+    requestBody?: Schema$ResourceView;
   }
   export interface Params$Resource$Regionviews$List {
     /**
@@ -908,10 +910,11 @@ export namespace resourceviews_v1beta1 {
      * The name of the resource view.
      */
     resourceViewName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RegionViewsRemoveResourcesRequest;
+    requestBody?: Schema$RegionViewsRemoveResourcesRequest;
   }
 
 
@@ -1441,10 +1444,11 @@ export namespace resourceviews_v1beta1 {
      * The zone name of the resource view.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ZoneViewsAddResourcesRequest;
+    requestBody?: Schema$ZoneViewsAddResourcesRequest;
   }
   export interface Params$Resource$Zoneviews$Delete {
     /**
@@ -1498,10 +1502,11 @@ export namespace resourceviews_v1beta1 {
      * The zone name of the resource view.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceView;
+    requestBody?: Schema$ResourceView;
   }
   export interface Params$Resource$Zoneviews$List {
     /**
@@ -1577,9 +1582,10 @@ export namespace resourceviews_v1beta1 {
      * The zone name of the resource view.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ZoneViewsRemoveResourcesRequest;
+    requestBody?: Schema$ZoneViewsRemoveResourcesRequest;
   }
 }

--- a/src/apis/resourceviews/v1beta2.ts
+++ b/src/apis/resourceviews/v1beta2.ts
@@ -1268,10 +1268,11 @@ export namespace resourceviews_v1beta2 {
      * The zone name of the resource view.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ZoneViewsAddResourcesRequest;
+    requestBody?: Schema$ZoneViewsAddResourcesRequest;
   }
   export interface Params$Resource$Zoneviews$Delete {
     /**
@@ -1349,10 +1350,11 @@ export namespace resourceviews_v1beta2 {
      * The zone name of the resource view.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResourceView;
+    requestBody?: Schema$ResourceView;
   }
   export interface Params$Resource$Zoneviews$List {
     /**
@@ -1443,10 +1445,11 @@ export namespace resourceviews_v1beta2 {
      * The zone name of the resource view.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ZoneViewsRemoveResourcesRequest;
+    requestBody?: Schema$ZoneViewsRemoveResourcesRequest;
   }
   export interface Params$Resource$Zoneviews$Setservice {
     /**
@@ -1466,9 +1469,10 @@ export namespace resourceviews_v1beta2 {
      * The zone name of the resource view.
      */
     zone?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ZoneViewsSetServiceRequest;
+    requestBody?: Schema$ZoneViewsSetServiceRequest;
   }
 }

--- a/src/apis/runtimeconfig/v1.ts
+++ b/src/apis/runtimeconfig/v1.ts
@@ -432,10 +432,11 @@ export namespace runtimeconfig_v1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Delete {
     /**

--- a/src/apis/runtimeconfig/v1beta1.ts
+++ b/src/apis/runtimeconfig/v1beta1.ts
@@ -1122,10 +1122,11 @@ export namespace runtimeconfig_v1beta1 {
      * strings.  `request_id` strings are limited to 64 characters.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RuntimeConfig;
+    requestBody?: Schema$RuntimeConfig;
   }
   export interface Params$Resource$Projects$Configs$Delete {
     /**
@@ -1197,10 +1198,11 @@ export namespace runtimeconfig_v1beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Configs$Testiampermissions {
     /**
@@ -1213,10 +1215,11 @@ export namespace runtimeconfig_v1beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Configs$Update {
     /**
@@ -1229,10 +1232,11 @@ export namespace runtimeconfig_v1beta1 {
      * `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RuntimeConfig;
+    requestBody?: Schema$RuntimeConfig;
   }
 
   export class Resource$Projects$Configs$Operations {
@@ -1416,10 +1420,11 @@ export namespace runtimeconfig_v1beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -1964,10 +1969,11 @@ export namespace runtimeconfig_v1beta1 {
      * strings.  `request_id` strings are limited to 64 characters.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variable;
+    requestBody?: Schema$Variable;
   }
   export interface Params$Resource$Projects$Configs$Variables$Delete {
     /**
@@ -2043,10 +2049,11 @@ export namespace runtimeconfig_v1beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Configs$Variables$Update {
     /**
@@ -2059,10 +2066,11 @@ export namespace runtimeconfig_v1beta1 {
      * `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variable;
+    requestBody?: Schema$Variable;
   }
   export interface Params$Resource$Projects$Configs$Variables$Watch {
     /**
@@ -2075,10 +2083,11 @@ export namespace runtimeconfig_v1beta1 {
      * `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$WatchVariableRequest;
+    requestBody?: Schema$WatchVariableRequest;
   }
 
 
@@ -2470,10 +2479,11 @@ export namespace runtimeconfig_v1beta1 {
      * strings.  `request_id` strings are limited to 64 characters.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Waiter;
+    requestBody?: Schema$Waiter;
   }
   export interface Params$Resource$Projects$Configs$Waiters$Delete {
     /**
@@ -2534,9 +2544,10 @@ export namespace runtimeconfig_v1beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 }

--- a/src/apis/safebrowsing/v4.ts
+++ b/src/apis/safebrowsing/v4.ts
@@ -866,10 +866,11 @@ export namespace safebrowsing_v4 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FindFullHashesRequest;
+    requestBody?: Schema$FindFullHashesRequest;
   }
 
 
@@ -956,10 +957,11 @@ export namespace safebrowsing_v4 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ThreatHit;
+    requestBody?: Schema$ThreatHit;
   }
 
 
@@ -1141,10 +1143,11 @@ export namespace safebrowsing_v4 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FetchThreatListUpdatesRequest;
+    requestBody?: Schema$FetchThreatListUpdatesRequest;
   }
 
 
@@ -1235,9 +1238,10 @@ export namespace safebrowsing_v4 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FindThreatMatchesRequest;
+    requestBody?: Schema$FindThreatMatchesRequest;
   }
 }

--- a/src/apis/script/v1.ts
+++ b/src/apis/script/v1.ts
@@ -1377,10 +1377,11 @@ export namespace script_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateProjectRequest;
+    requestBody?: Schema$CreateProjectRequest;
   }
   export interface Params$Resource$Projects$Get {
     /**
@@ -1438,10 +1439,11 @@ export namespace script_v1 {
      * The script project's Drive ID.
      */
     scriptId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Content;
+    requestBody?: Schema$Content;
   }
 
   export class Resource$Projects$Deployments {
@@ -1807,10 +1809,11 @@ export namespace script_v1 {
      * The script project's Drive ID.
      */
     scriptId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DeploymentConfig;
+    requestBody?: Schema$DeploymentConfig;
   }
   export interface Params$Resource$Projects$Deployments$Delete {
     /**
@@ -1876,10 +1879,11 @@ export namespace script_v1 {
      * The script project's Drive ID.
      */
     scriptId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateDeploymentRequest;
+    requestBody?: Schema$UpdateDeploymentRequest;
   }
 
 
@@ -2107,10 +2111,11 @@ export namespace script_v1 {
      * The script project's Drive ID.
      */
     scriptId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Version;
+    requestBody?: Schema$Version;
   }
   export interface Params$Resource$Projects$Versions$Get {
     /**
@@ -2244,9 +2249,10 @@ export namespace script_v1 {
      * properties**.
      */
     scriptId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ExecutionRequest;
+    requestBody?: Schema$ExecutionRequest;
   }
 }

--- a/src/apis/searchconsole/v1.ts
+++ b/src/apis/searchconsole/v1.ts
@@ -270,9 +270,10 @@ export namespace searchconsole_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RunMobileFriendlyTestRequest;
+    requestBody?: Schema$RunMobileFriendlyTestRequest;
   }
 }

--- a/src/apis/servicebroker/v1.ts
+++ b/src/apis/servicebroker/v1.ts
@@ -430,10 +430,11 @@ export namespace servicebroker_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__SetIamPolicyRequest;
+    requestBody?: Schema$GoogleIamV1__SetIamPolicyRequest;
   }
   export interface Params$Resource$V1$Testiampermissions {
     /**
@@ -446,9 +447,10 @@ export namespace servicebroker_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__TestIamPermissionsRequest;
+    requestBody?: Schema$GoogleIamV1__TestIamPermissionsRequest;
   }
 }

--- a/src/apis/servicebroker/v1alpha1.ts
+++ b/src/apis/servicebroker/v1alpha1.ts
@@ -1620,10 +1620,11 @@ export namespace servicebroker_v1alpha1 {
      * Parent must match `projects/[PROJECT_ID]/brokers/[BROKER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudServicebrokerV1alpha1__ServiceInstance;
+    requestBody?: Schema$GoogleCloudServicebrokerV1alpha1__ServiceInstance;
   }
   export interface Params$Resource$Projects$Brokers$V2$Service_instances$Delete {
     /**
@@ -1710,10 +1711,11 @@ export namespace servicebroker_v1alpha1 {
      * Parent must match `projects/[PROJECT_ID]/brokers/[BROKER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudServicebrokerV1alpha1__ServiceInstance;
+    requestBody?: Schema$GoogleCloudServicebrokerV1alpha1__ServiceInstance;
   }
 
   export class Resource$Projects$Brokers$V2$Service_instances$Service_bindings {
@@ -2129,10 +2131,11 @@ export namespace servicebroker_v1alpha1 {
      * `projects/[PROJECT_ID]/brokers/[BROKER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudServicebrokerV1alpha1__Binding;
+    requestBody?: Schema$GoogleCloudServicebrokerV1alpha1__Binding;
   }
   export interface Params$Resource$Projects$Brokers$V2$Service_instances$Service_bindings$Delete {
     /**
@@ -2484,10 +2487,11 @@ export namespace servicebroker_v1alpha1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__SetIamPolicyRequest;
+    requestBody?: Schema$GoogleIamV1__SetIamPolicyRequest;
   }
   export interface Params$Resource$V1alpha1$Testiampermissions {
     /**
@@ -2500,9 +2504,10 @@ export namespace servicebroker_v1alpha1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__TestIamPermissionsRequest;
+    requestBody?: Schema$GoogleIamV1__TestIamPermissionsRequest;
   }
 }

--- a/src/apis/servicebroker/v1beta1.ts
+++ b/src/apis/servicebroker/v1beta1.ts
@@ -924,10 +924,11 @@ export namespace servicebroker_v1beta1 {
      * The project in which to create broker.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudServicebrokerV1beta1__Broker;
+    requestBody?: Schema$GoogleCloudServicebrokerV1beta1__Broker;
   }
   export interface Params$Resource$Projects$Brokers$Delete {
     /**
@@ -2143,10 +2144,11 @@ export namespace servicebroker_v1beta1 {
      * Parent must match `projects/[PROJECT_ID]/brokers/[BROKER_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudServicebrokerV1beta1__ServiceInstance;
+    requestBody?: Schema$GoogleCloudServicebrokerV1beta1__ServiceInstance;
   }
   export interface Params$Resource$Projects$Brokers$V2$Service_instances$Delete {
     /**
@@ -2227,10 +2229,11 @@ export namespace servicebroker_v1beta1 {
      * `projects/[PROJECT_ID]/brokers/[BROKER_ID]/v2/service_instances/[INSTANCE_ID]`.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudServicebrokerV1beta1__ServiceInstance;
+    requestBody?: Schema$GoogleCloudServicebrokerV1beta1__ServiceInstance;
   }
 
   export class Resource$Projects$Brokers$V2$Service_instances$Service_bindings {
@@ -2624,10 +2627,11 @@ export namespace servicebroker_v1beta1 {
      * `projects/[PROJECT_ID]/brokers/[BROKER_ID]/v2/service_instances/[INSTANCE_ID]`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudServicebrokerV1beta1__Binding;
+    requestBody?: Schema$GoogleCloudServicebrokerV1beta1__Binding;
   }
   export interface Params$Resource$Projects$Brokers$V2$Service_instances$Service_bindings$Delete {
     /**
@@ -2960,10 +2964,11 @@ export namespace servicebroker_v1beta1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__SetIamPolicyRequest;
+    requestBody?: Schema$GoogleIamV1__SetIamPolicyRequest;
   }
   export interface Params$Resource$V1beta1$Testiampermissions {
     /**
@@ -2976,9 +2981,10 @@ export namespace servicebroker_v1beta1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GoogleIamV1__TestIamPermissionsRequest;
+    requestBody?: Schema$GoogleIamV1__TestIamPermissionsRequest;
   }
 }

--- a/src/apis/serviceconsumermanagement/v1.ts
+++ b/src/apis/serviceconsumermanagement/v1.ts
@@ -2573,10 +2573,11 @@ export namespace serviceconsumermanagement_v1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Delete {
     /**
@@ -3133,10 +3134,11 @@ export namespace serviceconsumermanagement_v1 {
      * Name of the tenancy unit.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AddTenantProjectRequest;
+    requestBody?: Schema$AddTenantProjectRequest;
   }
   export interface Params$Resource$Services$Tenancyunits$Create {
     /**
@@ -3153,10 +3155,11 @@ export namespace serviceconsumermanagement_v1 {
      * using the new tenancy unit.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateTenancyUnitRequest;
+    requestBody?: Schema$CreateTenancyUnitRequest;
   }
   export interface Params$Resource$Services$Tenancyunits$Delete {
     /**
@@ -3210,9 +3213,10 @@ export namespace serviceconsumermanagement_v1 {
      * 'services/service.googleapis.com/projects/12345/tenancyUnits/abcd'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemoveTenantProjectRequest;
+    requestBody?: Schema$RemoveTenantProjectRequest;
   }
 }

--- a/src/apis/servicecontrol/v1.ts
+++ b/src/apis/servicecontrol/v1.ts
@@ -1633,10 +1633,11 @@ export namespace servicecontrol_v1 {
      * definition of a service name.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AllocateQuotaRequest;
+    requestBody?: Schema$AllocateQuotaRequest;
   }
   export interface Params$Resource$Services$Check {
     /**
@@ -1651,10 +1652,11 @@ export namespace servicecontrol_v1 {
      * for the definition of a service name.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CheckRequest;
+    requestBody?: Schema$CheckRequest;
   }
   export interface Params$Resource$Services$Endreconciliation {
     /**
@@ -1668,10 +1670,11 @@ export namespace servicecontrol_v1 {
      * definition of a service name.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EndReconciliationRequest;
+    requestBody?: Schema$EndReconciliationRequest;
   }
   export interface Params$Resource$Services$Releasequota {
     /**
@@ -1685,10 +1688,11 @@ export namespace servicecontrol_v1 {
      * definition of a service name.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReleaseQuotaRequest;
+    requestBody?: Schema$ReleaseQuotaRequest;
   }
   export interface Params$Resource$Services$Report {
     /**
@@ -1703,10 +1707,11 @@ export namespace servicecontrol_v1 {
      * for the definition of a service name.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReportRequest;
+    requestBody?: Schema$ReportRequest;
   }
   export interface Params$Resource$Services$Startreconciliation {
     /**
@@ -1720,9 +1725,10 @@ export namespace servicecontrol_v1 {
      * definition of a service name.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartReconciliationRequest;
+    requestBody?: Schema$StartReconciliationRequest;
   }
 }

--- a/src/apis/servicemanagement/v1.ts
+++ b/src/apis/servicemanagement/v1.ts
@@ -3620,10 +3620,11 @@ export namespace servicemanagement_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ManagedService;
+    requestBody?: Schema$ManagedService;
   }
   export interface Params$Resource$Services$Delete {
     /**
@@ -3649,10 +3650,11 @@ export namespace servicemanagement_v1 {
      * cause the request to fail.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisableServiceRequest;
+    requestBody?: Schema$DisableServiceRequest;
   }
   export interface Params$Resource$Services$Enable {
     /**
@@ -3665,10 +3667,11 @@ export namespace servicemanagement_v1 {
      * cause the request to fail.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EnableServiceRequest;
+    requestBody?: Schema$EnableServiceRequest;
   }
   export interface Params$Resource$Services$Generateconfigreport {
     /**
@@ -3676,10 +3679,11 @@ export namespace servicemanagement_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GenerateConfigReportRequest;
+    requestBody?: Schema$GenerateConfigReportRequest;
   }
   export interface Params$Resource$Services$Get {
     /**
@@ -3726,10 +3730,11 @@ export namespace servicemanagement_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Services$List {
     /**
@@ -3768,10 +3773,11 @@ export namespace servicemanagement_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Services$Testiampermissions {
     /**
@@ -3784,10 +3790,11 @@ export namespace servicemanagement_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Services$Undelete {
     /**
@@ -4117,10 +4124,11 @@ export namespace servicemanagement_v1 {
      * example: `example.googleapis.com`.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Service;
+    requestBody?: Schema$Service;
   }
   export interface Params$Resource$Services$Configs$Get {
     /**
@@ -4177,10 +4185,11 @@ export namespace servicemanagement_v1 {
      * example: `example.googleapis.com`.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SubmitConfigSourceRequest;
+    requestBody?: Schema$SubmitConfigSourceRequest;
   }
 
 
@@ -4426,10 +4435,11 @@ export namespace servicemanagement_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Services$Consumers$Setiampolicy {
     /**
@@ -4442,10 +4452,11 @@ export namespace servicemanagement_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Services$Consumers$Testiampermissions {
     /**
@@ -4458,10 +4469,11 @@ export namespace servicemanagement_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
 
@@ -4709,10 +4721,11 @@ export namespace servicemanagement_v1 {
      * example: `example.googleapis.com`.
      */
     serviceName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Rollout;
+    requestBody?: Schema$Rollout;
   }
   export interface Params$Resource$Services$Rollouts$Get {
     /**

--- a/src/apis/serviceusage/v1beta1.ts
+++ b/src/apis/serviceusage/v1beta1.ts
@@ -2737,10 +2737,11 @@ export namespace serviceusage_v1beta1 {
      * `BatchEnableServices` method currently only supports projects.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchEnableServicesRequest;
+    requestBody?: Schema$BatchEnableServicesRequest;
   }
   export interface Params$Resource$Services$Disable {
     /**
@@ -2755,10 +2756,11 @@ export namespace serviceusage_v1beta1 {
      * is the project number (not project ID).
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisableServiceRequest;
+    requestBody?: Schema$DisableServiceRequest;
   }
   export interface Params$Resource$Services$Enable {
     /**
@@ -2775,10 +2777,11 @@ export namespace serviceusage_v1beta1 {
      * project number (not project ID).
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EnableServiceRequest;
+    requestBody?: Schema$EnableServiceRequest;
   }
   export interface Params$Resource$Services$Get {
     /**

--- a/src/apis/serviceuser/v1.ts
+++ b/src/apis/serviceuser/v1.ts
@@ -2312,10 +2312,11 @@ export namespace serviceuser_v1 {
      * /v1/projects/my-project/services/servicemanagement.googleapis.com:disable
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DisableServiceRequest;
+    requestBody?: Schema$DisableServiceRequest;
   }
   export interface Params$Resource$Projects$Services$Enable {
     /**
@@ -2329,10 +2330,11 @@ export namespace serviceuser_v1 {
      * /v1/projects/my-project/services/servicemanagement.googleapis.com:enable
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$EnableServiceRequest;
+    requestBody?: Schema$EnableServiceRequest;
   }
   export interface Params$Resource$Projects$Services$List {
     /**

--- a/src/apis/sheets/v4.ts
+++ b/src/apis/sheets/v4.ts
@@ -4796,10 +4796,11 @@ export namespace sheets_v4 {
      * The spreadsheet to apply the updates to.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchUpdateSpreadsheetRequest;
+    requestBody?: Schema$BatchUpdateSpreadsheetRequest;
   }
   export interface Params$Resource$Spreadsheets$Create {
     /**
@@ -4807,10 +4808,11 @@ export namespace sheets_v4 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Spreadsheet;
+    requestBody?: Schema$Spreadsheet;
   }
   export interface Params$Resource$Spreadsheets$Get {
     /**
@@ -4842,10 +4844,11 @@ export namespace sheets_v4 {
      * The spreadsheet to request.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GetSpreadsheetByDataFilterRequest;
+    requestBody?: Schema$GetSpreadsheetByDataFilterRequest;
   }
 
   export class Resource$Spreadsheets$Developermetadata {
@@ -5139,10 +5142,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet to retrieve metadata from.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchDeveloperMetadataRequest;
+    requestBody?: Schema$SearchDeveloperMetadataRequest;
   }
 
 
@@ -5303,10 +5307,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet containing the sheet to copy.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CopySheetToAnotherSpreadsheetRequest;
+    requestBody?: Schema$CopySheetToAnotherSpreadsheetRequest;
   }
 
 
@@ -6764,10 +6769,11 @@ export namespace sheets_v4 {
      * How the input data should be interpreted.
      */
     valueInputOption?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ValueRange;
+    requestBody?: Schema$ValueRange;
   }
   export interface Params$Resource$Spreadsheets$Values$Batchclear {
     /**
@@ -6779,10 +6785,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet to update.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchClearValuesRequest;
+    requestBody?: Schema$BatchClearValuesRequest;
   }
   export interface Params$Resource$Spreadsheets$Values$Batchclearbydatafilter {
     /**
@@ -6794,10 +6801,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet to update.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchClearValuesByDataFilterRequest;
+    requestBody?: Schema$BatchClearValuesByDataFilterRequest;
   }
   export interface Params$Resource$Spreadsheets$Values$Batchget {
     /**
@@ -6843,10 +6851,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet to retrieve data from.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchGetValuesByDataFilterRequest;
+    requestBody?: Schema$BatchGetValuesByDataFilterRequest;
   }
   export interface Params$Resource$Spreadsheets$Values$Batchupdate {
     /**
@@ -6858,10 +6867,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet to update.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchUpdateValuesRequest;
+    requestBody?: Schema$BatchUpdateValuesRequest;
   }
   export interface Params$Resource$Spreadsheets$Values$Batchupdatebydatafilter {
     /**
@@ -6873,10 +6883,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet to update.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchUpdateValuesByDataFilterRequest;
+    requestBody?: Schema$BatchUpdateValuesByDataFilterRequest;
   }
   export interface Params$Resource$Spreadsheets$Values$Clear {
     /**
@@ -6892,10 +6903,11 @@ export namespace sheets_v4 {
      * The ID of the spreadsheet to update.
      */
     spreadsheetId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ClearValuesRequest;
+    requestBody?: Schema$ClearValuesRequest;
   }
   export interface Params$Resource$Spreadsheets$Values$Get {
     /**
@@ -6969,9 +6981,10 @@ export namespace sheets_v4 {
      * How the input data should be interpreted.
      */
     valueInputOption?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ValueRange;
+    requestBody?: Schema$ValueRange;
   }
 }

--- a/src/apis/siteVerification/v1.ts
+++ b/src/apis/siteVerification/v1.ts
@@ -677,6 +677,12 @@ export namespace siteVerification_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$SiteVerificationWebResourceGettokenRequest;
   }
   export interface Params$Resource$Webresource$Insert {
     /**
@@ -688,10 +694,11 @@ export namespace siteVerification_v1 {
      * The method to use for verifying a site or domain.
      */
     verificationMethod?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SiteVerificationWebResourceResource;
+    requestBody?: Schema$SiteVerificationWebResourceResource;
   }
   export interface Params$Resource$Webresource$List {
     /**
@@ -709,10 +716,11 @@ export namespace siteVerification_v1 {
      * The id of a verified site or domain.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SiteVerificationWebResourceResource;
+    requestBody?: Schema$SiteVerificationWebResourceResource;
   }
   export interface Params$Resource$Webresource$Update {
     /**
@@ -724,9 +732,10 @@ export namespace siteVerification_v1 {
      * The id of a verified site or domain.
      */
     id?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SiteVerificationWebResourceResource;
+    requestBody?: Schema$SiteVerificationWebResourceResource;
   }
 }

--- a/src/apis/slides/v1.ts
+++ b/src/apis/slides/v1.ts
@@ -3385,10 +3385,11 @@ export namespace slides_v1 {
      * The presentation to apply the updates to.
      */
     presentationId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchUpdatePresentationRequest;
+    requestBody?: Schema$BatchUpdatePresentationRequest;
   }
   export interface Params$Resource$Presentations$Create {
     /**
@@ -3396,10 +3397,11 @@ export namespace slides_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Presentation;
+    requestBody?: Schema$Presentation;
   }
   export interface Params$Resource$Presentations$Get {
     /**

--- a/src/apis/sourcerepo/v1.ts
+++ b/src/apis/sourcerepo/v1.ts
@@ -822,10 +822,11 @@ export namespace sourcerepo_v1 {
      * `projects/<project>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Repo;
+    requestBody?: Schema$Repo;
   }
   export interface Params$Resource$Projects$Repos$Delete {
     /**
@@ -897,10 +898,11 @@ export namespace sourcerepo_v1 {
      * operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Repos$Testiampermissions {
     /**
@@ -913,9 +915,10 @@ export namespace sourcerepo_v1 {
      * See the operation documentation for the appropriate value for this field.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 }

--- a/src/apis/spanner/v1.ts
+++ b/src/apis/spanner/v1.ts
@@ -2469,10 +2469,11 @@ export namespace spanner_v1 {
      * are of the form `projects/<project>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateInstanceRequest;
+    requestBody?: Schema$CreateInstanceRequest;
   }
   export interface Params$Resource$Projects$Instances$Delete {
     /**
@@ -2511,10 +2512,11 @@ export namespace spanner_v1 {
      * ID>/databases/<database ID>` for database resources.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Instances$List {
     /**
@@ -2565,10 +2567,11 @@ export namespace spanner_v1 {
      * name must be between 6 and 30 characters in length.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateInstanceRequest;
+    requestBody?: Schema$UpdateInstanceRequest;
   }
   export interface Params$Resource$Projects$Instances$Setiampolicy {
     /**
@@ -2583,10 +2586,11 @@ export namespace spanner_v1 {
      * ID>/databases/<database ID>` for databases resources.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Instances$Testiampermissions {
     /**
@@ -2601,10 +2605,11 @@ export namespace spanner_v1 {
      * ID>/databases/<database ID>` for database resources.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
 
   export class Resource$Projects$Instances$Databases {
@@ -3275,10 +3280,11 @@ export namespace spanner_v1 {
      * Values are of the form `projects/<project>/instances/<instance>`.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateDatabaseRequest;
+    requestBody?: Schema$CreateDatabaseRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Dropdatabase {
     /**
@@ -3327,10 +3333,11 @@ export namespace spanner_v1 {
      * ID>/databases/<database ID>` for database resources.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$GetIamPolicyRequest;
+    requestBody?: Schema$GetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$List {
     /**
@@ -3367,10 +3374,11 @@ export namespace spanner_v1 {
      * ID>/databases/<database ID>` for databases resources.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$SetIamPolicyRequest;
+    requestBody?: Schema$SetIamPolicyRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Testiampermissions {
     /**
@@ -3385,10 +3393,11 @@ export namespace spanner_v1 {
      * ID>/databases/<database ID>` for database resources.
      */
     resource?: string;
+
     /**
      * Request body metadata
      */
-    resource_?: Schema$TestIamPermissionsRequest;
+    requestBody?: Schema$TestIamPermissionsRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Updateddl {
     /**
@@ -3400,10 +3409,11 @@ export namespace spanner_v1 {
      * Required. The database to update.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateDatabaseDdlRequest;
+    requestBody?: Schema$UpdateDatabaseDdlRequest;
   }
 
   export class Resource$Projects$Instances$Databases$Operations {
@@ -4771,10 +4781,11 @@ export namespace spanner_v1 {
      * Required. The session in which the transaction runs.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BeginTransactionRequest;
+    requestBody?: Schema$BeginTransactionRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Commit {
     /**
@@ -4787,10 +4798,11 @@ export namespace spanner_v1 {
      * running.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommitRequest;
+    requestBody?: Schema$CommitRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Create {
     /**
@@ -4802,10 +4814,11 @@ export namespace spanner_v1 {
      * Required. The database in which the new session is created.
      */
     database?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateSessionRequest;
+    requestBody?: Schema$CreateSessionRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Delete {
     /**
@@ -4828,10 +4841,11 @@ export namespace spanner_v1 {
      * Required. The session in which the SQL query should be performed.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ExecuteSqlRequest;
+    requestBody?: Schema$ExecuteSqlRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Executestreamingsql {
     /**
@@ -4843,10 +4857,11 @@ export namespace spanner_v1 {
      * Required. The session in which the SQL query should be performed.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ExecuteSqlRequest;
+    requestBody?: Schema$ExecuteSqlRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Get {
     /**
@@ -4899,10 +4914,11 @@ export namespace spanner_v1 {
      * Required. The session used to create the partitions.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PartitionQueryRequest;
+    requestBody?: Schema$PartitionQueryRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Partitionread {
     /**
@@ -4914,10 +4930,11 @@ export namespace spanner_v1 {
      * Required. The session used to create the partitions.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PartitionReadRequest;
+    requestBody?: Schema$PartitionReadRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Read {
     /**
@@ -4929,10 +4946,11 @@ export namespace spanner_v1 {
      * Required. The session in which the read should be performed.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReadRequest;
+    requestBody?: Schema$ReadRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Rollback {
     /**
@@ -4944,10 +4962,11 @@ export namespace spanner_v1 {
      * Required. The session in which the transaction to roll back is running.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RollbackRequest;
+    requestBody?: Schema$RollbackRequest;
   }
   export interface Params$Resource$Projects$Instances$Databases$Sessions$Streamingread {
     /**
@@ -4959,10 +4978,11 @@ export namespace spanner_v1 {
      * Required. The session in which the read should be performed.
      */
     session?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReadRequest;
+    requestBody?: Schema$ReadRequest;
   }
 
 

--- a/src/apis/spectrum/v1explorer.ts
+++ b/src/apis/spectrum/v1explorer.ts
@@ -1578,35 +1578,71 @@ export namespace spectrum_v1explorer {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PawsGetSpectrumRequest;
   }
   export interface Params$Resource$Paws$Getspectrumbatch {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PawsGetSpectrumBatchRequest;
   }
   export interface Params$Resource$Paws$Init {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PawsInitRequest;
   }
   export interface Params$Resource$Paws$Notifyspectrumuse {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PawsNotifySpectrumUseRequest;
   }
   export interface Params$Resource$Paws$Register {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PawsRegisterRequest;
   }
   export interface Params$Resource$Paws$Verifydevice {
     /**
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$PawsVerifyDeviceRequest;
   }
 }

--- a/src/apis/speech/v1.ts
+++ b/src/apis/speech/v1.ts
@@ -614,10 +614,11 @@ export namespace speech_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LongRunningRecognizeRequest;
+    requestBody?: Schema$LongRunningRecognizeRequest;
   }
   export interface Params$Resource$Speech$Recognize {
     /**
@@ -625,9 +626,10 @@ export namespace speech_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RecognizeRequest;
+    requestBody?: Schema$RecognizeRequest;
   }
 }

--- a/src/apis/speech/v1beta1.ts
+++ b/src/apis/speech/v1beta1.ts
@@ -567,10 +567,11 @@ export namespace speech_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AsyncRecognizeRequest;
+    requestBody?: Schema$AsyncRecognizeRequest;
   }
   export interface Params$Resource$Speech$Syncrecognize {
     /**
@@ -578,9 +579,10 @@ export namespace speech_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SyncRecognizeRequest;
+    requestBody?: Schema$SyncRecognizeRequest;
   }
 }

--- a/src/apis/sqladmin/v1beta3.ts
+++ b/src/apis/sqladmin/v1beta3.ts
@@ -2339,10 +2339,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the source as well as the clone Cloud SQL instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesCloneRequest;
+    requestBody?: Schema$InstancesCloneRequest;
   }
   export interface Params$Resource$Instances$Delete {
     /**
@@ -2373,10 +2374,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance to be exported.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesExportRequest;
+    requestBody?: Schema$InstancesExportRequest;
   }
   export interface Params$Resource$Instances$Get {
     /**
@@ -2407,10 +2409,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesImportRequest;
+    requestBody?: Schema$InstancesImportRequest;
   }
   export interface Params$Resource$Instances$Insert {
     /**
@@ -2423,10 +2426,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * should belong.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DatabaseInstance;
+    requestBody?: Schema$DatabaseInstance;
   }
   export interface Params$Resource$Instances$List {
     /**
@@ -2462,10 +2466,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DatabaseInstance;
+    requestBody?: Schema$DatabaseInstance;
   }
   export interface Params$Resource$Instances$Promotereplica {
     /**
@@ -2552,10 +2557,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstanceSetRootPasswordRequest;
+    requestBody?: Schema$InstanceSetRootPasswordRequest;
   }
   export interface Params$Resource$Instances$Update {
     /**
@@ -2571,10 +2577,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DatabaseInstance;
+    requestBody?: Schema$DatabaseInstance;
   }
 
 
@@ -3115,10 +3122,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * should belong.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslCertsInsertRequest;
+    requestBody?: Schema$SslCertsInsertRequest;
   }
   export interface Params$Resource$Sslcerts$List {
     /**

--- a/src/apis/sqladmin/v1beta4.ts
+++ b/src/apis/sqladmin/v1beta4.ts
@@ -1777,10 +1777,11 @@ export namespace sqladmin_v1beta4 {
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BackupRun;
+    requestBody?: Schema$BackupRun;
   }
   export interface Params$Resource$Backupruns$List {
     /**
@@ -2288,10 +2289,11 @@ export namespace sqladmin_v1beta4 {
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Database;
+    requestBody?: Schema$Database;
   }
   export interface Params$Resource$Databases$List {
     /**
@@ -2326,10 +2328,11 @@ export namespace sqladmin_v1beta4 {
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Database;
+    requestBody?: Schema$Database;
   }
   export interface Params$Resource$Databases$Update {
     /**
@@ -2349,10 +2352,11 @@ export namespace sqladmin_v1beta4 {
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Database;
+    requestBody?: Schema$Database;
   }
 
 
@@ -3699,10 +3703,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the source as well as the clone Cloud SQL instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesCloneRequest;
+    requestBody?: Schema$InstancesCloneRequest;
   }
   export interface Params$Resource$Instances$Delete {
     /**
@@ -3733,10 +3738,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesDemoteMasterRequest;
+    requestBody?: Schema$InstancesDemoteMasterRequest;
   }
   export interface Params$Resource$Instances$Export {
     /**
@@ -3752,10 +3758,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance to be exported.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesExportRequest;
+    requestBody?: Schema$InstancesExportRequest;
   }
   export interface Params$Resource$Instances$Failover {
     /**
@@ -3771,10 +3778,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * ID of the project that contains the read replica.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesFailoverRequest;
+    requestBody?: Schema$InstancesFailoverRequest;
   }
   export interface Params$Resource$Instances$Get {
     /**
@@ -3805,10 +3813,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesImportRequest;
+    requestBody?: Schema$InstancesImportRequest;
   }
   export interface Params$Resource$Instances$Insert {
     /**
@@ -3821,10 +3830,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * should belong.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DatabaseInstance;
+    requestBody?: Schema$DatabaseInstance;
   }
   export interface Params$Resource$Instances$List {
     /**
@@ -3865,10 +3875,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DatabaseInstance;
+    requestBody?: Schema$DatabaseInstance;
   }
   export interface Params$Resource$Instances$Promotereplica {
     /**
@@ -3929,10 +3940,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesRestoreBackupRequest;
+    requestBody?: Schema$InstancesRestoreBackupRequest;
   }
   export interface Params$Resource$Instances$Startreplica {
     /**
@@ -3978,10 +3990,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the Cloud SQL project.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InstancesTruncateLogRequest;
+    requestBody?: Schema$InstancesTruncateLogRequest;
   }
   export interface Params$Resource$Instances$Update {
     /**
@@ -3997,10 +4010,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DatabaseInstance;
+    requestBody?: Schema$DatabaseInstance;
   }
 
 
@@ -4569,10 +4583,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the Cloud SQL project.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslCertsCreateEphemeralRequest;
+    requestBody?: Schema$SslCertsCreateEphemeralRequest;
   }
   export interface Params$Resource$Sslcerts$Delete {
     /**
@@ -4627,10 +4642,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * should belong.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SslCertsInsertRequest;
+    requestBody?: Schema$SslCertsInsertRequest;
   }
   export interface Params$Resource$Sslcerts$List {
     /**
@@ -5067,10 +5083,11 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$User;
+    requestBody?: Schema$User;
   }
   export interface Params$Resource$Users$List {
     /**
@@ -5109,9 +5126,10 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
      * Project ID of the project that contains the instance.
      */
     project?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$User;
+    requestBody?: Schema$User;
   }
 }

--- a/src/apis/storage/v1.ts
+++ b/src/apis/storage/v1.ts
@@ -1638,10 +1638,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
   export interface Params$Resource$Bucketaccesscontrols$List {
     /**
@@ -1679,10 +1680,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
   export interface Params$Resource$Bucketaccesscontrols$Update {
     /**
@@ -1704,10 +1706,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
 
 
@@ -3027,10 +3030,11 @@ export namespace storage_v1 {
      * The project to be billed for this request.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
   export interface Params$Resource$Buckets$List {
     /**
@@ -3123,10 +3127,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
   export interface Params$Resource$Buckets$Setiampolicy {
     /**
@@ -3143,10 +3148,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Buckets$Testiampermissions {
     /**
@@ -3205,10 +3211,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
 
 
@@ -3343,6 +3350,12 @@ export namespace storage_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Channel;
   }
 
 
@@ -4174,10 +4187,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Defaultobjectaccesscontrols$List {
     /**
@@ -4225,10 +4239,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Defaultobjectaccesscontrols$Update {
     /**
@@ -4250,10 +4265,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
 
 
@@ -4813,10 +4829,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Notification;
+    requestBody?: Schema$Notification;
   }
   export interface Params$Resource$Notifications$List {
     /**
@@ -5740,10 +5757,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Objectaccesscontrols$List {
     /**
@@ -5801,10 +5819,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Objectaccesscontrols$Update {
     /**
@@ -5836,10 +5855,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
 
 
@@ -7718,10 +7738,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ComposeRequest;
+    requestBody?: Schema$ComposeRequest;
   }
   export interface Params$Resource$Objects$Copy {
     /**
@@ -7811,10 +7832,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Delete {
     /**
@@ -8015,14 +8037,16 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -8031,7 +8055,7 @@ export namespace storage_v1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Objects$List {
@@ -8138,10 +8162,11 @@ export namespace storage_v1 {
      * The project to be billed for this request, for Requester Pays buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Rewrite {
     /**
@@ -8257,10 +8282,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Setiampolicy {
     /**
@@ -8287,10 +8313,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Policy;
+    requestBody?: Schema$Policy;
   }
   export interface Params$Resource$Objects$Testiampermissions {
     /**
@@ -8378,10 +8405,11 @@ export namespace storage_v1 {
      * buckets.
      */
     userProject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Watchall {
     /**
@@ -8431,10 +8459,11 @@ export namespace storage_v1 {
      * is false. For more information, see Object Versioning.
      */
     versions?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 

--- a/src/apis/storage/v1beta1.ts
+++ b/src/apis/storage/v1beta1.ts
@@ -813,10 +813,11 @@ export namespace storage_v1beta1 {
      * Name of a bucket.
      */
     bucket?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
   export interface Params$Resource$Bucketaccesscontrols$List {
     /**
@@ -844,10 +845,11 @@ export namespace storage_v1beta1 {
      * group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.
      */
     entity?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
   export interface Params$Resource$Bucketaccesscontrols$Update {
     /**
@@ -864,10 +866,11 @@ export namespace storage_v1beta1 {
      * group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.
      */
     entity?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
 
 
@@ -1310,10 +1313,11 @@ export namespace storage_v1beta1 {
      * to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
   export interface Params$Resource$Buckets$List {
     /**
@@ -1353,10 +1357,11 @@ export namespace storage_v1beta1 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
   export interface Params$Resource$Buckets$Update {
     /**
@@ -1372,10 +1377,11 @@ export namespace storage_v1beta1 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
 
 
@@ -1862,10 +1868,11 @@ export namespace storage_v1beta1 {
      * Name of the object.
      */
     object?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Objectaccesscontrols$List {
     /**
@@ -1901,10 +1908,11 @@ export namespace storage_v1beta1 {
      * Name of the object.
      */
     object?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Objectaccesscontrols$Update {
     /**
@@ -1925,10 +1933,11 @@ export namespace storage_v1beta1 {
      * Name of the object.
      */
     object?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
 
 
@@ -2402,14 +2411,16 @@ export namespace storage_v1beta1 {
      * resource specifies the acl property, when it defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -2418,7 +2429,7 @@ export namespace storage_v1beta1 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Objects$List {
@@ -2476,10 +2487,11 @@ export namespace storage_v1beta1 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Update {
     /**
@@ -2499,9 +2511,10 @@ export namespace storage_v1beta1 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
 }

--- a/src/apis/storage/v1beta2.ts
+++ b/src/apis/storage/v1beta2.ts
@@ -979,10 +979,11 @@ export namespace storage_v1beta2 {
      * Name of a bucket.
      */
     bucket?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
   export interface Params$Resource$Bucketaccesscontrols$List {
     /**
@@ -1010,10 +1011,11 @@ export namespace storage_v1beta2 {
      * group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.
      */
     entity?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
   export interface Params$Resource$Bucketaccesscontrols$Update {
     /**
@@ -1030,10 +1032,11 @@ export namespace storage_v1beta2 {
      * group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.
      */
     entity?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BucketAccessControl;
+    requestBody?: Schema$BucketAccessControl;
   }
 
 
@@ -1509,10 +1512,11 @@ export namespace storage_v1beta2 {
      * to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
   export interface Params$Resource$Buckets$List {
     /**
@@ -1562,10 +1566,11 @@ export namespace storage_v1beta2 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
   export interface Params$Resource$Buckets$Update {
     /**
@@ -1591,10 +1596,11 @@ export namespace storage_v1beta2 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Bucket;
+    requestBody?: Schema$Bucket;
   }
 
 
@@ -1678,6 +1684,12 @@ export namespace storage_v1beta2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Channel;
   }
 
 
@@ -2148,10 +2160,11 @@ export namespace storage_v1beta2 {
      * Name of a bucket.
      */
     bucket?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Defaultobjectaccesscontrols$List {
     /**
@@ -2189,10 +2202,11 @@ export namespace storage_v1beta2 {
      * group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.
      */
     entity?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Defaultobjectaccesscontrols$Update {
     /**
@@ -2209,10 +2223,11 @@ export namespace storage_v1beta2 {
      * group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.
      */
     entity?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
 
 
@@ -2720,10 +2735,11 @@ export namespace storage_v1beta2 {
      * Name of the object.
      */
     object?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Objectaccesscontrols$List {
     /**
@@ -2769,10 +2785,11 @@ export namespace storage_v1beta2 {
      * Name of the object.
      */
     object?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
   export interface Params$Resource$Objectaccesscontrols$Update {
     /**
@@ -2798,10 +2815,11 @@ export namespace storage_v1beta2 {
      * Name of the object.
      */
     object?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ObjectAccessControl;
+    requestBody?: Schema$ObjectAccessControl;
   }
 
 
@@ -3501,10 +3519,11 @@ export namespace storage_v1beta2 {
      * metageneration matches the given value.
      */
     ifMetagenerationMatch?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ComposeRequest;
+    requestBody?: Schema$ComposeRequest;
   }
   export interface Params$Resource$Objects$Copy {
     /**
@@ -3580,10 +3599,11 @@ export namespace storage_v1beta2 {
      * Name of the source object.
      */
     sourceObject?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Delete {
     /**
@@ -3710,14 +3730,16 @@ export namespace storage_v1beta2 {
      * resource specifies the acl property, when it defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -3726,7 +3748,7 @@ export namespace storage_v1beta2 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Objects$List {
@@ -3813,10 +3835,11 @@ export namespace storage_v1beta2 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Update {
     /**
@@ -3861,10 +3884,11 @@ export namespace storage_v1beta2 {
      * Set of properties to return. Defaults to full.
      */
     projection?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Object;
+    requestBody?: Schema$Object;
   }
   export interface Params$Resource$Objects$Watchall {
     /**
@@ -3906,9 +3930,10 @@ export namespace storage_v1beta2 {
      * If true, lists all versions of a file as distinct results.
      */
     versions?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 }

--- a/src/apis/storagetransfer/v1.ts
+++ b/src/apis/storagetransfer/v1.ts
@@ -1382,10 +1382,11 @@ export namespace storagetransfer_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TransferJob;
+    requestBody?: Schema$TransferJob;
   }
   export interface Params$Resource$Transferjobs$Get {
     /**
@@ -1438,10 +1439,11 @@ export namespace storagetransfer_v1 {
      * The name of job to update. Required.
      */
     jobName?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateTransferJobRequest;
+    requestBody?: Schema$UpdateTransferJobRequest;
   }
 
 
@@ -2278,10 +2280,11 @@ export namespace storagetransfer_v1 {
      * The name of the transfer operation. Required.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PauseTransferOperationRequest;
+    requestBody?: Schema$PauseTransferOperationRequest;
   }
   export interface Params$Resource$Transferoperations$Resume {
     /**
@@ -2293,9 +2296,10 @@ export namespace storagetransfer_v1 {
      * The name of the transfer operation. Required.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResumeTransferOperationRequest;
+    requestBody?: Schema$ResumeTransferOperationRequest;
   }
 }

--- a/src/apis/streetviewpublish/v1.ts
+++ b/src/apis/streetviewpublish/v1.ts
@@ -831,10 +831,11 @@ export namespace streetviewpublish_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Photo;
+    requestBody?: Schema$Photo;
   }
   export interface Params$Resource$Photo$Delete {
     /**
@@ -869,10 +870,11 @@ export namespace streetviewpublish_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Empty;
+    requestBody?: Schema$Empty;
   }
   export interface Params$Resource$Photo$Update {
     /**
@@ -898,10 +900,11 @@ export namespace streetviewpublish_v1 {
      * connections will be removed.</aside>
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Photo;
+    requestBody?: Schema$Photo;
   }
 
 
@@ -1226,10 +1229,11 @@ export namespace streetviewpublish_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchDeletePhotosRequest;
+    requestBody?: Schema$BatchDeletePhotosRequest;
   }
   export interface Params$Resource$Photos$Batchget {
     /**
@@ -1254,10 +1258,11 @@ export namespace streetviewpublish_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchUpdatePhotosRequest;
+    requestBody?: Schema$BatchUpdatePhotosRequest;
   }
   export interface Params$Resource$Photos$List {
     /**

--- a/src/apis/surveys/v2.ts
+++ b/src/apis/surveys/v2.ts
@@ -721,10 +721,11 @@ export namespace surveys_v2 {
      * External URL ID for the panel.
      */
     panelId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$MobileAppPanel;
+    requestBody?: Schema$MobileAppPanel;
   }
 
 
@@ -815,10 +816,11 @@ export namespace surveys_v2 {
      * External URL ID for the survey.
      */
     surveyUrlId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResultsGetRequest;
+    requestBody?: Schema$ResultsGetRequest;
   }
 
 
@@ -1317,6 +1319,12 @@ export namespace surveys_v2 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Survey;
   }
   export interface Params$Resource$Surveys$List {
     /**
@@ -1347,10 +1355,11 @@ export namespace surveys_v2 {
      *
      */
     resourceId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SurveysStartRequest;
+    requestBody?: Schema$SurveysStartRequest;
   }
   export interface Params$Resource$Surveys$Stop {
     /**
@@ -1373,9 +1382,10 @@ export namespace surveys_v2 {
      * External URL ID for the survey.
      */
     surveyUrlId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Survey;
+    requestBody?: Schema$Survey;
   }
 }

--- a/src/apis/tagmanager/v1.ts
+++ b/src/apis/tagmanager/v1.ts
@@ -1255,10 +1255,11 @@ export namespace tagmanager_v1 {
      * in storage.
      */
     fingerprint?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
   export class Resource$Accounts$Containers {
@@ -1643,10 +1644,11 @@ export namespace tagmanager_v1 {
      * The GTM Account ID.
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Container;
+    requestBody?: Schema$Container;
   }
   export interface Params$Resource$Accounts$Containers$Delete {
     /**
@@ -1708,10 +1710,11 @@ export namespace tagmanager_v1 {
      * container in storage.
      */
     fingerprint?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Container;
+    requestBody?: Schema$Container;
   }
 
   export class Resource$Accounts$Containers$Environments {
@@ -2169,10 +2172,11 @@ export namespace tagmanager_v1 {
      * The GTM Container ID.
      */
     containerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
   export interface Params$Resource$Accounts$Containers$Environments$Delete {
     /**
@@ -2250,10 +2254,11 @@ export namespace tagmanager_v1 {
      * environment in storage.
      */
     fingerprint?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
   export interface Params$Resource$Accounts$Containers$Environments$Update {
     /**
@@ -2278,10 +2283,11 @@ export namespace tagmanager_v1 {
      * environment in storage.
      */
     fingerprint?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
 
 
@@ -2660,10 +2666,11 @@ export namespace tagmanager_v1 {
      * The GTM Container ID.
      */
     containerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
   export interface Params$Resource$Accounts$Containers$Folders$Delete {
     /**
@@ -2741,10 +2748,11 @@ export namespace tagmanager_v1 {
      * The GTM Folder ID.
      */
     folderId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
 
   export class Resource$Accounts$Containers$Folders$Entities {
@@ -2970,10 +2978,11 @@ export namespace tagmanager_v1 {
      * The variables to be moved to the folder.
      */
     variableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
 
 
@@ -3084,10 +3093,11 @@ export namespace tagmanager_v1 {
      * The GTM Environment ID.
      */
     environmentId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
 
 
@@ -3464,10 +3474,11 @@ export namespace tagmanager_v1 {
      * The GTM Container ID.
      */
     containerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Tag;
+    requestBody?: Schema$Tag;
   }
   export interface Params$Resource$Accounts$Containers$Tags$Delete {
     /**
@@ -3545,10 +3556,11 @@ export namespace tagmanager_v1 {
      * The GTM Tag ID.
      */
     tagId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Tag;
+    requestBody?: Schema$Tag;
   }
 
 
@@ -3926,10 +3938,11 @@ export namespace tagmanager_v1 {
      * The GTM Container ID.
      */
     containerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Trigger;
+    requestBody?: Schema$Trigger;
   }
   export interface Params$Resource$Accounts$Containers$Triggers$Delete {
     /**
@@ -4007,10 +4020,11 @@ export namespace tagmanager_v1 {
      * The GTM Trigger ID.
      */
     triggerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Trigger;
+    requestBody?: Schema$Trigger;
   }
 
 
@@ -4388,10 +4402,11 @@ export namespace tagmanager_v1 {
      * The GTM Container ID.
      */
     containerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variable;
+    requestBody?: Schema$Variable;
   }
   export interface Params$Resource$Accounts$Containers$Variables$Delete {
     /**
@@ -4469,10 +4484,11 @@ export namespace tagmanager_v1 {
      * The GTM Variable ID.
      */
     variableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variable;
+    requestBody?: Schema$Variable;
   }
 
 
@@ -5096,10 +5112,11 @@ export namespace tagmanager_v1 {
      * The GTM Container ID.
      */
     containerId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateContainerVersionRequestVersionOptions;
+    requestBody?: Schema$CreateContainerVersionRequestVersionOptions;
   }
   export interface Params$Resource$Accounts$Containers$Versions$Delete {
     /**
@@ -5248,10 +5265,11 @@ export namespace tagmanager_v1 {
      * container version in storage.
      */
     fingerprint?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContainerVersion;
+    requestBody?: Schema$ContainerVersion;
   }
 
 
@@ -5621,10 +5639,11 @@ export namespace tagmanager_v1 {
      * The GTM Account ID.
      */
     accountId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserAccess;
+    requestBody?: Schema$UserAccess;
   }
   export interface Params$Resource$Accounts$Permissions$Delete {
     /**
@@ -5681,9 +5700,10 @@ export namespace tagmanager_v1 {
      * The GTM User ID.
      */
     permissionId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserAccess;
+    requestBody?: Schema$UserAccess;
   }
 }

--- a/src/apis/tagmanager/v2.ts
+++ b/src/apis/tagmanager/v2.ts
@@ -1846,10 +1846,11 @@ export namespace tagmanager_v2 {
      * GTM Accounts's API relative path. Example: accounts/{account_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Account;
+    requestBody?: Schema$Account;
   }
 
   export class Resource$Accounts$Containers {
@@ -2217,10 +2218,11 @@ export namespace tagmanager_v2 {
      * GTM Account's API relative path. Example: accounts/{account_id}.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Container;
+    requestBody?: Schema$Container;
   }
   export interface Params$Resource$Accounts$Containers$Delete {
     /**
@@ -2277,10 +2279,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Container;
+    requestBody?: Schema$Container;
   }
 
   export class Resource$Accounts$Containers$Environments {
@@ -2784,10 +2787,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
   export interface Params$Resource$Accounts$Containers$Environments$Delete {
     /**
@@ -2845,10 +2849,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/environments/{environment_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
   export interface Params$Resource$Accounts$Containers$Environments$Reauthorize {
     /**
@@ -2861,10 +2866,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/environments/{environment_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
   export interface Params$Resource$Accounts$Containers$Environments$Update {
     /**
@@ -2882,10 +2888,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/environments/{environment_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Environment;
+    requestBody?: Schema$Environment;
   }
 
 
@@ -3478,10 +3485,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/versions/{version_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ContainerVersion;
+    requestBody?: Schema$ContainerVersion;
   }
 
 
@@ -4563,10 +4571,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Workspace;
+    requestBody?: Schema$Workspace;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Create_version {
     /**
@@ -4579,10 +4588,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateContainerVersionRequestVersionOptions;
+    requestBody?: Schema$CreateContainerVersionRequestVersionOptions;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Delete {
     /**
@@ -4676,10 +4686,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Entity;
+    requestBody?: Schema$Entity;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Sync {
     /**
@@ -4709,10 +4720,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Workspace;
+    requestBody?: Schema$Workspace;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Updateproposal {
     /**
@@ -4725,10 +4737,11 @@ export namespace tagmanager_v2 {
      * accounts/{aid}/containers/{cid}/workspace/{wid}/workspace_proposal
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UpdateWorkspaceProposalRequest;
+    requestBody?: Schema$UpdateWorkspaceProposalRequest;
   }
 
   export class Resource$Accounts$Containers$Workspaces$Built_in_variables {
@@ -5710,10 +5723,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Folders$Delete {
     /**
@@ -5794,10 +5808,11 @@ export namespace tagmanager_v2 {
      * The variables to be moved to the folder.
      */
     variableId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Folders$Revert {
     /**
@@ -5832,10 +5847,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}/folders/{folder_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Folder;
+    requestBody?: Schema$Folder;
   }
 
 
@@ -5999,10 +6015,11 @@ export namespace tagmanager_v2 {
      * accounts/{aid}/containers/{cid}/workspace/{wid}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CreateWorkspaceProposalRequest;
+    requestBody?: Schema$CreateWorkspaceProposalRequest;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Proposal$Delete {
     /**
@@ -6449,10 +6466,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Tag;
+    requestBody?: Schema$Tag;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Tags$Delete {
     /**
@@ -6527,10 +6545,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}/tags/{tag_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Tag;
+    requestBody?: Schema$Tag;
   }
 
 
@@ -6969,10 +6988,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Trigger;
+    requestBody?: Schema$Trigger;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Triggers$Delete {
     /**
@@ -7047,10 +7067,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}/triggers/{trigger_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Trigger;
+    requestBody?: Schema$Trigger;
   }
 
 
@@ -7493,10 +7514,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variable;
+    requestBody?: Schema$Variable;
   }
   export interface Params$Resource$Accounts$Containers$Workspaces$Variables$Delete {
     /**
@@ -7571,10 +7593,11 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/containers/{container_id}/workspaces/{workspace_id}/variables/{variable_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Variable;
+    requestBody?: Schema$Variable;
   }
 
 
@@ -7941,10 +7964,11 @@ export namespace tagmanager_v2 {
      * GTM Account's API relative path. Example: accounts/{account_id}
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserPermission;
+    requestBody?: Schema$UserPermission;
   }
   export interface Params$Resource$Accounts$User_permissions$Delete {
     /**
@@ -7996,9 +8020,10 @@ export namespace tagmanager_v2 {
      * accounts/{account_id}/user_permissions/{user_permission_id}
      */
     path?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UserPermission;
+    requestBody?: Schema$UserPermission;
   }
 }

--- a/src/apis/tasks/v1.ts
+++ b/src/apis/tasks/v1.ts
@@ -634,6 +634,12 @@ export namespace tasks_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$TaskList;
   }
   export interface Params$Resource$Tasklists$List {
     /**
@@ -661,10 +667,11 @@ export namespace tasks_v1 {
      * Task list identifier.
      */
     tasklist?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TaskList;
+    requestBody?: Schema$TaskList;
   }
   export interface Params$Resource$Tasklists$Update {
     /**
@@ -676,10 +683,11 @@ export namespace tasks_v1 {
      * Task list identifier.
      */
     tasklist?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TaskList;
+    requestBody?: Schema$TaskList;
   }
 
 
@@ -1289,10 +1297,11 @@ export namespace tasks_v1 {
      * Task list identifier.
      */
     tasklist?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Task;
+    requestBody?: Schema$Task;
   }
   export interface Params$Resource$Tasks$List {
     /**
@@ -1394,10 +1403,11 @@ export namespace tasks_v1 {
      * Task list identifier.
      */
     tasklist?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Task;
+    requestBody?: Schema$Task;
   }
   export interface Params$Resource$Tasks$Update {
     /**
@@ -1413,9 +1423,10 @@ export namespace tasks_v1 {
      * Task list identifier.
      */
     tasklist?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Task;
+    requestBody?: Schema$Task;
   }
 }

--- a/src/apis/testing/v1.ts
+++ b/src/apis/testing/v1.ts
@@ -1194,10 +1194,11 @@ export namespace testing_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$FileReference;
+    requestBody?: Schema$FileReference;
   }
 
 
@@ -1479,10 +1480,11 @@ export namespace testing_v1 {
      * A UUID is recommended.  Optional, but strongly recommended.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TestMatrix;
+    requestBody?: Schema$TestMatrix;
   }
   export interface Params$Resource$Projects$Testmatrices$Get {
     /**

--- a/src/apis/texttospeech/v1beta1.ts
+++ b/src/apis/texttospeech/v1beta1.ts
@@ -316,10 +316,11 @@ export namespace texttospeech_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SynthesizeSpeechRequest;
+    requestBody?: Schema$SynthesizeSpeechRequest;
   }
 
 

--- a/src/apis/toolresults/v1beta3.ts
+++ b/src/apis/toolresults/v1beta3.ts
@@ -1820,10 +1820,11 @@ export namespace toolresults_v1beta3 {
      * example, a UUID.  Optional, but strongly recommended.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$History;
+    requestBody?: Schema$History;
   }
   export interface Params$Resource$Projects$Histories$Get {
     /**
@@ -2203,10 +2204,11 @@ export namespace toolresults_v1beta3 {
      * example, a UUID.  Optional, but strongly recommended.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Execution;
+    requestBody?: Schema$Execution;
   }
   export interface Params$Resource$Projects$Histories$Executions$Get {
     /**
@@ -2275,10 +2277,11 @@ export namespace toolresults_v1beta3 {
      * example, a UUID.  Optional, but strongly recommended.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Execution;
+    requestBody?: Schema$Execution;
   }
 
   export class Resource$Projects$Histories$Executions$Clusters {
@@ -3017,10 +3020,11 @@ export namespace toolresults_v1beta3 {
      * example, a UUID.  Optional, but strongly recommended.
      */
     requestId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Step;
+    requestBody?: Schema$Step;
   }
   export interface Params$Resource$Projects$Histories$Executions$Steps$Get {
     /**
@@ -3123,10 +3127,11 @@ export namespace toolresults_v1beta3 {
      * A Step id.  Required.
      */
     stepId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Step;
+    requestBody?: Schema$Step;
   }
   export interface Params$Resource$Projects$Histories$Executions$Steps$Publishxunitxmlfiles {
     /**
@@ -3150,10 +3155,11 @@ export namespace toolresults_v1beta3 {
      * A Step id. Note: This step must include a TestExecutionStep.  Required.
      */
     stepId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PublishXunitXmlFilesRequest;
+    requestBody?: Schema$PublishXunitXmlFilesRequest;
   }
 
   export class Resource$Projects$Histories$Executions$Steps$Perfmetricssummary {
@@ -3271,10 +3277,11 @@ export namespace toolresults_v1beta3 {
      * A tool results step ID.
      */
     stepId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PerfMetricsSummary;
+    requestBody?: Schema$PerfMetricsSummary;
   }
 
 
@@ -3568,10 +3575,11 @@ export namespace toolresults_v1beta3 {
      * A tool results step ID.
      */
     stepId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PerfSampleSeries;
+    requestBody?: Schema$PerfSampleSeries;
   }
   export interface Params$Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Get {
     /**
@@ -3861,10 +3869,11 @@ export namespace toolresults_v1beta3 {
      * A tool results step ID.
      */
     stepId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchCreatePerfSamplesRequest;
+    requestBody?: Schema$BatchCreatePerfSamplesRequest;
   }
   export interface Params$Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples$List {
     /**

--- a/src/apis/tpu/v1alpha1.ts
+++ b/src/apis/tpu/v1alpha1.ts
@@ -1409,10 +1409,11 @@ export namespace tpu_v1alpha1 {
      * The parent resource name.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Node;
+    requestBody?: Schema$Node;
   }
   export interface Params$Resource$Projects$Locations$Nodes$Delete {
     /**
@@ -1465,10 +1466,11 @@ export namespace tpu_v1alpha1 {
      * The resource name.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReimageNodeRequest;
+    requestBody?: Schema$ReimageNodeRequest;
   }
   export interface Params$Resource$Projects$Locations$Nodes$Reset {
     /**
@@ -1480,10 +1482,11 @@ export namespace tpu_v1alpha1 {
      * The resource name.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ResetNodeRequest;
+    requestBody?: Schema$ResetNodeRequest;
   }
   export interface Params$Resource$Projects$Locations$Nodes$Start {
     /**
@@ -1495,10 +1498,11 @@ export namespace tpu_v1alpha1 {
      * The resource name.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartNodeRequest;
+    requestBody?: Schema$StartNodeRequest;
   }
   export interface Params$Resource$Projects$Locations$Nodes$Stop {
     /**
@@ -1510,10 +1514,11 @@ export namespace tpu_v1alpha1 {
      * The resource name.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StopNodeRequest;
+    requestBody?: Schema$StopNodeRequest;
   }
 
 

--- a/src/apis/translate/v2.ts
+++ b/src/apis/translate/v2.ts
@@ -341,10 +341,11 @@ export namespace translate_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$DetectLanguageRequest;
+    requestBody?: Schema$DetectLanguageRequest;
   }
   export interface Params$Resource$Detections$List {
     /**
@@ -655,9 +656,10 @@ export namespace translate_v2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$TranslateTextRequest;
+    requestBody?: Schema$TranslateTextRequest;
   }
 }

--- a/src/apis/urlshortener/v1.ts
+++ b/src/apis/urlshortener/v1.ts
@@ -417,6 +417,12 @@ export namespace urlshortener_v1 {
      * Auth client or API Key for the request
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
+
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$Url;
   }
   export interface Params$Resource$Url$List {
     /**

--- a/src/apis/vault/v1.ts
+++ b/src/apis/vault/v1.ts
@@ -1050,10 +1050,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$AddMatterPermissionsRequest;
+    requestBody?: Schema$AddMatterPermissionsRequest;
   }
   export interface Params$Resource$Matters$Close {
     /**
@@ -1065,10 +1066,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CloseMatterRequest;
+    requestBody?: Schema$CloseMatterRequest;
   }
   export interface Params$Resource$Matters$Create {
     /**
@@ -1076,10 +1078,11 @@ export namespace vault_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Matter;
+    requestBody?: Schema$Matter;
   }
   export interface Params$Resource$Matters$Delete {
     /**
@@ -1142,10 +1145,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$RemoveMatterPermissionsRequest;
+    requestBody?: Schema$RemoveMatterPermissionsRequest;
   }
   export interface Params$Resource$Matters$Reopen {
     /**
@@ -1157,10 +1161,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ReopenMatterRequest;
+    requestBody?: Schema$ReopenMatterRequest;
   }
   export interface Params$Resource$Matters$Undelete {
     /**
@@ -1172,10 +1177,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$UndeleteMatterRequest;
+    requestBody?: Schema$UndeleteMatterRequest;
   }
   export interface Params$Resource$Matters$Update {
     /**
@@ -1187,10 +1193,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Matter;
+    requestBody?: Schema$Matter;
   }
 
   export class Resource$Matters$Holds {
@@ -1556,10 +1563,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Hold;
+    requestBody?: Schema$Hold;
   }
   export interface Params$Resource$Matters$Holds$Delete {
     /**
@@ -1634,10 +1642,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Hold;
+    requestBody?: Schema$Hold;
   }
 
   export class Resource$Matters$Holds$Accounts {
@@ -1880,10 +1889,11 @@ export namespace vault_v1 {
      * The matter ID.
      */
     matterId?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$HeldAccount;
+    requestBody?: Schema$HeldAccount;
   }
   export interface Params$Resource$Matters$Holds$Accounts$Delete {
     /**

--- a/src/apis/videointelligence/v1.ts
+++ b/src/apis/videointelligence/v1.ts
@@ -352,21 +352,21 @@ export namespace videointelligence_v1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1beta2_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -375,8 +375,9 @@ export namespace videointelligence_v1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1beta2_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -391,7 +392,7 @@ export namespace videointelligence_v1 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1beta2_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -668,28 +669,28 @@ export namespace videointelligence_v1 {
      */
     // clang-format off
     alternatives?: Schema$GoogleCloudVideointelligenceV1p1beta1_SpeechRecognitionAlternative[];
-    // clang-format on
+    // clang-format off
   }
   /**
    * Annotation progress for a single video.
    */
   export interface Schema$GoogleCloudVideointelligenceV1p1beta1_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -698,8 +699,9 @@ export namespace videointelligence_v1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1p1beta1_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -719,7 +721,7 @@ export namespace videointelligence_v1 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1p1beta1_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -1000,21 +1002,21 @@ export namespace videointelligence_v1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -1023,8 +1025,9 @@ export namespace videointelligence_v1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -1039,7 +1042,7 @@ export namespace videointelligence_v1 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -1075,9 +1078,9 @@ export namespace videointelligence_v1 {
     labelDetectionConfig?:
         Schema$GoogleCloudVideointelligenceV1_LabelDetectionConfig;
     /**
-     * Video segments to annotate. The segments may overlap and are not required
-     * to be contiguous or span the whole video. If unspecified, each video is
-     * treated as a single segment.
+     * Non-streaming request only. Video segments to annotate. The segments may
+     * overlap and are not required to be contiguous or span the whole video. If
+     * unspecified, each video is treated as a single segment.
      */
     segments?: Schema$GoogleCloudVideointelligenceV1_VideoSegment[];
     /**
@@ -1543,10 +1546,11 @@ export namespace videointelligence_v1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleLongrunning_CancelOperationRequest;
+    requestBody?: Schema$GoogleLongrunning_CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Delete {
     /**
@@ -1688,9 +1692,10 @@ export namespace videointelligence_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudVideointelligenceV1_AnnotateVideoRequest;
+    requestBody?: Schema$GoogleCloudVideointelligenceV1_AnnotateVideoRequest;
   }
 }

--- a/src/apis/videointelligence/v1beta1.ts
+++ b/src/apis/videointelligence/v1beta1.ts
@@ -435,21 +435,21 @@ export namespace videointelligence_v1beta1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1beta2_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -458,8 +458,9 @@ export namespace videointelligence_v1beta1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1beta2_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -474,7 +475,7 @@ export namespace videointelligence_v1beta1 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1beta2_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -758,21 +759,21 @@ export namespace videointelligence_v1beta1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1p1beta1_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -781,8 +782,9 @@ export namespace videointelligence_v1beta1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1p1beta1_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -802,7 +804,7 @@ export namespace videointelligence_v1beta1 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1p1beta1_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -991,21 +993,21 @@ export namespace videointelligence_v1beta1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -1014,8 +1016,9 @@ export namespace videointelligence_v1beta1 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -1030,7 +1033,7 @@ export namespace videointelligence_v1beta1 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -1253,9 +1256,11 @@ export namespace videointelligence_v1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudVideointelligenceV1beta1_AnnotateVideoRequest;
+    requestBody?:
+        Schema$GoogleCloudVideointelligenceV1beta1_AnnotateVideoRequest;
   }
 }

--- a/src/apis/videointelligence/v1beta2.ts
+++ b/src/apis/videointelligence/v1beta2.ts
@@ -442,21 +442,21 @@ export namespace videointelligence_v1beta2 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1beta2_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -465,8 +465,9 @@ export namespace videointelligence_v1beta2 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1beta2_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -481,7 +482,7 @@ export namespace videointelligence_v1beta2 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1beta2_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -517,9 +518,9 @@ export namespace videointelligence_v1beta2 {
     labelDetectionConfig?:
         Schema$GoogleCloudVideointelligenceV1beta2_LabelDetectionConfig;
     /**
-     * Video segments to annotate. The segments may overlap and are not required
-     * to be contiguous or span the whole video. If unspecified, each video is
-     * treated as a single segment.
+     * Non-streaming request only. Video segments to annotate. The segments may
+     * overlap and are not required to be contiguous or span the whole video. If
+     * unspecified, each video is treated as a single segment.
      */
     segments?: Schema$GoogleCloudVideointelligenceV1beta2_VideoSegment[];
     /**
@@ -784,28 +785,28 @@ export namespace videointelligence_v1beta2 {
      */
     // clang-format off
     alternatives?: Schema$GoogleCloudVideointelligenceV1p1beta1_SpeechRecognitionAlternative[];
-    // clang-format on
+    // clang-format o
   }
   /**
    * Annotation progress for a single video.
    */
   export interface Schema$GoogleCloudVideointelligenceV1p1beta1_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -814,8 +815,9 @@ export namespace videointelligence_v1beta2 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1p1beta1_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -835,7 +837,7 @@ export namespace videointelligence_v1beta2 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1p1beta1_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -1024,21 +1026,21 @@ export namespace videointelligence_v1beta2 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1_VideoAnnotationProgress {
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
     /**
-     * Approximate percentage processed thus far. Guaranteed to be 100 when
-     * fully processed.
+     * Output only. Approximate percentage processed thus far. Guaranteed to be
+     * 100 when fully processed.
      */
     progressPercent?: number;
     /**
-     * Time when the request was received.
+     * Output only. Time when the request was received.
      */
     startTime?: string;
     /**
-     * Time of the most recent update.
+     * Output only. Time of the most recent update.
      */
     updateTime?: string;
   }
@@ -1047,8 +1049,9 @@ export namespace videointelligence_v1beta2 {
    */
   export interface Schema$GoogleCloudVideointelligenceV1_VideoAnnotationResults {
     /**
-     * If set, indicates an error. Note that for a single `AnnotateVideoRequest`
-     * some videos may succeed and some may fail.
+     * Output only. Non-streaming error only. If set, indicates an error. Note
+     * that for a single `AnnotateVideoRequest` some videos may succeed and some
+     * may fail.
      */
     error?: Schema$GoogleRpc_Status;
     /**
@@ -1063,7 +1066,7 @@ export namespace videointelligence_v1beta2 {
     frameLabelAnnotations?:
         Schema$GoogleCloudVideointelligenceV1_LabelAnnotation[];
     /**
-     * Video file location in [Google Cloud
+     * Output only. Video file location in [Google Cloud
      * Storage](https://cloud.google.com/storage/).
      */
     inputUri?: string;
@@ -1286,9 +1289,11 @@ export namespace videointelligence_v1beta2 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudVideointelligenceV1beta2_AnnotateVideoRequest;
+    requestBody?:
+        Schema$GoogleCloudVideointelligenceV1beta2_AnnotateVideoRequest;
   }
 }

--- a/src/apis/vision/v1.ts
+++ b/src/apis/vision/v1.ts
@@ -2120,10 +2120,11 @@ export namespace vision_v1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$BatchAnnotateImagesRequest;
+    requestBody?: Schema$BatchAnnotateImagesRequest;
   }
 
 
@@ -2534,10 +2535,11 @@ export namespace vision_v1 {
      * The name of the operation resource to be cancelled.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CancelOperationRequest;
+    requestBody?: Schema$CancelOperationRequest;
   }
   export interface Params$Resource$Operations$Delete {
     /**

--- a/src/apis/vision/v1p1beta1.ts
+++ b/src/apis/vision/v1p1beta1.ts
@@ -2016,9 +2016,10 @@ export namespace vision_v1p1beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudVisionV1p1beta1BatchAnnotateImagesRequest;
+    requestBody?: Schema$GoogleCloudVisionV1p1beta1BatchAnnotateImagesRequest;
   }
 }

--- a/src/apis/vision/v1p2beta1.ts
+++ b/src/apis/vision/v1p2beta1.ts
@@ -1391,10 +1391,12 @@ export namespace vision_v1p2beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudVisionV1p2beta1AsyncBatchAnnotateFilesRequest;
+    requestBody?:
+        Schema$GoogleCloudVisionV1p2beta1AsyncBatchAnnotateFilesRequest;
   }
 
 
@@ -1495,9 +1497,10 @@ export namespace vision_v1p2beta1 {
      */
     auth?: string|OAuth2Client|JWT|Compute|UserRefreshClient;
 
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GoogleCloudVisionV1p2beta1BatchAnnotateImagesRequest;
+    requestBody?: Schema$GoogleCloudVisionV1p2beta1BatchAnnotateImagesRequest;
   }
 }

--- a/src/apis/webmasters/v3.ts
+++ b/src/apis/webmasters/v3.ts
@@ -455,10 +455,11 @@ export namespace webmasters_v3 {
      * The site's URL, including protocol. For example: http://www.example.com/
      */
     siteUrl?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$SearchAnalyticsQueryRequest;
+    requestBody?: Schema$SearchAnalyticsQueryRequest;
   }
 
 

--- a/src/apis/websecurityscanner/v1alpha.ts
+++ b/src/apis/websecurityscanner/v1alpha.ts
@@ -922,10 +922,11 @@ export namespace websecurityscanner_v1alpha {
      * should be a project resource name in the format 'projects/{projectId}'.
      */
     parent?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ScanConfig;
+    requestBody?: Schema$ScanConfig;
   }
   export interface Params$Resource$Projects$Scanconfigs$Delete {
     /**
@@ -993,10 +994,11 @@ export namespace websecurityscanner_v1alpha {
      * https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
      */
     updateMask?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ScanConfig;
+    requestBody?: Schema$ScanConfig;
   }
   export interface Params$Resource$Projects$Scanconfigs$Start {
     /**
@@ -1009,10 +1011,11 @@ export namespace websecurityscanner_v1alpha {
      * follows the format of 'projects/{projectId}/scanConfigs/{scanConfigId}'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StartScanRunRequest;
+    requestBody?: Schema$StartScanRunRequest;
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns {
@@ -1286,10 +1289,11 @@ export namespace websecurityscanner_v1alpha {
      * 'projects/{projectId}/scanConfigs/{scanConfigId}/scanRuns/{scanRunId}'.
      */
     name?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$StopScanRunRequest;
+    requestBody?: Schema$StopScanRunRequest;
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns$Crawledurls {

--- a/src/apis/youtube/v3.ts
+++ b/src/apis/youtube/v3.ts
@@ -5118,10 +5118,11 @@ export namespace youtube_v3 {
      * properties that the API response will include.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Activity;
+    requestBody?: Schema$Activity;
   }
   export interface Params$Resource$Activities$List {
     /**
@@ -5677,14 +5678,16 @@ export namespace youtube_v3 {
      * your file are incorrect and want YouTube to try to fix them.
      */
     sync?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Caption;
+    requestBody?: Schema$Caption;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -5693,7 +5696,7 @@ export namespace youtube_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Captions$List {
@@ -5777,14 +5780,16 @@ export namespace youtube_v3 {
      * automatically synchronize the caption track with the audio track.
      */
     sync?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Caption;
+    requestBody?: Schema$Caption;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -5793,7 +5798,7 @@ export namespace youtube_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -5923,14 +5928,16 @@ export namespace youtube_v3 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChannelBannerResource;
+    requestBody?: Schema$ChannelBannerResource;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -5939,7 +5946,7 @@ export namespace youtube_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -6209,10 +6216,11 @@ export namespace youtube_v3 {
      * value specifies.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Channel;
+    requestBody?: Schema$Channel;
   }
 
 
@@ -6582,10 +6590,11 @@ export namespace youtube_v3 {
      * can include in the parameter value are snippet and contentDetails.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChannelSection;
+    requestBody?: Schema$ChannelSection;
   }
   export interface Params$Resource$Channelsections$List {
     /**
@@ -6672,10 +6681,11 @@ export namespace youtube_v3 {
      * can include in the parameter value are snippet and contentDetails.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$ChannelSection;
+    requestBody?: Schema$ChannelSection;
   }
 
 
@@ -7114,10 +7124,11 @@ export namespace youtube_v3 {
      * cost of 2 units.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
   export interface Params$Resource$Comments$List {
     /**
@@ -7210,10 +7221,11 @@ export namespace youtube_v3 {
      * can update.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Comment;
+    requestBody?: Schema$Comment;
   }
 
 
@@ -7458,10 +7470,11 @@ export namespace youtube_v3 {
      * cost of 2 units.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommentThread;
+    requestBody?: Schema$CommentThread;
   }
   export interface Params$Resource$Commentthreads$List {
     /**
@@ -7549,10 +7562,11 @@ export namespace youtube_v3 {
      * all of the properties that the API request can update.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$CommentThread;
+    requestBody?: Schema$CommentThread;
   }
 
 
@@ -8616,10 +8630,11 @@ export namespace youtube_v3 {
      * and status.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiveBroadcast;
+    requestBody?: Schema$LiveBroadcast;
   }
   export interface Params$Resource$Livebroadcasts$List {
     /**
@@ -8813,10 +8828,11 @@ export namespace youtube_v3 {
      * broadcast will revert to the default privacy setting.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiveBroadcast;
+    requestBody?: Schema$LiveBroadcast;
   }
 
 
@@ -8990,10 +9006,11 @@ export namespace youtube_v3 {
      * snippet.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiveChatBan;
+    requestBody?: Schema$LiveChatBan;
   }
 
 
@@ -9244,10 +9261,11 @@ export namespace youtube_v3 {
      * response will include. Set the parameter value to snippet.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiveChatMessage;
+    requestBody?: Schema$LiveChatMessage;
   }
   export interface Params$Resource$Livechatmessages$List {
     /**
@@ -9542,10 +9560,11 @@ export namespace youtube_v3 {
      * snippet.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiveChatModerator;
+    requestBody?: Schema$LiveChatModerator;
   }
   export interface Params$Resource$Livechatmoderators$List {
     /**
@@ -9961,10 +9980,11 @@ export namespace youtube_v3 {
      * you can include in the parameter value are id, snippet, cdn, and status.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiveStream;
+    requestBody?: Schema$LiveStream;
   }
   export interface Params$Resource$Livestreams$List {
     /**
@@ -10084,10 +10104,11 @@ export namespace youtube_v3 {
      * mutable property, the existing value for that property will be removed.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$LiveStream;
+    requestBody?: Schema$LiveStream;
   }
 
 
@@ -10434,10 +10455,11 @@ export namespace youtube_v3 {
      * properties that the API response will include.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlaylistItem;
+    requestBody?: Schema$PlaylistItem;
   }
   export interface Params$Resource$Playlistitems$List {
     /**
@@ -10533,10 +10555,11 @@ export namespace youtube_v3 {
      * and replaced with the default settings.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$PlaylistItem;
+    requestBody?: Schema$PlaylistItem;
   }
 
 
@@ -10897,10 +10920,11 @@ export namespace youtube_v3 {
      * properties that the API response will include.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Playlist;
+    requestBody?: Schema$Playlist;
   }
   export interface Params$Resource$Playlists$List {
     /**
@@ -11014,10 +11038,11 @@ export namespace youtube_v3 {
      * will be deleted.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Playlist;
+    requestBody?: Schema$Playlist;
   }
 
 
@@ -11717,10 +11742,11 @@ export namespace youtube_v3 {
      * properties that the API response will include.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Subscription;
+    requestBody?: Schema$Subscription;
   }
   export interface Params$Resource$Subscriptions$List {
     /**
@@ -12051,10 +12077,12 @@ export namespace youtube_v3 {
      * video thumbnail is being provided.
      */
     videoId?: string;
+
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -12063,7 +12091,7 @@ export namespace youtube_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
 
@@ -12911,14 +12939,16 @@ export namespace youtube_v3 {
      * to remove shaky camera motions.
      */
     stabilize?: boolean;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Video;
+    requestBody?: Schema$Video;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -12927,7 +12957,7 @@ export namespace youtube_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Videos$List {
@@ -13067,10 +13097,11 @@ export namespace youtube_v3 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$VideoAbuseReport;
+    requestBody?: Schema$VideoAbuseReport;
   }
   export interface Params$Resource$Videos$Update {
     /**
@@ -13111,10 +13142,11 @@ export namespace youtube_v3 {
      * included in the API response.
      */
     part?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Video;
+    requestBody?: Schema$Video;
   }
 
 
@@ -13285,14 +13317,16 @@ export namespace youtube_v3 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$InvideoBranding;
+    requestBody?: Schema$InvideoBranding;
+
     /**
      * Media metadata
      */
-    media: {
+    media?: {
       /**
        * Media mime-type
        */
@@ -13301,7 +13335,7 @@ export namespace youtube_v3 {
       /**
        * Media body contents
        */
-      body: any;
+      body?: any;
     };
   }
   export interface Params$Resource$Watermarks$Unset {

--- a/src/apis/youtubeAnalytics/v1.ts
+++ b/src/apis/youtubeAnalytics/v1.ts
@@ -400,10 +400,11 @@ export namespace youtubeAnalytics_v1 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GroupItem;
+    requestBody?: Schema$GroupItem;
   }
   export interface Params$Resource$Groupitems$List {
     /**
@@ -753,10 +754,11 @@ export namespace youtubeAnalytics_v1 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
   export interface Params$Resource$Groups$List {
     /**
@@ -814,10 +816,11 @@ export namespace youtubeAnalytics_v1 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
 
 

--- a/src/apis/youtubeAnalytics/v1beta1.ts
+++ b/src/apis/youtubeAnalytics/v1beta1.ts
@@ -400,10 +400,11 @@ export namespace youtubeAnalytics_v1beta1 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GroupItem;
+    requestBody?: Schema$GroupItem;
   }
   export interface Params$Resource$Groupitems$List {
     /**
@@ -753,10 +754,11 @@ export namespace youtubeAnalytics_v1beta1 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
   export interface Params$Resource$Groups$List {
     /**
@@ -814,10 +816,11 @@ export namespace youtubeAnalytics_v1beta1 {
      * to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
 
 

--- a/src/apis/youtubeAnalytics/v2.ts
+++ b/src/apis/youtubeAnalytics/v2.ts
@@ -625,10 +625,11 @@ export namespace youtubeAnalytics_v2 {
      * linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$GroupItem;
+    requestBody?: Schema$GroupItem;
   }
   export interface Params$Resource$Groupitems$List {
     /**
@@ -980,10 +981,11 @@ export namespace youtubeAnalytics_v2 {
      * linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
   export interface Params$Resource$Groups$List {
     /**
@@ -1045,10 +1047,11 @@ export namespace youtubeAnalytics_v2 {
      * linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Group;
+    requestBody?: Schema$Group;
   }
 
 

--- a/src/apis/youtubereporting/v1.ts
+++ b/src/apis/youtubereporting/v1.ts
@@ -835,10 +835,11 @@ export namespace youtubereporting_v1 {
      * not set, the user is acting for himself (his own channel).
      */
     onBehalfOfContentOwner?: string;
+
     /**
      * Request body metadata
      */
-    resource?: Schema$Job;
+    requestBody?: Schema$Job;
   }
   export interface Params$Resource$Jobs$Delete {
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ export {proximitybeacon_v1beta1} from './apis/proximitybeacon/v1beta1';
 export {pubsub_v1} from './apis/pubsub/v1';
 export {pubsub_v1beta1a} from './apis/pubsub/v1beta1a';
 export {pubsub_v1beta2} from './apis/pubsub/v1beta2';
+export {redis_v1beta1} from './apis/redis/v1beta1';
 export {replicapool_v1beta1} from './apis/replicapool/v1beta1';
 export {replicapool_v1beta2} from './apis/replicapool/v1beta2';
 export {replicapoolupdater_v1beta1} from './apis/replicapoolupdater/v1beta1';

--- a/src/templates/api-endpoint.njk
+++ b/src/templates/api-endpoint.njk
@@ -140,28 +140,30 @@ export interface Schema${{ schema.id }} {
          */
         {{ pname|getSafeParamName }}?: {{ p.type }};
         {% endfor %}
-        {% if m.request %}
-          /**
-           * Request body metadata
-           */
-           resource?: Schema${{ m.request.$ref }};
-        {% endif %}
-        {% if m.supportsMediaUpload %}
-          /**
-           * Media metadata
-           */
-          media: {
-            /**
-             * Media mime-type
-             */
-            mediaType?: string;
+      {% endif %}
 
-            /**
-             * Media body contents
-             */
-            body: any;
-          }
-        {% endif %}
+      {% if m.request %}
+        /**
+          * Request body metadata
+          */
+          requestBody?: Schema${{ m.request.$ref }};
+      {% endif %}
+
+      {% if m.supportsMediaUpload %}
+        /**
+          * Media metadata
+          */
+        media?: {
+          /**
+            * Media mime-type
+            */
+          mediaType?: string;
+
+          /**
+            * Media body contents
+            */
+          body?: any;
+        }
       {% endif %}
     }
   {% endfor %}

--- a/src/templates/resource-partial.njk
+++ b/src/templates/resource-partial.njk
@@ -49,28 +49,30 @@
                */
               {{ pname|cleanPropertyName|safe }}?: {{ p|getType }};
             {% endfor %}
-            {% if m.request %}
-              /**
-               * Request body metadata
-               */
-              resource{{'_' if m|hasResourceParam}}?: Schema${{ m.request.$ref }};
-            {% endif %}
-            {% if m.supportsMediaUpload %}
-              /**
-               * Media metadata
-               */
-              media: {
-                /**
-                 * Media mime-type
-                 */
-                mediaType?: string;
+          {% endif %}
 
-                /**
-                 * Media body contents
-                 */
-                body: any;
-              };
-            {% endif %}
+           {% if m.request %}
+            /**
+              * Request body metadata
+              */
+            requestBody?: Schema${{ m.request.$ref }};
+          {% endif %}
+
+          {% if m.supportsMediaUpload %}
+            /**
+              * Media metadata
+              */
+            media?: {
+              /**
+                * Media mime-type
+                */
+              mediaType?: string;
+
+              /**
+                * Media body contents
+                */
+              body?: any;
+            };
           {% endif %}
         }
       {% endfor %}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -13,7 +13,7 @@
 
 import {AxiosResponse} from 'axios';
 import * as url from 'url';
-import {GoogleApis} from '../src/index';
+import {GoogleApis} from '../src';
 import {Endpoint} from '../src/lib/endpoint';
 
 export abstract class Utils {
@@ -31,9 +31,12 @@ export abstract class Utils {
         version + '/rest';
   }
 
-  static loadApi(
+  // tslint:disable-next-line no-any
+  static loadApi<T = any>(
       google: GoogleApis, name: string, version: string, options = {}) {
-    return google.discoverAPI(Utils.getDiscoveryUrl(name, version), options);
+    return google.discoverAPI(Utils.getDiscoveryUrl(name, version), options) as
+    // tslint:disable-next-line no-any
+        any as T;
   }
 
   static readonly noop = () => undefined;


### PR DESCRIPTION
This is a backwards compatible change that changes the `resource` special case name to `requestBody`.  Doing this for 2 reasons:

1. It's fairly common to have a `resource` parameter required independent of the body.  We have a janky thing right now where we force clients to use `resource_` in this case, which is neither obvious nor well documented.

2. `requestBody` does a better job of explaining what this object actually is and what it does. 

Resolves #721 