### PR TITLE
Specifies method for refreshing access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ oauth2client.setCredentials({
 });
 ```
 
-Once the client has a refresh token, access tokens will be acquired and refreshed automatically.
+Once the client has a refresh token, access tokens will be acquired and refreshed automatically in the next call to the API. You can use the `oauth2Client.refreshAccessToken()` method for this purpose, returning the tokens in the response.
 
 ### Using API keys
 You may need to send an API key with the request you are going to make. The following uses an API key to make a request to the Google+ API service to retrieve a person's profile given a userId:


### PR DESCRIPTION
Small docs update to specify an optional method to use for refreshing the access token.

Additional fix for #1157 

- [X] `npm test` succeeds
- [X] Pull request has been squashed into 1 commit
- [X] I did NOT manually make changes to anything in `apis/`
- [n/a] Code coverage does not decrease (if any source code was changed)
- [n/a] Appropriate JSDoc comments were updated in source code (if applicable)
- [X] Appropriate changes to readme/docs are included in PR
