### PR TITLE
chore: reduce # of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "google-auth-library": "^1.4.0",
-    "googleapis-common": "^0.2.0",
-    "pify": "^4.0.0",
-    "qs": "^6.5.2",
-    "url-template": "^2.0.8",
-    "uuid": "^3.2.1"
+    "google-auth-library": "^1.6.0",
+    "googleapis-common": "^0.2.0"
   },
   "files": [
     "LICENSE",
@@ -128,12 +124,14 @@
     "nyc": "^12.0.2",
     "opn": "^5.3.0",
     "p-queue": "^2.4.2",
+    "pify": "^4.0.0",
     "rimraf": "^2.6.2",
     "semistandard": "^12.0.1",
     "server-destroy": "^1.0.1",
     "source-map-support": "^0.5.5",
     "tmp": "^0.0.33",
     "typedoc": "^0.12.0",
-    "typescript": "~3.0.0"
+    "typescript": "~3.0.0",
+    "uuid": "^3.2.1"
   }
 }


### PR DESCRIPTION
Mostly moves out dependencies that are brought in by googleapis/nodejs-googleapis-common now. 