### PR TITLE
fix: drop support for node.js 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,6 @@ workflows:
   version: 2
   tests:
     jobs: &workflow_jobs
-      - node4:
-          filters:
-            tags:
-              only: /.*/
       - node6:
           filters:
             tags:
@@ -66,7 +62,6 @@ workflows:
               only: /.*/
       - publish_npm:
           requires:
-            - node4
             - node6
             - node8
             - node9
@@ -85,11 +80,6 @@ workflows:
     jobs: *workflow_jobs
 
 jobs:
-  node4:
-    docker:
-      - image: node:4
-        user: node
-    <<: *unit_tests
   node6:
     docker:
       - image: node:6

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "devDependencies": {
     "@types/express": "^4.11.1",


### PR DESCRIPTION
Now that node.js 4 is EOL, I would like to explicitly drop support for it here.  Thoughts / opinions welcomed :)