### PR TITLE
Remove curly-braces from google object declaration

### DIFF
--- a/samples/drive/quickstart.js
+++ b/samples/drive/quickstart.js
@@ -14,7 +14,7 @@
 'use strict';
 
 // [START main_body]
-const {google} = require('googleapis');
+const google = require('googleapis');
 const express = require('express');
 const opn = require('opn');
 const path = require('path');


### PR DESCRIPTION
Breaks the sample because the 'drive' object doesn't exist later.

```js
TypeError: Cannot read property 'auth' of undefined
    at Object.<anonymous> (google_node_api_quickstart.js:28:27)
```

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm test` succeeds
- [ ] Pull request has been squashed into 1 commit
- [ ] I did NOT manually make changes to anything in `apis/`
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate JSDoc comments were updated in source code (if applicable)
- [ ] Appropriate changes to readme/docs are included in PR
