### PR TITLE
chore: release 31.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "name": "Alexander Fenster"
     }
   ],
-  "version": "31.0.0",
+  "version": "31.0.1",
   "scripts": {
     "test": "make test -j 4"
   },

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapis-common",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A common tooling library used by the googleapis npm module. You probably don't want to use this directly.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
[Release notes](https://github.com/google/google-api-nodejs-client/releases/edit/untagged-da14cc88a5cb369b7758)